### PR TITLE
feat: directional step-count error + paired significance in the decomposition evaluator

### DIFF
--- a/configs/musique_eval.json
+++ b/configs/musique_eval.json
@@ -15,5 +15,13 @@
   },
   "composite_step_count_error_scale": 3.0,
 
+  "paired_comparison": {
+    "_note": "Parameters for --compare (paired significance between two per-item files). The bootstrap is resampled from the top-level 'seed' (or --seed), so a comparison is reproducible; iterations, alpha and the mismatch-report cap are parameters of the test, so they live here and land in the run's config snapshot instead of being literals in the script.",
+    "bootstrap_iterations": 10000,
+    "alpha": 0.05,
+    "max_reported_id_mismatches": 20,
+    "out_prefix": "compare"
+  },
+
   "paths_config": "paths.json"
 }

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,0 +1,197 @@
+# Decomposition metrics — what the evaluator actually computes
+
+Source of truth: [`scripts/musique_decompositions_evaluator.py`](../scripts/musique_decompositions_evaluator.py)
+and [`configs/musique_eval.json`](../configs/musique_eval.json). Every statement below was
+read off that code, not off a plan; the function that implements each metric is named so a
+reader can check it. If the code and this file disagree, the code is right and this file is
+a bug.
+
+Every metric here is **string-level**: no model is in the loop (`METRIC_DEFINITIONS`
+`not_a_semantic_metric`). Two decompositions that mean the same thing but word a step
+differently score as a mismatch.
+
+## 1. How rows are built
+
+- **Predictions** (`--predictions`): a JSON list of objects with `question` and
+  `decomposition`. A string `decomposition` is split on newlines with a leading `<n>. `
+  enumerator removed per line (`_split_decomposition_text`); a list `decomposition` takes
+  each string, or each element's `question` field (`_decomp_to_steps`).
+- **Gold**: JSONL rows with `question` and `question_decomposition`, keyed by the question
+  text lowercased and whitespace-collapsed (`_load_gold`, `_normalize_question`).
+- **Joining is by question text, not by id** (`_build_eval_rows`). A prediction whose
+  question has no gold row is counted in `missing_gold_count` and excluded from every
+  metric.
+- `limit` (config, or `--limit`) truncates the prediction list *before* matching.
+- **`item_id`** is written into each per-item row: the prediction's `query_id`, else its
+  `id`, else the normalized question text (`_item_id`). It is the key `--compare` aligns
+  two runs on; it is not used for gold matching.
+
+Two normalizations exist and they are **not** the same:
+
+| | used by | rule |
+|---|---|---|
+| `_normalize_step` | exact match, step P/R/F1, ordered accuracy | lowercase, strip punctuation **except `#`** (so `[#k]` survives), collapse whitespace |
+| `_tokenize` | ROUGE-L only | lowercase, collapse whitespace, split on spaces — **punctuation is not stripped** |
+
+So `strike?` and `strike` are one token apart for ROUGE-L but identical for the step-level
+metrics. This asymmetry is inherited from v1 and is deliberate only in the sense that
+nobody has changed it; it is worth knowing before reading a ROUGE-L number closely.
+
+## 2. The metrics
+
+Unless stated otherwise, an aggregate is the **macro average**: the metric is computed per
+item and the per-item values are averaged over evaluated rows (`_aggregate`). The single
+exception is `reference_validity_micro`, which pools counts across all rows.
+
+| metrics JSON key | definition (function) |
+|---|---|
+| `exact_match_rate` | 1.0 when pred and gold step lists have equal length and equal normalized text at every position, else 0.0; averaged (`_exact_decomposition_match`) |
+| `step_precision_macro` / `step_recall_macro` / `step_f1_macro` | **set-based, unordered**: P = \|pred ∩ gold\| / \|pred\|, R = \|pred ∩ gold\| / \|gold\| over sets of normalized steps; F1 is the harmonic mean **per item**, then averaged (so it is not the F1 of the averaged P and R). Duplicate steps collapse in the set (`_step_prf`) |
+| `ordered_step_accuracy_macro` | positional matches / `max(len(pred), len(gold))` — a length mismatch is penalised through the denominator (`_ordered_step_accuracy`) |
+| `rouge_l_precision_macro` / `_recall_macro` / `_f1_macro` | see §3 |
+| `reference_validity_macro` | per item: valid `[#k]` references / total references, where valid means `1 <= k < the step's own 1-based index`; an item with **no** references scores 1.0. Averaged over items (`_reference_validity`) |
+| `reference_validity_micro` | total valid references / total references pooled over all rows; 1.0 when there are no references anywhere |
+| `step_count_abs_error_mae` | mean of \|len(pred) − len(gold)\| |
+| `step_count_mae` | the same number, reported again so the directional family reads as one block |
+| `mean_signed_step_count_error` | mean of len(pred) − len(gold). **Over- and under-decomposition cancel here**, which is why the two rates below are reported next to it |
+| `over_decomposition_rate` | fraction of rows with len(pred) > len(gold) |
+| `under_decomposition_rate` | fraction of rows with len(pred) < len(gold) |
+| `hop_count_exact_match_rate`, `hop_count_abs_error_mae` | predicted hop count = number of predicted steps; gold hop count = the gold row's `hop_count` when it is a positive int, else the gold step count |
+| `predicted_hop_distribution`, `gold_hop_distribution` | counts of items per hop count |
+| `per_gold_hop_metrics` | the **entire** aggregate block above, recomputed per gold hop depth (2, 3, 4, …) — including the four directional step-count metrics |
+
+Per item, the same quantities are written to `<prefix>_per_item.json`, plus
+`step_count_signed_error` (`len(pred) − len(gold)`), `pred_steps`, `gold_steps` and
+`item_id`.
+
+Reference validity checks **predicted** decompositions only; gold is never checked. Note
+the sharp edge stated in `METRIC_DEFINITIONS`: a prediction with no `[#k]` references at
+all scores 1.0 macro and contributes nothing to the micro denominator — a near-perfect
+reference-validity number can mean "no references were emitted", not "references were
+correct". (v1 saw exactly this; see `docs/prior-work.md`.)
+
+## 3. ROUGE-L — the answer to the supervisor's question
+
+Read off `_rouge_l`, `_join_steps` and `_tokenize`, verbatim behaviour:
+
+- **The steps are joined into one string** before scoring: `_join_steps` concatenates the
+  steps with `\n`, and the same is done to gold. There is no per-step alignment and no
+  step-by-step ROUGE.
+- **It is LCS-based.** `_lcs_len` is a standard dynamic-programming longest common
+  subsequence over whitespace tokens of the lowercased joined text (the `\n` separator is
+  collapsed to a space by `_tokenize`, so it is ROUGE-L over the flattened token stream,
+  not summary-level ROUGE-L / ROUGE-Lsum).
+- **It reports precision, recall and F1**: P = LCS / \|pred tokens\|, R = LCS / \|gold
+  tokens\|, F1 = the unweighted harmonic mean (β = 1). All three are in the metrics JSON.
+- **It is macro-averaged across items**: computed per item, then averaged over evaluated
+  rows in `_aggregate`.
+- Edge cases: both sides empty → (1.0, 1.0, 1.0); exactly one side empty → (0.0, 0.0, 0.0).
+- No stemming, no stopword removal, no punctuation stripping, no external ROUGE package —
+  this is the repo's own implementation, so it is not numerically comparable to a
+  `rouge-score` / `pyrouge` number without checking their tokenizers.
+
+## 4. Composite score
+
+`_composite_score` combines **aggregate** values (not per-item ones):
+
+```
+composite = w_step_f1            * step_f1_macro
+          + w_ordered            * ordered_step_accuracy_macro
+          + w_reference_micro    * reference_validity_micro
+          + w_step_count         * max(0, 1 - step_count_abs_error_mae / scale)
+```
+
+Weights and scale, from `configs/musique_eval.json` (they land in every run's config
+snapshot and metrics JSON):
+
+| config key | value |
+|---|---|
+| `composite_score_weights.step_f1_macro` | 0.4 |
+| `composite_score_weights.ordered_step_accuracy_macro` | 0.3 |
+| `composite_score_weights.reference_validity_micro` | 0.2 |
+| `composite_score_weights.step_count_error` | 0.1 |
+| `composite_step_count_error_scale` | 3.0 |
+
+The weights are a **choice, not a result**: they were hard-coded literals in v1 and were
+promoted to config in v2 so a run records them. Jahid's supervisor flagged this score as
+handmade and possibly biased and asked for it to be checked against standard methods
+(`docs/meetings/2026-08-12-supervisor-meeting-transcript-crosscheck.md`, open item 4). Two
+consequences worth carrying into the write-up: the 0.2 reference-validity term is a micro
+rate that can swing the composite on a handful of `[#k]` references, and the step-count
+term is direction-blind (it uses the MAE, so over- and under-decomposition are penalised
+identically). The directional metrics in §2 are reported separately precisely because the
+composite cannot express that difference.
+
+## 5. Paired comparison (`--compare A_per_item.json B_per_item.json`)
+
+Compares two runs **on the same evaluation set**. Parameters live in
+`configs/musique_eval.json` under `paired_comparison`: `bootstrap_iterations` 10000,
+`alpha` 0.05, `max_reported_id_mismatches` 20, `out_prefix` `compare`. The seed is the
+config's top-level `seed` (42) or `--seed`.
+
+- **Alignment** (`_load_per_item`, `_aligned_ids`): rows are keyed by `item_id`. A
+  duplicate id inside one file, or any id present in one file and not the other, aborts the
+  run with the offending ids listed (capped at `max_reported_id_mismatches`). There is no
+  silent intersection — a comparison across different evaluation sets is not a comparison
+  (CLAUDE.md, evidence discipline). Aligned ids are processed in sorted order, so the
+  bootstrap is reproducible.
+- **Paired bootstrap CIs** (`_paired_bootstrap`, `_statistics_for`) for `rouge_l_f1`,
+  `step_f1`, `ordered_step_accuracy` and `composite_score`. Each of the 10000 resamples
+  draws n item indices with replacement (`numpy.random.default_rng(seed)`) and applies the
+  **same** indices to both systems; every statistic is recomputed from the resampled items.
+  The interval is the [alpha/2, 1−alpha/2] percentile of the difference **system_a minus
+  system_b**, and `significant` is true when that interval excludes 0. The point estimate
+  runs through the same function with the identity resample, so the observed value and the
+  distribution cannot drift apart. `composite_score` is genuinely recomputed on each
+  resample (its reference term is a micro rate and its step-count term a MAE, neither of
+  which is an average of per-item values) using **this config's** weights and scale, which
+  need not be the ones the per-item files were produced with.
+- **McNemar** (`_mcnemar`, `_mcnemar_exact_p`) for the two binary metrics `exact_match` and
+  `hop_count_exact_match`: with b = #(a correct, b wrong) and c = #(a wrong, b correct),
+  the exact two-sided p-value is `min(1, 2 * BinomialCDF(min(b, c); b + c, 0.5))`, computed
+  with exact integer arithmetic. With no discordant pairs p = 1.0. `significant` is
+  `p < alpha`.
+- **Six tests are reported and none is corrected for multiple comparisons.** The run note
+  says so too.
+- This substitutes paired bootstrap + McNemar for the "t-test" the supervisor asked for
+  ([31:33] in the meeting cross-check); the substitution is recorded there as open item 8.
+
+Output: `<out_prefix>_config.json`, `<out_prefix>_metrics.json` and `<out_prefix>_notes.md`
+in the run directory, with a Markdown table of every statistic, its difference, its
+interval or p-value, and its significant/not annotation.
+
+## 6. "Composite score" names two different things — proposed fix
+
+The name currently collides in Jahid's work:
+
+1. **this decomposition-quality composite** — §4, computed by
+   `scripts/musique_decompositions_evaluator.py`, key `composite_score` in its metrics
+   JSON, and the same key aggregated by `scripts/pool_sweep_orchestrator.py` and plotted by
+   `scripts/plot_pool_sweep.py`;
+2. **a rank-weighted retrieval score** used on the retrieval / re-ranking side of the work.
+   No implementation of it exists in this repository as of this commit — it is not defined
+   here, and this file deliberately does not guess its formula.
+
+Two different quantities under one name is a write-up hazard in November and a review
+hazard before that. **Proposal: keep "composite score" for (1) and rename (2) to
+"retrieval rank score."** Renaming (2) rather than (1) leaves every committed metrics JSON,
+config key and plot in this repo valid. This is a naming proposal, not a decision: the
+retrieval-side quantity is Jahid's, and the rename should be confirmed by him before it is
+applied anywhere.
+
+## 7. Running it
+
+```bash
+# score one run against gold
+.venv/bin/python scripts/musique_decompositions_evaluator.py \
+    --predictions runs/<...>/results.json
+
+# paired significance between two scored runs (same eval set)
+.venv/bin/python scripts/musique_decompositions_evaluator.py \
+    --compare runs/<a>/eval_per_item.json runs/<b>/eval_per_item.json
+```
+
+The hand-computed checks for all of the above are in
+[`tests/test_decomposition_metrics.py`](../tests/test_decomposition_metrics.py) (also run
+as the `decomposition_metric_tests` stage of `scripts/smoke_test.py`); each test's
+docstring shows the arithmetic behind its expected numbers against the fabricated fixture.

--- a/docs/meetings/2026-08-12-supervisor-meeting-transcript-crosscheck.md
+++ b/docs/meetings/2026-08-12-supervisor-meeting-transcript-crosscheck.md
@@ -1,0 +1,89 @@
+# Transcript cross-check — 2026-08-12 supervisor meeting
+
+Source: Fathom recording of the Jahid ↔ Ahmmad O.M. Saleh meeting
+(fathom.video/calls/782792212), cross-checked 2026-08-17 by a read-only agent
+against `Plan after the meeting.md` and ADRs 0006/0007/0008. Timestamps link
+into the recording. Caveats: Fathom's speaker labels are scrambled in places
+(attribution below is by content); ASR garbling ("music" = MuSiQue,
+"Quen" = Qwen, "G-Rack" = GRAG, "hope" = hop).
+
+This note records what the transcript supports. It changes no decision;
+discrepancies are triaged in the companion GitHub issue.
+
+## Verdicts on the recorded decisions
+
+| Repo claim | Verdict |
+|---|---|
+| Supervisor meeting (Jahid + Saleh) | Confirmed by content; the transcript itself carries no date |
+| Jury dropped, engineering-not-research reasoning (ADR 0006 §1) | Confirmed; "moves to Future Work" and the CLAUDE.md closed-model tie-in are repo glosses; the drop was Jahid's concession to Saleh's stated opinion ([1:12:34] "If you are sure about the judge idea… I will continue with you"), not an edict |
+| Dataset roles: MuSiQue = decomp + e2e, MetaQA = e2e via GRAG (ADR 0006 §2) | Confirmed ([1:14:00]–[1:14:29]); ADR omits a sanctioned fallback: [1:15:24] "If you want to shrink… to one dataset, continue with the music" |
+| Few-shot method fixed: bi-encoder top-20 → cross-encoder top-5, typed masking (ADR 0006 §3) | Method + typed masking confirmed ([1:24:27] "Keep the experiment on bi-encoder, cross-encoder type… leave the rest as an ablation"); **the numbers 20 and 5 were not fixed in the meeting** — top-20 is v1 practice ([42:55]), top-5 appears only in hypotheticals ([38:17], [1:18:00]) |
+| Pool size 2000 (ADR 0006 §4) | Confirmed verbatim ([1:24:27] "2000 was the best one. So keep it 2000", reconfirmed [1:32:24]); note the transcript is internally inconsistent on the evidence — [26:16]/[47:17]/[1:29:25] describe 4000 as (co-)best |
+| Contribution framing (ADR 0006 §5) | Confirmed ([1:11:38] "You are proposing a strategy, how you choose your few shots… with empirical study"); "hop-aware" wording is a gloss |
+| Router OPEN pending guided-vs-unguided (ADR 0006 §6) | Confirmed as end state ([1:16:12]–[1:16:23]); preceded by a near-removal moment ([58:33] "will you include router or not? No… 90% I'm sure") that was then reopened |
+| Length cap not cheating (Prompt 4) | Confirmed ([36:22] "you may set a stopping criteria… fix the max token… It's not cheating"); supervisor's example cap was **6** lines, the plan's default is 8 (config) |
+| Eval set 600 = 200/hop (ADR 0007) | Confirmed ([26:16], [1:28:51] "I will pick the 600 questions that I have checked"; [1:29:13] fine-tuning evaluated "on the same 600 samples"); Jahid voiced unresolved doubt about the size ([28:50]) |
+| No 600M router cap; up to 8B (ADR 0008) | Transcript **silent on any cap**; router work at Qwen-3B/7B and Mistral-7B discussed approvingly ([10:30], [12:29], [24:18]); the only "600 million" is an unrelated competition anecdote ([1:34:05]); quantization never mentioned. Consistent with ADR 0008's provenance finding; its supersession caveat stands |
+
+## The two open items from issue #6 — confirmed still open
+
+- **Thesis-primary metric: explicitly deferred.** [31:59] "For the other
+  metric, we will leave it for the next meeting." [32:51] "It's not studied
+  fully, so we don't know what is the best evaluation metric can be."
+- **Embedding model: never chosen.** The bi-encoder/cross-encoder *method* was
+  fixed; no specific model was named ([42:26] mentions "MiniLM and stuff like
+  that" descriptively; [43:52] pre-trained, nothing trained).
+
+## Said in the meeting, recorded nowhere (for Jahid to triage)
+
+1. **Router as regression, not only classification** ([1:02:00] "you can deal
+   with it as a regression problem… You are putting an assumption that you
+   already know the maximum number of hops").
+2. **Apply the same few-shot/pool method to the router itself** if kept, and
+   evaluate MuSiQue with-router vs without ([1:02:00], [1:15:24]).
+3. **Reinforcement learning out of scope for the master's** ([1:34:39] "this
+   idea is worth your PhD… I don't put it as a baseline").
+4. **Check the handmade composite score against standard re-ranking methods /
+   bias check** ([46:18] "This composite score is handmade… Maybe it's
+   biased. Let's put a note").
+5. **Literature check before adopting any method** ([1:07:16]).
+6. **Mixing MetaQA + MuSiQue training data** floated, "not yet decided"
+   ([1:33:23], [1:34:03]).
+7. **Fine-tuning sequencing ambiguous**: Jahid asked to fine-tune first
+   ([1:28:00]); Saleh recommended pipeline-first ([1:30:28]) but closed with
+   "but do fine-tuning. Let's see" ([1:29:56]) and "In case you do the fine
+   tuning and everything didn't crash… continue following the figure I shared"
+   ([1:35:43]). The plan resolves this silently by putting fine-tuning last.
+8. **The supervisor asked for "a t-test, a statistical test"** ([31:33]); the
+   metrics work implements paired bootstrap CIs + McNemar instead — a
+   defensible substitution, recorded here as one.
+9. **Error asymmetry value judgment**: over-decomposition more tolerable than
+   under-decomposition ([33:23] "a three-hop question, it's fine to make it a
+   four-hop, but it's not fine to make it a two-hop… check how many questions
+   has been… under-decomposed, not over-decomposed").
+10. **Failure cases kept in the ablation study** ([1:16:58]).
+11. **The pipeline figure Saleh screenshotted and said he would send**
+    ([1:33:00]) is referenced nowhere in the repo.
+12. Presentation action items (dataset-statistics slide, ROUGE explanation,
+    define typed/uniform/raw, un-bold non-best numbers) — [09:16], [27:42],
+    [54:00].
+
+## GRAG, fine-tuning, timeline
+
+- **GRAG**: the supervisor's method ([33:55] "you can connect it to my
+  method, G-Rack"); the operative line [1:14:13] "We can run MetaQA data on
+  GRAG **that you have**" is ambiguous about who has it; **no handover date,
+  repo, or access mechanism was discussed**. Prompt 8's
+  external-dependency-to-chase stance is the safe reading.
+- **Fine-tuning was ordered, not merely allowed** ([1:29:56] "but do
+  fine-tuning"), LoRA named, two arms (best pool / full train split)
+  ([1:27:05]), expected "a couple days" ([1:32:24]), both outcomes sellable
+  and never hidden ([1:30:17]–[1:31:36]).
+- **Closed-model-judging rule corroborated**: [49:29] "you said that Gemini is
+  not kind of truth… It may hallucinate, so we cannot use it as a judge";
+  [1:10:53] "GPT, Gemini, these ones, closed, big models… I don't like this
+  approach. On research."
+- The meeting decisions were to be **presented to the professor ("hoca")**
+  ([1:26:25] "We present it to… hoca, what is our plan for ablation study,
+  what is our baseline, and we will continue based on that").
+- No mention of the October/November/December calendar in the transcript.

--- a/scripts/musique_decompositions_evaluator.py
+++ b/scripts/musique_decompositions_evaluator.py
@@ -6,7 +6,7 @@ Scoring techniques (all string-level, no model in the loop):
 - Exact match (full decomposition)
 - Step-level precision/recall/F1 (unordered)
 - Ordered step accuracy
-- Step count error
+- Step count error, signed (over- vs under-decomposition) and absolute
 - Reference validity for [#k] chains
 - ROUGE-L precision/recall/F1 (LCS-based)
 - A composite score whose weights come from the config
@@ -17,19 +17,31 @@ Inputs:
 - gold: JSONL with items containing
     {"question": "...", "question_decomposition": [{"question": "..."}, ...]}
 
+Two modes:
+- default: score one predictions file against gold, writing ``<prefix>_per_item.json``
+  plus the standard config/metrics/notes trail.
+- ``--compare A_per_item.json B_per_item.json``: paired significance between two runs
+  **on the same evaluation set** (bootstrap CIs + McNemar). It aligns rows by item id
+  and refuses to run when the two sets differ, because a comparison across different
+  evaluation sets is not a comparison (CLAUDE.md, evidence discipline).
+
 Ported from v1 ``scripts/musique_decompositions_evaluator.py``. Adapted for v2: the
-gold path, run directory, seed, limit and the composite-score weights come from
-``configs/musique_eval.json``; the run writes the standard config/metrics/notes trail.
+gold path, run directory, seed, limit, the composite-score weights and the paired
+comparison parameters come from ``configs/musique_eval.json``; the run writes the
+standard config/metrics/notes trail.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+import numpy as np
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_REPO_ROOT / "src"))
@@ -85,6 +97,25 @@ METRIC_DEFINITIONS: dict[str, Any] = {
         "references / total references across all rows"
     ),
     "step_count_abs_error_mae": "mean of |len(pred steps) - len(gold steps)|",
+    "step_count_mae": (
+        "same number as step_count_abs_error_mae, reported again so the directional "
+        "step-count family (over/under rates, signed mean, MAE) reads as one block"
+    ),
+    "step_count_signed_error": (
+        "per item: len(pred steps) - len(gold steps). Positive = over-decomposition "
+        "(more steps than gold), negative = under-decomposition"
+    ),
+    "mean_signed_step_count_error": (
+        "mean of the per-item signed error. Near zero does NOT mean accurate step "
+        "counts: over- and under-decomposition cancel, which is why the two rates and "
+        "the MAE are reported next to it"
+    ),
+    "over_decomposition_rate": "fraction of rows with len(pred steps) > len(gold steps)",
+    "under_decomposition_rate": "fraction of rows with len(pred steps) < len(gold steps)",
+    "item_id": (
+        "the prediction's 'query_id', else its 'id', else its normalized question text; "
+        "this is the key --compare aligns two runs on"
+    ),
     "hop_count_metrics": (
         "predicted hop count is the number of predicted steps; gold hop count is the "
         "gold 'hop_count' field when present and positive, else the gold step count"
@@ -103,8 +134,46 @@ METRIC_DEFINITIONS: dict[str, Any] = {
 }
 
 
+#: Written into every comparison metrics JSON, for the same reason as METRIC_DEFINITIONS:
+#: "significant" is meaningless without the test and the resampling unit behind it.
+COMPARISON_DEFINITIONS: dict[str, Any] = {
+    "alignment": (
+        "the two per-item files are aligned on 'item_id' and must cover exactly the same "
+        "ids; any id present in one and not the other aborts the run"
+    ),
+    "difference_direction": "every reported difference is system_a minus system_b",
+    "paired_bootstrap": (
+        "percentile bootstrap over items: each of the bootstrap_iterations resamples "
+        "draws n item indices with replacement and applies the SAME indices to both "
+        "systems (paired), then recomputes each statistic from the resampled items. The "
+        "reported interval is the [alpha/2, 1-alpha/2] percentile of the difference"
+    ),
+    "bootstrap_significance": (
+        "significant = the confidence interval of the difference excludes 0. This is a "
+        "CI-based decision, not a p-value"
+    ),
+    "composite_score_in_bootstrap": (
+        "recomputed on each resample from the resampled items (its reference-validity "
+        "term is a micro rate and its step-count term a MAE, so neither is an average of "
+        "per-item values), using the weights and scale of THIS config — which are the "
+        "config's, not necessarily the ones the per-item files were produced with"
+    ),
+    "mcnemar": (
+        "exact two-sided McNemar on the discordant pairs of a binary metric: with b = "
+        "#(a correct, b wrong) and c = #(a wrong, b correct), p = min(1, 2 * "
+        "BinomialCDF(min(b, c); b + c, 0.5)). p = 1.0 when there are no discordant pairs"
+    ),
+    "mcnemar_significance": "significant = p_value < alpha",
+    "multiple_comparisons": (
+        "six tests are reported per comparison and none of the p-values or intervals is "
+        "corrected for multiple comparisons"
+    ),
+}
+
+
 @dataclass
 class EvalRow:
+    item_id: str
     question: str
     pred_steps: list[str]
     gold_steps: list[str]
@@ -264,6 +333,17 @@ def _join_steps(steps: list[str]) -> str:
     return "\n".join(s.strip() for s in steps if s.strip())
 
 
+def _item_id(obj: dict[str, Any], question: str) -> str:
+    """The key --compare aligns on. Falls back to the normalized question text."""
+    for key in ("query_id", "id"):
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+    return _normalize_question(question)
+
+
 def _build_eval_rows(
     predictions: list[dict[str, Any]],
     gold_by_question: dict[str, dict[str, Any]],
@@ -280,6 +360,7 @@ def _build_eval_rows(
             continue
         rows.append(
             EvalRow(
+                item_id=_item_id(obj, question),
                 question=question,
                 pred_steps=_decomp_to_steps(obj.get("decomposition")),
                 gold_steps=gold_obj["steps"],
@@ -302,6 +383,10 @@ _EMPTY_AGGREGATE = {
     "reference_validity_macro": 0.0,
     "reference_validity_micro": 1.0,
     "step_count_abs_error_mae": 0.0,
+    "step_count_mae": 0.0,
+    "mean_signed_step_count_error": 0.0,
+    "over_decomposition_rate": 0.0,
+    "under_decomposition_rate": 0.0,
     "hop_count_exact_match_rate": 0.0,
     "hop_count_abs_error_mae": 0.0,
     "predicted_hop_distribution": {},
@@ -323,6 +408,9 @@ def _aggregate(items: list[dict[str, Any]]) -> dict[str, Any]:
     def mean(key: str) -> float:
         return sum(float(it[key]) for it in items) / m
 
+    signed = [int(it["step_count_signed_error"]) for it in items]
+    step_count_mae = mean("step_count_abs_error")
+
     return {
         "num_rows": m,
         "exact_match_rate": mean("exact_match"),
@@ -335,7 +423,11 @@ def _aggregate(items: list[dict[str, Any]]) -> dict[str, Any]:
         "rouge_l_f1_macro": mean("rouge_l_f1"),
         "reference_validity_macro": mean("reference_validity_rate"),
         "reference_validity_micro": 1.0 if ref_valid_den == 0 else ref_valid_num / ref_valid_den,
-        "step_count_abs_error_mae": mean("step_count_abs_error"),
+        "step_count_abs_error_mae": step_count_mae,
+        "step_count_mae": step_count_mae,
+        "mean_signed_step_count_error": sum(signed) / m,
+        "over_decomposition_rate": sum(1 for s in signed if s > 0) / m,
+        "under_decomposition_rate": sum(1 for s in signed if s < 0) / m,
         "hop_count_exact_match_rate": mean("hop_count_exact_match"),
         "hop_count_abs_error_mae": mean("hop_count_abs_error"),
         "predicted_hop_distribution": pred_dist,
@@ -352,16 +444,354 @@ def _composite_score(overall: dict[str, Any], weights: dict[str, float], scale: 
     )
 
 
+# --------------------------------------------------------------------------------------
+# Paired comparison of two runs (--compare)
+# --------------------------------------------------------------------------------------
+
+#: Statistics compared with a paired bootstrap CI. Every one is recomputed from the
+#: resampled items, so the point estimate and the interval come from the same code path.
+BOOTSTRAP_STATISTICS = ("rouge_l_f1", "step_f1", "ordered_step_accuracy", "composite_score")
+
+#: Binary per-item metrics compared with McNemar.
+MCNEMAR_STATISTICS = ("exact_match", "hop_count_exact_match")
+
+#: Per-item fields a comparison needs. A file missing one of them is a file this script
+#: did not write (or wrote before these metrics existed), and saying so beats a KeyError.
+_REQUIRED_PER_ITEM_FIELDS = (
+    "item_id",
+    "step_f1",
+    "ordered_step_accuracy",
+    "rouge_l_f1",
+    "reference_valid_count",
+    "reference_total_count",
+    "step_count_abs_error",
+    *MCNEMAR_STATISTICS,
+)
+
+
+def _load_per_item(path: Path) -> dict[str, dict[str, Any]]:
+    """Load a ``*_per_item.json`` file into {item_id: row}, failing loudly on duplicates."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise SystemExit(f"--compare expects a per-item JSON list: {path}")
+    by_id: dict[str, dict[str, Any]] = {}
+    duplicates: list[str] = []
+    for i, obj in enumerate(raw):
+        if not isinstance(obj, dict):
+            raise SystemExit(f"{path}: row {i} is not an object")
+        missing = [f for f in _REQUIRED_PER_ITEM_FIELDS if f not in obj]
+        if missing:
+            raise SystemExit(
+                f"{path}: row {i} is missing {missing}. --compare takes the "
+                f"'<prefix>_per_item.json' files written by this script; re-run the "
+                f"evaluation to regenerate them."
+            )
+        item_id = str(obj["item_id"])
+        if item_id in by_id:
+            duplicates.append(item_id)
+        by_id[item_id] = obj
+    if duplicates:
+        raise SystemExit(f"{path}: duplicate item_id(s): {sorted(set(duplicates))}")
+    return by_id
+
+
+def _aligned_ids(
+    a_by_id: dict[str, dict[str, Any]],
+    b_by_id: dict[str, dict[str, Any]],
+    path_a: Path,
+    path_b: Path,
+    max_reported: int,
+) -> list[str]:
+    """Ids common to both files, or abort naming the offenders.
+
+    A comparison across two different evaluation sets is not a comparison (CLAUDE.md,
+    evidence discipline), so a mismatch is fatal rather than an intersection.
+    """
+    only_a = sorted(set(a_by_id) - set(b_by_id))
+    only_b = sorted(set(b_by_id) - set(a_by_id))
+    if only_a or only_b:
+        def _fmt(ids: list[str]) -> str:
+            shown = ids[:max_reported]
+            more = "" if len(ids) <= max_reported else f" ... (+{len(ids) - max_reported} more)"
+            return ", ".join(shown) + more
+
+        lines = [
+            "--compare requires the SAME evaluation set in both files; they differ.",
+            f"  a: {path_a} ({len(a_by_id)} items)",
+            f"  b: {path_b} ({len(b_by_id)} items)",
+        ]
+        if only_a:
+            lines.append(f"  only in a ({len(only_a)}): {_fmt(only_a)}")
+        if only_b:
+            lines.append(f"  only in b ({len(only_b)}): {_fmt(only_b)}")
+        raise SystemExit("\n".join(lines))
+    return sorted(a_by_id)
+
+
+def _statistic_arrays(rows: list[dict[str, Any]]) -> dict[str, np.ndarray]:
+    """The per-item columns every compared statistic is built from."""
+    def col(key: str) -> np.ndarray:
+        return np.array([float(r[key]) for r in rows], dtype=float)
+
+    return {
+        "step_f1": col("step_f1"),
+        "ordered_step_accuracy": col("ordered_step_accuracy"),
+        "rouge_l_f1": col("rouge_l_f1"),
+        "reference_valid_count": col("reference_valid_count"),
+        "reference_total_count": col("reference_total_count"),
+        "step_count_abs_error": col("step_count_abs_error"),
+    }
+
+
+def _statistics_for(
+    arrays: dict[str, np.ndarray],
+    index: np.ndarray,
+    weights: dict[str, float],
+    scale: float,
+) -> dict[str, np.ndarray]:
+    """Evaluate every bootstrap statistic on resamples ``index`` of shape (draws, n).
+
+    Returns one array of length ``draws`` per statistic. The point estimate uses this
+    same function with a single "resample" that is the identity, so the observed value
+    and the bootstrap distribution can never drift apart.
+    """
+    step_f1 = arrays["step_f1"][index].mean(axis=1)
+    ordered = arrays["ordered_step_accuracy"][index].mean(axis=1)
+    rouge = arrays["rouge_l_f1"][index].mean(axis=1)
+
+    valid = arrays["reference_valid_count"][index].sum(axis=1)
+    total = arrays["reference_total_count"][index].sum(axis=1)
+    # A resample with no [#k] references at all scores 1.0, matching _aggregate().
+    ref_micro = np.where(total == 0, 1.0, valid / np.where(total == 0, 1.0, total))
+
+    mae = arrays["step_count_abs_error"][index].mean(axis=1)
+    step_count_term = np.maximum(0.0, 1.0 - mae / scale)
+
+    composite = (
+        float(require(weights, "step_f1_macro")) * step_f1
+        + float(require(weights, "ordered_step_accuracy_macro")) * ordered
+        + float(require(weights, "reference_validity_micro")) * ref_micro
+        + float(require(weights, "step_count_error")) * step_count_term
+    )
+    return {
+        "rouge_l_f1": rouge,
+        "step_f1": step_f1,
+        "ordered_step_accuracy": ordered,
+        "composite_score": composite,
+    }
+
+
+def _paired_bootstrap(
+    arrays_a: dict[str, np.ndarray],
+    arrays_b: dict[str, np.ndarray],
+    n: int,
+    iterations: int,
+    alpha: float,
+    seed: int,
+    weights: dict[str, float],
+    scale: float,
+) -> dict[str, dict[str, float]]:
+    identity = np.arange(n)[None, :]
+    point_a = _statistics_for(arrays_a, identity, weights, scale)
+    point_b = _statistics_for(arrays_b, identity, weights, scale)
+
+    rng = np.random.default_rng(seed)
+    index = rng.integers(0, n, size=(iterations, n))
+    draws_a = _statistics_for(arrays_a, index, weights, scale)
+    draws_b = _statistics_for(arrays_b, index, weights, scale)
+
+    lo_pct = 100.0 * (alpha / 2.0)
+    hi_pct = 100.0 * (1.0 - alpha / 2.0)
+
+    out: dict[str, dict[str, float]] = {}
+    for name in BOOTSTRAP_STATISTICS:
+        diffs = draws_a[name] - draws_b[name]
+        ci_low, ci_high = (float(x) for x in np.percentile(diffs, [lo_pct, hi_pct]))
+        out[name] = {
+            "system_a": float(point_a[name][0]),
+            "system_b": float(point_b[name][0]),
+            "difference": float(point_a[name][0] - point_b[name][0]),
+            "ci_low": ci_low,
+            "ci_high": ci_high,
+            "significant": bool(ci_low > 0.0 or ci_high < 0.0),
+        }
+    return out
+
+
+def _mcnemar_exact_p(b: int, c: int) -> float:
+    """Two-sided exact McNemar p-value on discordant counts ``b`` and ``c``."""
+    n = b + c
+    if n == 0:
+        return 1.0
+    tail = sum(math.comb(n, k) for k in range(min(b, c) + 1))
+    return min(1.0, 2.0 * (tail / (2**n)))
+
+
+def _mcnemar(
+    rows_a: list[dict[str, Any]],
+    rows_b: list[dict[str, Any]],
+    alpha: float,
+) -> dict[str, dict[str, float]]:
+    out: dict[str, dict[str, float]] = {}
+    for name in MCNEMAR_STATISTICS:
+        a_vals = [float(r[name]) >= 1.0 for r in rows_a]
+        b_vals = [float(r[name]) >= 1.0 for r in rows_b]
+        only_a = sum(1 for x, y in zip(a_vals, b_vals) if x and not y)
+        only_b = sum(1 for x, y in zip(a_vals, b_vals) if y and not x)
+        p_value = _mcnemar_exact_p(only_a, only_b)
+        n = len(a_vals)
+        out[name] = {
+            "system_a_rate": sum(a_vals) / n,
+            "system_b_rate": sum(b_vals) / n,
+            "difference": (sum(a_vals) - sum(b_vals)) / n,
+            "correct_only_in_a": only_a,
+            "correct_only_in_b": only_b,
+            "discordant_pairs": only_a + only_b,
+            "p_value": p_value,
+            "significant": bool(p_value < alpha),
+        }
+    return out
+
+
+def _compare(
+    args: argparse.Namespace,
+    cfg: dict[str, Any],
+    paths_cfg: dict[str, Any],
+    seed: int,
+    seeded: dict[str, Any],
+    weights: dict[str, float],
+    scale: float,
+) -> None:
+    compare_cfg = require(cfg, "paired_comparison")
+    iterations = int(require(compare_cfg, "bootstrap_iterations"))
+    alpha = float(require(compare_cfg, "alpha"))
+    max_reported = int(require(compare_cfg, "max_reported_id_mismatches"))
+    out_prefix = args.out_prefix or require(compare_cfg, "out_prefix")
+
+    path_a, path_b = args.compare
+    a_by_id = _load_per_item(path_a)
+    b_by_id = _load_per_item(path_b)
+    ids = _aligned_ids(a_by_id, b_by_id, path_a, path_b, max_reported)
+    if not ids:
+        raise SystemExit("--compare: both files are empty, nothing to compare.")
+
+    rows_a = [a_by_id[i] for i in ids]
+    rows_b = [b_by_id[i] for i in ids]
+    n = len(ids)
+
+    bootstrap = _paired_bootstrap(
+        _statistic_arrays(rows_a),
+        _statistic_arrays(rows_b),
+        n=n,
+        iterations=iterations,
+        alpha=alpha,
+        seed=seed,
+        weights=weights,
+        scale=scale,
+    )
+    mcnemar = _mcnemar(rows_a, rows_b, alpha)
+
+    run_dir = args.run_dir if args.run_dir is not None else runs_path(paths_cfg, require(cfg, "run_subdir"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics = {
+        "script": Path(__file__).name,
+        "mode": "compare",
+        "created_utc": now_iso(),
+        "seed": seed,
+        "seeded": seeded,
+        "system_a_path": str(path_a.resolve()),
+        "system_b_path": str(path_b.resolve()),
+        "num_aligned_items": n,
+        "bootstrap_iterations": iterations,
+        "alpha": alpha,
+        "confidence_level": 1.0 - alpha,
+        "difference_direction": "system_a minus system_b",
+        "bootstrap": bootstrap,
+        "mcnemar": mcnemar,
+        "composite_score_weights": weights,
+        "composite_step_count_error_scale": scale,
+        "comparison_definitions": COMPARISON_DEFINITIONS,
+    }
+
+    snapshot = {
+        "script": Path(__file__).name,
+        "mode": "compare",
+        "created_utc": now_iso(),
+        "config_path": cfg.get("_config_path"),
+        "compare": [str(path_a), str(path_b)],
+        "run_dir": str(run_dir),
+        "seed": seed,
+        "out_prefix": out_prefix,
+        "bootstrap_iterations": iterations,
+        "alpha": alpha,
+        "composite_score_weights": weights,
+        "composite_step_count_error_scale": scale,
+    }
+
+    note_lines = [
+        f"- System a: `{path_a}`",
+        f"- System b: `{path_b}`",
+        f"- Aligned items: {n} (same evaluation set in both files)",
+        f"- Paired bootstrap: {iterations} resamples, seed {seed}, "
+        f"{100 * (1 - alpha):.0f}% percentile CI of (a - b)",
+        "",
+        "| statistic | a | b | a - b | CI | test | significant |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for name, r in bootstrap.items():
+        note_lines.append(
+            f"| {name} | {r['system_a']:.4f} | {r['system_b']:.4f} | {r['difference']:+.4f} | "
+            f"[{r['ci_low']:+.4f}, {r['ci_high']:+.4f}] | bootstrap | "
+            f"{'yes' if r['significant'] else 'no'} |"
+        )
+    for name, r in mcnemar.items():
+        note_lines.append(
+            f"| {name} | {r['system_a_rate']:.4f} | {r['system_b_rate']:.4f} | "
+            f"{r['difference']:+.4f} | p={r['p_value']:.4g} (b={r['correct_only_in_a']}, "
+            f"c={r['correct_only_in_b']}) | McNemar | "
+            f"{'yes' if r['significant'] else 'no'} |"
+        )
+    note_lines.append("")
+    note_lines.append(
+        "No correction for multiple comparisons is applied to these six tests."
+    )
+
+    write_run_artifacts(
+        run_dir,
+        config_snapshot=snapshot,
+        metrics=metrics,
+        note_title="MuSiQue decomposition comparison (paired)",
+        note_lines=note_lines,
+        prefix=f"{out_prefix}_",
+    )
+
+    print(f"Compared {n} aligned items ({iterations} bootstrap resamples, seed {seed})")
+    for line in note_lines[5:]:
+        print(line)
+
+
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--config", default="musique_eval.json", help="Config (default: configs/musique_eval.json)")
-    p.add_argument("--predictions", type=Path, required=True, help="Predicted decompositions JSON (list).")
+    p.add_argument("--predictions", type=Path, default=None, help="Predicted decompositions JSON (list).")
+    p.add_argument(
+        "--compare",
+        type=Path,
+        nargs=2,
+        default=None,
+        metavar=("A_PER_ITEM", "B_PER_ITEM"),
+        help="Paired significance between two '<prefix>_per_item.json' files (same eval set).",
+    )
     p.add_argument("--gold", type=Path, default=None, help="Override the gold JSONL from config.")
     p.add_argument("--run-dir", type=Path, default=None, help="Override the run directory from config.")
     p.add_argument("--seed", type=int, default=None, help="Override the config seed.")
     p.add_argument("--limit", type=int, default=None, help="Override the config row cap.")
     p.add_argument("--out-prefix", default=None, help="Override the artifact filename prefix.")
-    return p.parse_args()
+    args = p.parse_args()
+    if (args.predictions is None) == (args.compare is None):
+        p.error("pass exactly one of --predictions (scoring) or --compare A B (comparison)")
+    return args
 
 
 def main() -> None:
@@ -371,10 +801,15 @@ def main() -> None:
 
     seed = args.seed if args.seed is not None else int(require(cfg, "seed"))
     seeded = set_global_seed(seed)
-    limit = args.limit if args.limit is not None else require(cfg, "limit")
-    out_prefix = args.out_prefix or require(cfg, "out_prefix")
     weights = require(cfg, "composite_score_weights")
     scale = float(require(cfg, "composite_step_count_error_scale"))
+
+    if args.compare is not None:
+        _compare(args, cfg, paths_cfg, seed, seeded, weights, scale)
+        return
+
+    limit = args.limit if args.limit is not None else require(cfg, "limit")
+    out_prefix = args.out_prefix or require(cfg, "out_prefix")
 
     gold_path = (
         args.gold
@@ -414,6 +849,7 @@ def main() -> None:
         gold_hops = row.gold_hop_count
 
         item_row = {
+            "item_id": row.item_id,
             "question": row.question,
             "pred_steps": row.pred_steps,
             "gold_steps": row.gold_steps,
@@ -430,6 +866,7 @@ def main() -> None:
             "reference_validity_rate": ref_rate,
             "reference_valid_count": ref_ok,
             "reference_total_count": ref_total,
+            "step_count_signed_error": len(row.pred_steps) - len(row.gold_steps),
             "step_count_abs_error": abs(len(row.pred_steps) - len(row.gold_steps)),
             "predicted_hop_count": pred_hops,
             "gold_hop_count": gold_hops,
@@ -495,6 +932,10 @@ def main() -> None:
             f"- Step F1 (macro): {metrics['step_f1_macro']:.4f}",
             f"- Ordered step accuracy: {metrics['ordered_step_accuracy_macro']:.4f}",
             f"- ROUGE-L F1 (macro): {metrics['rouge_l_f1_macro']:.4f}",
+            f"- Step count: MAE {metrics['step_count_mae']:.4f}, mean signed "
+            f"{metrics['mean_signed_step_count_error']:+.4f} "
+            f"(over {metrics['over_decomposition_rate']:.4f} / "
+            f"under {metrics['under_decomposition_rate']:.4f})",
             f"- Composite score: {metrics['composite_score']:.4f}",
             f"- Per-item: `{per_item_path}`",
         ],

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -115,6 +115,11 @@ def _stages() -> list[Stage]:
 
     return [
         Stage(
+            name="decomposition_metric_tests",
+            cmd=[sys.executable, "-m", "unittest", "discover", "-s", "tests"],
+            note="hand-computed metric checks for the decomposition evaluator (tests/)",
+        ),
+        Stage(
             name="musique_eval",
             cmd=[
                 sys.executable, SCRIPTS / "musique_decompositions_evaluator.py",

--- a/tests/test_decomposition_metrics.py
+++ b/tests/test_decomposition_metrics.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Hand-computed checks for ``scripts/musique_decompositions_evaluator.py``.
+
+Every expected number below is computed by hand from the **fabricated** fixture gold
+(``tests/fixtures/data_root/musique/dev_data/musique_ans_v1.0_dev_clean.jsonl``) and the
+metric definitions in the script; the arithmetic is written out in each test's docstring.
+The fixture never changes, so a number moving here means a normalization, matching or
+aggregation rule changed — which must be a deliberate, reviewed edit (same contract as
+the golden metrics in ``scripts/smoke_test.py``).
+
+Predictions are generated into a temp directory and the script is run as a subprocess
+with ``QAV2_PATHS_CONFIG=configs/smoke_paths.json``, so the real CLI, the real config and
+the real artifact writing are all exercised. Nothing here touches real data.
+
+Run::
+
+    .venv/bin/python -m unittest discover -s tests -v
+    .venv/bin/python tests/test_decomposition_metrics.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+GOLD_PATH = FIXTURES / "data_root" / "musique" / "dev_data" / "musique_ans_v1.0_dev_clean.jsonl"
+PREDICTIONS_FIXTURE = FIXTURES / "predictions" / "decomposer_results_musique.json"
+EVALUATOR = REPO_ROOT / "scripts" / "musique_decompositions_evaluator.py"
+SMOKE_PATHS_CONFIG = REPO_ROOT / "configs" / "smoke_paths.json"
+
+PLACES = 9
+
+
+def _load_gold() -> dict[str, dict[str, Any]]:
+    rows: dict[str, dict[str, Any]] = {}
+    with GOLD_PATH.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                obj = json.loads(line)
+                rows[obj["id"]] = obj
+    return rows
+
+
+GOLD = _load_gold()
+
+
+def gold_steps(item_id: str) -> list[str]:
+    return [s["question"] for s in GOLD[item_id]["question_decomposition"]]
+
+
+def as_decomposition(steps: list[str]) -> str:
+    """The enumerated string form a decomposer run actually emits."""
+    return "\n".join(f"{i}. {s}" for i, s in enumerate(steps, start=1))
+
+
+def prediction(item_id: str, steps: list[str]) -> dict[str, Any]:
+    return {
+        "query_id": item_id,
+        "question": GOLD[item_id]["question"],
+        "hop_count": GOLD[item_id]["hop_count"],
+        "decomposition": as_decomposition(steps),
+    }
+
+
+class EvaluatorTestBase(unittest.TestCase):
+    """Shared plumbing: write a predictions file, run the script, read the artifacts."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory(prefix="qav2_metrics_test_")
+        cls.tmp = Path(cls._tmp.name)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def _run(self, argv: list[str], expect_ok: bool = True) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env["QAV2_PATHS_CONFIG"] = str(SMOKE_PATHS_CONFIG)
+        proc = subprocess.run(
+            [sys.executable, str(EVALUATOR), *argv],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if expect_ok:
+            self.assertEqual(proc.returncode, 0, f"evaluator failed:\n{proc.stdout}\n{proc.stderr}")
+        return proc
+
+    def evaluate(self, name: str, predictions: list[dict[str, Any]]) -> tuple[dict[str, Any], Path]:
+        """Score ``predictions`` against the fixture gold; return (metrics, per_item path)."""
+        preds_path = self.tmp / f"{name}_predictions.json"
+        preds_path.write_text(json.dumps(predictions, ensure_ascii=False, indent=2), encoding="utf-8")
+        run_dir = self.tmp / name
+        self._run(["--predictions", str(preds_path), "--run-dir", str(run_dir)])
+        metrics = json.loads((run_dir / "eval_metrics.json").read_text(encoding="utf-8"))
+        return metrics, run_dir / "eval_per_item.json"
+
+    def assertMetrics(self, metrics: dict[str, Any], expected: dict[str, float]) -> None:
+        for key, value in expected.items():
+            with self.subTest(metric=key):
+                self.assertAlmostEqual(metrics[key], value, places=PLACES)
+
+
+class TestDirectionalStepCount(EvaluatorTestBase):
+    def test_prediction_longer_than_gold(self) -> None:
+        """4 predicted steps against the 2-step gold of 2hop__d001_a (over-decomposition).
+
+        Hand computation (1 evaluated row):
+          steps      pred 4, gold 2 -> signed +2, |error| 2
+          step set   tp 2 -> P 2/4 = 0.5, R 2/2 = 1.0, F1 = 2*0.5*1/1.5 = 2/3
+          ordered    2 positional matches / max(4, 2) = 0.5
+          ROUGE-L    gold joined = 10 whitespace tokens, pred = 10 + 7 + 3 = 20, and the
+                     gold token sequence is a prefix of the pred one, so LCS = 10
+                     -> P 10/20 = 0.5, R 10/10 = 1.0, F1 = 2/3
+          refs       [#1] in step 2 and [#3] in step 4 are both backward -> 2/2 = 1.0
+          hops       gold hop_count 2 vs 4 predicted -> exact 0, |error| 2
+          composite  0.4*(2/3) + 0.3*0.5 + 0.2*1.0 + 0.1*max(0, 1 - 2/3) = 0.65
+        """
+        steps = gold_steps("2hop__d001_a") + [
+            "Which city is the union based in?",
+            "Who founded [#3]?",
+        ]
+        metrics, _ = self.evaluate("longer", [prediction("2hop__d001_a", steps)])
+
+        self.assertEqual(metrics["total_evaluated"], 1)
+        self.assertMetrics(
+            metrics,
+            {
+                "exact_match_rate": 0.0,
+                "step_precision_macro": 0.5,
+                "step_recall_macro": 1.0,
+                "step_f1_macro": 2 / 3,
+                "ordered_step_accuracy_macro": 0.5,
+                "rouge_l_precision_macro": 0.5,
+                "rouge_l_recall_macro": 1.0,
+                "rouge_l_f1_macro": 2 / 3,
+                "reference_validity_macro": 1.0,
+                "reference_validity_micro": 1.0,
+                "step_count_mae": 2.0,
+                "step_count_abs_error_mae": 2.0,
+                "mean_signed_step_count_error": 2.0,
+                "over_decomposition_rate": 1.0,
+                "under_decomposition_rate": 0.0,
+                "hop_count_exact_match_rate": 0.0,
+                "hop_count_abs_error_mae": 2.0,
+                "composite_score": 0.65,
+            },
+        )
+        self.assertMetrics(
+            metrics["per_gold_hop_metrics"]["2"],
+            {
+                "step_count_mae": 2.0,
+                "mean_signed_step_count_error": 2.0,
+                "over_decomposition_rate": 1.0,
+                "under_decomposition_rate": 0.0,
+            },
+        )
+
+    def test_prediction_shorter_than_gold(self) -> None:
+        """The first 2 steps of the 4-step gold of 4hop1__d003_c (under-decomposition).
+
+        Hand computation (1 evaluated row):
+          steps      pred 2, gold 4 -> signed -2, |error| 2
+          step set   tp 2 -> P 2/2 = 1.0, R 2/4 = 0.5, F1 = 2/3
+          ordered    2 positional matches / max(2, 4) = 0.5
+          ROUGE-L    gold joined = 4 + 3 + 5 + 6 = 18 tokens, pred = 4 + 3 = 7, LCS = 7
+                     -> P 7/7 = 1.0, R 7/18, F1 = 2*(7/18)/(1 + 7/18) = 14/25 = 0.56
+          refs       [#1] in step 2 is backward -> 1/1 = 1.0
+          hops       gold hop_count 4 vs 2 predicted -> exact 0, |error| 2
+          composite  0.4*(2/3) + 0.3*0.5 + 0.2*1.0 + 0.1*max(0, 1 - 2/3) = 0.65
+        """
+        steps = gold_steps("4hop1__d003_c")[:2]
+        metrics, _ = self.evaluate("shorter", [prediction("4hop1__d003_c", steps)])
+
+        self.assertEqual(metrics["total_evaluated"], 1)
+        self.assertMetrics(
+            metrics,
+            {
+                "exact_match_rate": 0.0,
+                "step_precision_macro": 1.0,
+                "step_recall_macro": 0.5,
+                "step_f1_macro": 2 / 3,
+                "ordered_step_accuracy_macro": 0.5,
+                "rouge_l_precision_macro": 1.0,
+                "rouge_l_recall_macro": 7 / 18,
+                "rouge_l_f1_macro": 0.56,
+                "reference_validity_micro": 1.0,
+                "step_count_mae": 2.0,
+                "mean_signed_step_count_error": -2.0,
+                "over_decomposition_rate": 0.0,
+                "under_decomposition_rate": 1.0,
+                "hop_count_exact_match_rate": 0.0,
+                "hop_count_abs_error_mae": 2.0,
+                "composite_score": 0.65,
+            },
+        )
+        self.assertMetrics(
+            metrics["per_gold_hop_metrics"]["4"],
+            {
+                "step_count_mae": 2.0,
+                "mean_signed_step_count_error": -2.0,
+                "over_decomposition_rate": 0.0,
+                "under_decomposition_rate": 1.0,
+            },
+        )
+
+    def test_empty_prediction(self) -> None:
+        """An empty decomposition string against the 2-step gold of 2hop__d001_a.
+
+        Hand computation (1 evaluated row):
+          steps      pred 0, gold 2 -> signed -2, |error| 2, counted as under-decomposition
+          step set   pred set empty (gold set is not) -> P 0, R 0, F1 0
+          ordered    0 matches / max(0, 2) = 0.0
+          ROUGE-L    pred has no tokens, gold has 10 -> P/R/F1 all 0.0
+          refs       no [#k] at all -> per-row rate 1.0 and micro 1.0 (0 valid of 0 total):
+                     reference validity does NOT punish an empty prediction
+          composite  0.4*0 + 0.3*0 + 0.2*1.0 + 0.1*max(0, 1 - 2/3) = 0.2 + 1/30 = 7/30
+        """
+        pred = prediction("2hop__d001_a", [])
+        pred["decomposition"] = ""
+        metrics, _ = self.evaluate("empty", [pred])
+
+        self.assertEqual(metrics["total_evaluated"], 1)
+        self.assertMetrics(
+            metrics,
+            {
+                "exact_match_rate": 0.0,
+                "step_precision_macro": 0.0,
+                "step_recall_macro": 0.0,
+                "step_f1_macro": 0.0,
+                "ordered_step_accuracy_macro": 0.0,
+                "rouge_l_precision_macro": 0.0,
+                "rouge_l_recall_macro": 0.0,
+                "rouge_l_f1_macro": 0.0,
+                "reference_validity_macro": 1.0,
+                "reference_validity_micro": 1.0,
+                "step_count_mae": 2.0,
+                "mean_signed_step_count_error": -2.0,
+                "over_decomposition_rate": 0.0,
+                "under_decomposition_rate": 1.0,
+                "hop_count_exact_match_rate": 0.0,
+                "composite_score": 7 / 30,
+            },
+        )
+        self.assertEqual(metrics["predicted_hop_distribution"], {"0": 1})
+
+
+class TestReferenceValidity(EvaluatorTestBase):
+    def test_forward_reference(self) -> None:
+        """3hop1__d002_b with step 2 pointing forward at [#3] instead of back at [#1].
+
+        Hand computation (1 evaluated row):
+          steps      pred 3, gold 3 -> signed 0, so over/under rates are both 0
+          refs       step 2 uses [#3] (needs 1 <= 3 < 2: invalid), step 3 uses [#2]
+                     (valid) -> per-row rate 1/2, micro 1/2
+          step set   step 2 differs -> tp 2, P 2/3, R 2/3, F1 2/3
+          ordered    2 positional matches / 3 = 2/3
+          ROUGE-L    16 tokens on each side differing in exactly one token -> LCS 15,
+                     P = R = F1 = 15/16 = 0.9375
+          composite  0.4*(2/3) + 0.3*(2/3) + 0.2*0.5 + 0.1*1.0 = 2/3
+        """
+        steps = gold_steps("3hop1__d002_b")
+        steps[1] = steps[1].replace("[#1]", "[#3]")
+        metrics, _ = self.evaluate("forward_ref", [prediction("3hop1__d002_b", steps)])
+
+        self.assertMetrics(
+            metrics,
+            {
+                "exact_match_rate": 0.0,
+                "step_f1_macro": 2 / 3,
+                "ordered_step_accuracy_macro": 2 / 3,
+                "rouge_l_f1_macro": 15 / 16,
+                "reference_validity_macro": 0.5,
+                "reference_validity_micro": 0.5,
+                "step_count_mae": 0.0,
+                "mean_signed_step_count_error": 0.0,
+                "over_decomposition_rate": 0.0,
+                "under_decomposition_rate": 0.0,
+                "hop_count_exact_match_rate": 1.0,
+                "composite_score": 2 / 3,
+            },
+        )
+
+    def test_self_reference(self) -> None:
+        """2hop__d001_a with step 2 referring to itself as [#2].
+
+        Hand computation (1 evaluated row):
+          refs       step 2 uses [#2] (needs 1 <= 2 < 2: invalid) -> rate 0.0, micro 0.0
+          step set   step 2 differs -> tp 1, P 1/2, R 1/2, F1 0.5
+          ordered    1 positional match / 2 = 0.5
+          ROUGE-L    10 tokens each side differing in one token -> LCS 9, P = R = F1 = 0.9
+          steps      pred 2, gold 2 -> signed 0; hop count matches -> exact 1.0
+          composite  0.4*0.5 + 0.3*0.5 + 0.2*0.0 + 0.1*1.0 = 0.45
+        """
+        steps = gold_steps("2hop__d001_a")
+        steps[1] = steps[1].replace("[#1]", "[#2]")
+        metrics, _ = self.evaluate("self_ref", [prediction("2hop__d001_a", steps)])
+
+        self.assertMetrics(
+            metrics,
+            {
+                "exact_match_rate": 0.0,
+                "step_f1_macro": 0.5,
+                "ordered_step_accuracy_macro": 0.5,
+                "rouge_l_precision_macro": 0.9,
+                "rouge_l_recall_macro": 0.9,
+                "rouge_l_f1_macro": 0.9,
+                "reference_validity_macro": 0.0,
+                "reference_validity_micro": 0.0,
+                "step_count_mae": 0.0,
+                "mean_signed_step_count_error": 0.0,
+                "hop_count_exact_match_rate": 1.0,
+                "composite_score": 0.45,
+            },
+        )
+
+
+class TestPairedComparison(EvaluatorTestBase):
+    def _per_item_of_fixture(self) -> Path:
+        """Score the committed fixture predictions once; reuse the per-item file."""
+        run_dir = self.tmp / "compare_base"
+        if not (run_dir / "eval_per_item.json").exists():
+            self._run(
+                ["--predictions", str(PREDICTIONS_FIXTURE), "--run-dir", str(run_dir)]
+            )
+        return run_dir / "eval_per_item.json"
+
+    def test_identical_inputs_are_never_significant(self) -> None:
+        """A file compared with itself: every difference is exactly 0, nothing significant.
+
+        Hand computation: with a = b item by item, every paired bootstrap resample gives
+        difference 0, so the percentile interval is [0, 0] — which contains 0, hence not
+        significant. McNemar sees no discordant pairs (b = c = 0), so p = 1.0 by the
+        convention in _mcnemar_exact_p, hence not significant.
+        """
+        per_item = self._per_item_of_fixture()
+        run_dir = self.tmp / "compare_identical"
+        self._run(["--compare", str(per_item), str(per_item), "--run-dir", str(run_dir)])
+        metrics = json.loads((run_dir / "compare_metrics.json").read_text(encoding="utf-8"))
+
+        # 4 fixture predictions, 1 without a gold row -> 3 evaluated, so 3 aligned items.
+        self.assertEqual(metrics["num_aligned_items"], 3)
+        self.assertEqual(sorted(metrics["bootstrap"]), sorted(
+            ["rouge_l_f1", "step_f1", "ordered_step_accuracy", "composite_score"]
+        ))
+        for name, result in metrics["bootstrap"].items():
+            with self.subTest(statistic=name):
+                self.assertAlmostEqual(result["difference"], 0.0, places=PLACES)
+                self.assertAlmostEqual(result["ci_low"], 0.0, places=PLACES)
+                self.assertAlmostEqual(result["ci_high"], 0.0, places=PLACES)
+                self.assertFalse(result["significant"])
+        self.assertEqual(sorted(metrics["mcnemar"]), ["exact_match", "hop_count_exact_match"])
+        for name, result in metrics["mcnemar"].items():
+            with self.subTest(statistic=name):
+                self.assertEqual(result["discordant_pairs"], 0)
+                self.assertAlmostEqual(result["p_value"], 1.0, places=PLACES)
+                self.assertFalse(result["significant"])
+
+        # The comparison's point estimates must reproduce the scoring run's aggregates:
+        # step F1 8/9 and composite 0.9222... over the 3 fixture rows.
+        self.assertAlmostEqual(metrics["bootstrap"]["step_f1"]["system_a"], 8 / 9, places=PLACES)
+        self.assertAlmostEqual(
+            metrics["bootstrap"]["composite_score"]["system_a"], 0.9222222222222222, places=PLACES
+        )
+
+    def test_identical_inputs_are_reproducible(self) -> None:
+        """Same seed, same inputs -> byte-identical bootstrap results."""
+        per_item = self._per_item_of_fixture()
+        first = self.tmp / "compare_seed_a"
+        second = self.tmp / "compare_seed_b"
+        for run_dir in (first, second):
+            self._run(["--compare", str(per_item), str(per_item), "--run-dir", str(run_dir)])
+        a = json.loads((first / "compare_metrics.json").read_text(encoding="utf-8"))
+        b = json.loads((second / "compare_metrics.json").read_text(encoding="utf-8"))
+        self.assertEqual(a["bootstrap"], b["bootstrap"])
+        self.assertEqual(a["seed"], b["seed"])
+
+    def test_different_evaluation_sets_are_refused(self) -> None:
+        """Dropping one item from one side must abort and name the offending id."""
+        per_item = self._per_item_of_fixture()
+        rows = json.loads(per_item.read_text(encoding="utf-8"))
+        dropped = rows[0]["item_id"]
+        short_path = self.tmp / "compare_short_per_item.json"
+        short_path.write_text(json.dumps(rows[1:], ensure_ascii=False, indent=2), encoding="utf-8")
+
+        proc = self._run(
+            [
+                "--compare", str(per_item), str(short_path),
+                "--run-dir", str(self.tmp / "compare_mismatch"),
+            ],
+            expect_ok=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        message = proc.stdout + proc.stderr
+        self.assertIn(dropped, message)
+        self.assertIn("SAME evaluation set", message)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #11

Extends `scripts/musique_decompositions_evaluator.py` — no parallel evaluator, no new metrics module.

## 1. Directional step-count error

Per item: `step_count_signed_error` = `len(pred steps) - len(gold steps)` (positive = over-decomposition). The aggregate — and, because it is computed by the same `_aggregate()`, **every per-gold-hop block** — gains `over_decomposition_rate`, `under_decomposition_rate`, `step_count_mae` and `mean_signed_step_count_error`.

`step_count_mae` is deliberately the same number as the pre-existing `step_count_abs_error_mae`; it is reported again so the directional family reads as one block, and `METRIC_DEFINITIONS` says exactly that.

## 2. Paired significance (`--compare A_per_item.json B_per_item.json`)

- Aligns two per-item files on a new `item_id` field (`query_id`, else `id`, else the normalized question). Duplicate ids inside a file, or any id in one file and not the other, abort the run with the offending ids named (cap from config). No silent intersection.
- Paired percentile bootstrap CIs for `rouge_l_f1`, `step_f1`, `ordered_step_accuracy`, `composite_score`: the same resampled indices are applied to both systems and every statistic is recomputed from the resampled items, so `composite_score` (micro reference-validity term + MAE term) is handled correctly rather than averaged from per-item values. Seeded with `numpy.random.default_rng(seed)`, seed from config or `--seed`; ids sorted so the resample is reproducible. Significant = CI excludes 0.
- Exact two-sided McNemar for `exact_match` and `hop_count_exact_match`; `p = min(1, 2*BinomialCDF(min(b,c); b+c, 0.5))` in exact integer arithmetic, `p = 1.0` with no discordant pairs. Significant = `p < alpha`.
- Six tests, **no multiple-comparison correction** — stated in the metrics JSON, the run note and the docs.
- `bootstrap_iterations` (10000), `alpha` (0.05), `max_reported_id_mismatches` (20) and `out_prefix` come from `configs/musique_eval.json` under `paired_comparison`, with a `_note` in the existing style.

## 3. Tests

`tests/test_decomposition_metrics.py`, stdlib `unittest` (no new dependency), subprocess-driven through the real CLI + `configs/smoke_paths.json`, hand-computed against the fabricated fixture. The arithmetic is written out in each docstring: longer than gold, shorter than gold, empty prediction, forward reference `[#3]` used in step 2, self reference `[#2]` in step 2, `--compare` on identical inputs (every difference 0, nothing significant), bootstrap reproducibility, and refusal on differing eval sets. Wired into `scripts/smoke_test.py` as the `decomposition_metric_tests` stage.

```
.venv/bin/python -m unittest discover -s tests -v   ->  Ran 8 tests ... OK
.venv/bin/python scripts/smoke_test.py              ->  25/25 stages passed
```

The pre-existing golden metrics for the `musique_eval` stage (`exact_match_rate` 2/3, `step_f1_macro` 8/9, `rouge_l_f1_macro` 32/33, `composite_score` 0.9222…) are unchanged, so the added metrics did not shift any existing one.

## 4. `docs/METRICS.md`

Written from the code, not from the brief. It states explicitly that ROUGE-L joins the steps into one newline-separated string, is LCS-based over whitespace tokens of the lowercased text, reports precision/recall/F1 (β=1), and is macro-averaged across items — the question Jahid could not answer in the meeting. It also records the normalization asymmetry the code actually has (step-level metrics strip punctuation except `#`; ROUGE-L strips none), lists the composite weights from `configs/musique_eval.json`, and flags that "composite score" names two different things — this decomposition-quality composite and a rank-weighted retrieval score — proposing **"retrieval rank score"** for the second (a proposal for Jahid to confirm; the retrieval-side quantity has no implementation in this repo and the doc does not guess its formula).

## Notes for review

- No closed model anywhere near this path; every metric is string-level.
- No parameter counts involved (no model is loaded).
- `numpy` is used for the bootstrap; it is already pinned in `requirements.txt`. No new dependency.
- Timing sanity check on 600 synthetic items x 10000 resamples: ~3s wall clock. Those numbers are fabricated inputs for a performance check only and are not a metric claim; no experiment log entry is implied by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)