### PR TITLE
feat: adapter-evaluation guards (prompt parity incl. --guided, base-model assertion) + review minors

### DIFF
--- a/components/decomposer/README.md
+++ b/components/decomposer/README.md
@@ -184,6 +184,18 @@ Guarantees that are hard failures, not warnings:
   zero-shot prompt, and the few-shot examples come from the same MuSiQue pool it trained on.
   `--adapter-with-few-shot-i-know` overrides it deliberately, prints a warning and is
   recorded in the run's metrics; such a run is not the fine-tuned arm of the comparison.
+- **An adapter run whose prompt is not the prompt it was trained on is refused.** The
+  training run's own record decides — `training_provenance.json` inside the adapter directory
+  (written by `train_lora.py`), or the training run's `config.json` next to it for adapters
+  trained before that file existed. `guided`, the prompt file, the prompt style and whether
+  the prompt carries few-shot examples must all match, so `--adapter --no-few-shot --guided`
+  (a guided template with a hop line, which training never rendered) no longer runs. No
+  readable training record is also a refusal. `--adapter-prompt-mismatch-i-know` overrides
+  it, warns, and is recorded; such a run is not the fine-tuned arm either.
+- **An adapter attaches only to the base model it names.** `adapter_config.json`'s
+  `base_model_name_or_path` is compared against the run's `model_id` before
+  `PeftModel.from_pretrained`, because LoRA weights attach by module name and shape: a
+  different fine-tune of the same architecture would load silently.
 - **A hop-signal disagreement is fatal for an arm that filters on hops** (`train_hops` not
   null): the generalisation claim rests on those labels being right.
 - Adapters, checkpoints and prediction dumps stay under `runs/`; only config, metrics and the

--- a/components/decomposer/README.md
+++ b/components/decomposer/README.md
@@ -184,14 +184,24 @@ Guarantees that are hard failures, not warnings:
   zero-shot prompt, and the few-shot examples come from the same MuSiQue pool it trained on.
   `--adapter-with-few-shot-i-know` overrides it deliberately, prints a warning and is
   recorded in the run's metrics; such a run is not the fine-tuned arm of the comparison.
+  **That flag alone is not enough**: few-shot examples are also a prompt difference from the
+  training prompt, so the parity guard below refuses as well and
+  `--adapter-prompt-mismatch-i-know` has to be passed with it. Two flags, deliberately — one
+  says "I want examples", the other says "I accept the off-training prompt", and both land in
+  the config snapshot and the metrics.
 - **An adapter run whose prompt is not the prompt it was trained on is refused.** The
   training run's own record decides — `training_provenance.json` inside the adapter directory
   (written by `train_lora.py`), or the training run's `config.json` next to it for adapters
-  trained before that file existed. `guided`, the prompt file, the prompt style and whether
-  the prompt carries few-shot examples must all match, so `--adapter --no-few-shot --guided`
-  (a guided template with a hop line, which training never rendered) no longer runs. No
-  readable training record is also a refusal. `--adapter-prompt-mismatch-i-know` overrides
-  it, warns, and is recorded; such a run is not the fine-tuned arm either.
+  trained before that file existed. A record counts only if it says `script: train_lora.py`
+  **and** its `model_id` matches the base model `adapter_config.json` names, so a provenance
+  file copied in from another run does not pass. Compared fields: `guided`, the prompt file,
+  the prompt style and whether the prompt carries few-shot examples — so
+  `--adapter --no-few-shot --guided` (a guided template with a hop line, which training never
+  rendered) no longer runs — plus `prompt_sha256`, the content of the rendered prompt file,
+  **when the record carries it** (recorded from 2026-08-19 onwards; a record without it is
+  reported as not compared, not refused, because exp-001's predates it). No usable training
+  record is also a refusal. `--adapter-prompt-mismatch-i-know` overrides it, warns without
+  claiming a refusal, and is recorded; such a run is not the fine-tuned arm either.
 - **An adapter attaches only to the base model it names.** `adapter_config.json`'s
   `base_model_name_or_path` is compared against the run's `model_id` before
   `PeftModel.from_pretrained`, because LoRA weights attach by module name and shape: a

--- a/components/decomposer/run_decomposer.py
+++ b/components/decomposer/run_decomposer.py
@@ -1008,6 +1008,24 @@ ADAPTER_PROMPT_PARITY_FIELDS = (
     "few_shot_examples_in_prompt",
 )
 
+#: Content-level parity, compared **only when the training record carries it**. The four
+#: fields above are the prompt *selection*; the sha256 of the rendered prompt file is the
+#: prompt itself, which catches an edited prompt file that kept its name. ``train_lora.py``
+#: records it from this training run onwards; the exp-001 snapshot predates it, and an absent
+#: field is recorded as unchecked rather than refused (a re-train is not acceptable for it).
+ADAPTER_PROMPT_PARITY_OPTIONAL_FIELDS = ("prompt_sha256",)
+
+
+def _parity_value(value: Any) -> str:
+    """Render a parity field for a human: ``null`` for a missing one, never ``'None'``.
+
+    ``repr`` would print an absent field as the string ``'None'``, which reads like a prompt
+    file literally named "None". A field the record does not carry is reported as ``null``.
+    """
+    if value is None:
+        return "null (absent)"
+    return repr(value)
+
 
 def training_prompt_selection(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     """The prompt choices a training record states, as ``(selection, problems)``.
@@ -1026,10 +1044,25 @@ def training_prompt_selection(payload: dict[str, Any]) -> tuple[dict[str, Any], 
     problems: list[str] = []
     for field in ADAPTER_PROMPT_PARITY_FIELDS:
         if field == "few_shot_examples_in_prompt":
+            # A boolean when the record has one; otherwise derived from the rendered block,
+            # which must at least be a string ("" = trained zero-shot).
             if field in prompt:
-                selection[field] = bool(prompt[field])
+                if not isinstance(prompt[field], bool):
+                    problems.append(
+                        f"'prompt.{field}' is {prompt[field]!r} "
+                        f"({type(prompt[field]).__name__}), not a boolean"
+                    )
+                else:
+                    selection[field] = prompt[field]
             elif "few_shot_examples" in prompt:
-                selection[field] = bool(str(prompt["few_shot_examples"]).strip())
+                block = prompt["few_shot_examples"]
+                if not isinstance(block, str):
+                    problems.append(
+                        f"'prompt.few_shot_examples' is {block!r} "
+                        f"({type(block).__name__}), not a string"
+                    )
+                else:
+                    selection[field] = bool(block.strip())
             else:
                 problems.append(
                     "no 'prompt.few_shot_examples_in_prompt' or 'prompt.few_shot_examples'"
@@ -1039,8 +1072,56 @@ def training_prompt_selection(payload: dict[str, Any]) -> tuple[dict[str, Any], 
             problems.append(f"no 'prompt.{field}'")
             continue
         value = prompt[field]
-        selection[field] = bool(value) if field == "guided" else str(value)
+        # Strict types, no coercion: bool("false") is True and str(None) is "None", and
+        # either would let a malformed record silently claim a training condition. A record
+        # this guard cannot read exactly is not a record it should compare against.
+        if field == "guided":
+            if not isinstance(value, bool):
+                problems.append(
+                    f"'prompt.guided' is {value!r} ({type(value).__name__}), not a boolean"
+                )
+                continue
+            selection[field] = value
+            continue
+        if not isinstance(value, str) or not value:
+            problems.append(
+                f"'prompt.{field}' is {value!r} ({type(value).__name__}), not a non-empty string"
+            )
+            continue
+        selection[field] = value
+    # Content-level parity, when the record carries it (see ADAPTER_PROMPT_PARITY_OPTIONAL_
+    # FIELDS): compared only if present, so records written before it existed stay usable.
+    for field in ADAPTER_PROMPT_PARITY_OPTIONAL_FIELDS:
+        if field not in prompt:
+            continue
+        value = prompt[field]
+        if not isinstance(value, str) or not value:
+            problems.append(
+                f"'prompt.{field}' is {value!r} ({type(value).__name__}), not a non-empty string"
+            )
+            continue
+        selection[field] = value
     return selection, problems
+
+
+def adapter_declared_base_model(adapter_path: str | Path) -> str | None:
+    """``adapter_config.json``'s ``base_model_name_or_path``, or None when unreadable.
+
+    The soft read of what :func:`assert_adapter_base_model` asserts: used to cross-check a
+    training record against the adapter it sits beside, where an unreadable file is a "cannot
+    cross-check" rather than a refusal (that refusal belongs at attach time, on a real run).
+    """
+    config_path = Path(adapter_path) / ADAPTER_CONFIG_FILE
+    if not config_path.exists():
+        return None
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get(ADAPTER_BASE_MODEL_FIELD)
+    return str(value) if isinstance(value, str) and value else None
 
 
 def read_adapter_training_record(adapter_path: str | Path) -> dict[str, Any]:
@@ -1050,8 +1131,16 @@ def read_adapter_training_record(adapter_path: str | Path) -> dict[str, Any]:
 
     1. ``<adapter>/training_provenance.json`` - written by ``train_lora.py`` next to the
        weights, so a copied adapter directory carries its own provenance;
-    2. ``<adapter>/../config.json`` - the training run's config snapshot, required to be a
-       ``train_lora.py`` snapshot so an unrelated ``config.json`` cannot be mistaken for one.
+    2. ``<adapter>/../config.json`` - the training run's config snapshot, for adapters trained
+       before the provenance file existed (exp-001).
+
+    A candidate is only *usable* if it says it came from ``train_lora.py`` (``script``) and its
+    ``model_id`` agrees with the base model ``adapter_config.json`` names. Both checks apply to
+    both candidates: the provenance file is a plain JSON file inside a directory anyone can
+    copy, so "it is next to the weights" is not evidence that it describes them. A candidate
+    that fails either check is recorded as a problem and the next one is tried; when the
+    cross-check cannot be done at all (no readable ``adapter_config.json``, or a record with no
+    ``model_id``) the record is still usable and says so.
 
     Returns a record for the run artifacts; never raises. The refusal is
     :func:`check_adapter_prompt_parity`'s, which needs the record either way.
@@ -1062,6 +1151,7 @@ def read_adapter_training_record(adapter_path: str | Path) -> dict[str, Any]:
         ("training_run_config", path.parent / TRAINING_SNAPSHOT_FILE),
     ]
     looked_at = [str(p) for _, p in candidates]
+    declared_base_model = adapter_declared_base_model(path)
     problems: list[str] = []
     for source, candidate in candidates:
         if not candidate.exists():
@@ -1075,13 +1165,38 @@ def read_adapter_training_record(adapter_path: str | Path) -> dict[str, Any]:
         if not isinstance(payload, dict):
             problems.append(f"{candidate}: not a JSON object")
             continue
-        script = str(payload.get("script") or "")
-        if source == "training_run_config" and script != TRAINING_SCRIPT_NAME:
+        script = payload.get("script")
+        if script != TRAINING_SCRIPT_NAME:
             problems.append(
-                f"{candidate}: script is {script!r}, not {TRAINING_SCRIPT_NAME!r} (not a "
-                "training run's snapshot)"
+                f"{candidate}: 'script' is {script!r}, not {TRAINING_SCRIPT_NAME!r} (not a "
+                f"record written by {TRAINING_SCRIPT_NAME})"
             )
             continue
+        record_model_id = payload.get("model_id")
+        cross_check: dict[str, Any] = {
+            "checked": False,
+            "record_model_id": record_model_id if isinstance(record_model_id, str) else None,
+            "adapter_base_model": declared_base_model,
+        }
+        if isinstance(record_model_id, str) and record_model_id and declared_base_model:
+            if record_model_id != declared_base_model:
+                problems.append(
+                    f"{candidate}: 'model_id' is {record_model_id!r} but "
+                    f"{ADAPTER_CONFIG_FILE} names base model {declared_base_model!r} - this "
+                    "record does not describe this adapter (a copied or stale file)"
+                )
+                continue
+            cross_check["checked"] = True
+        else:
+            missing = (
+                f"the record has no 'model_id'"
+                if not (isinstance(record_model_id, str) and record_model_id)
+                else f"no readable {ADAPTER_CONFIG_FILE}.{ADAPTER_BASE_MODEL_FIELD} beside it"
+            )
+            cross_check["note"] = (
+                "unchecked: this record was not cross-checked against the adapter's own base "
+                f"model because {missing}"
+            )
         selection, field_problems = training_prompt_selection(payload)
         if field_problems:
             problems.append(f"{candidate}: " + "; ".join(field_problems))
@@ -1093,6 +1208,7 @@ def read_adapter_training_record(adapter_path: str | Path) -> dict[str, Any]:
             "trained_on": selection,
             "training_run_id": payload.get("run_id"),
             "training_arm": payload.get("arm"),
+            "model_id_cross_check": cross_check,
             "looked_at": looked_at,
             "problems": problems,
         }
@@ -1103,6 +1219,12 @@ def read_adapter_training_record(adapter_path: str | Path) -> dict[str, Any]:
         "trained_on": None,
         "training_run_id": None,
         "training_arm": None,
+        "model_id_cross_check": {
+            "checked": False,
+            "record_model_id": None,
+            "adapter_base_model": declared_base_model,
+            "note": "unchecked: no usable training record was found",
+        },
         "looked_at": looked_at,
         "problems": problems,
     }
@@ -1144,37 +1266,61 @@ def check_adapter_prompt_parity(
     found = read_adapter_training_record(adapter)
     record["training_record"] = {
         k: found[k]
-        for k in ("found", "source", "path", "training_run_id", "training_arm", "looked_at",
-                  "problems")
+        for k in ("found", "source", "path", "training_run_id", "training_arm",
+                  "model_id_cross_check", "looked_at", "problems")
     }
     record["trained_on"] = found["trained_on"]
 
     if not found["found"]:
         detail = "\n  ".join(found["problems"]) or "no candidate paths"
-        message = (
-            f"[decomposer] REFUSING TO RUN: cannot tell what adapter {adapter} was trained "
-            f"on, so its prompt cannot be checked against this run's.\n"
+        body = (
+            f"cannot tell what adapter {adapter} was trained on, so its prompt cannot be "
+            f"checked against this run's.\n"
             f"  {detail}\n"
             f"Expected {ADAPTER_PROVENANCE_FILE} in the adapter directory (written by "
             f"{TRAINING_SCRIPT_NAME}) or the training run's {TRAINING_SNAPSHOT_FILE} next to "
-            f"it. Point --adapter at the directory {TRAINING_SCRIPT_NAME} wrote, or pass "
-            f"{ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} to run unchecked (recorded in the config "
-            "snapshot and the metrics)."
+            f"it, naming {TRAINING_SCRIPT_NAME} in 'script' and this adapter's base model in "
+            f"'model_id'."
         )
         if not override:
-            raise SystemExit(message)
+            raise SystemExit(
+                f"[decomposer] REFUSING TO RUN: {body}\n"
+                f"Point --adapter at the directory {TRAINING_SCRIPT_NAME} wrote, or pass "
+                f"{ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} to run unchecked (recorded in the "
+                "config snapshot and the metrics)."
+            )
         record["note"] = (
             "unchecked: no training record found and "
             f"{ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} was passed, so this run's prompt is not "
             "known to be the one the adapter was trained on"
         )
-        print("WARNING: " + message)
+        print(
+            f"WARNING: running --adapter with its prompt UNCHECKED "
+            f"({ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG}): {body}\n"
+            "The run proceeds and is recorded as adapter_prompt_parity.checked false with "
+            "that override; it is not the fine-tuned arm of the comparison unless the prompt "
+            "is confirmed some other way."
+        )
         return record
 
     trained_on = found["trained_on"]
+    compared = list(ADAPTER_PROMPT_PARITY_FIELDS) + [
+        field for field in ADAPTER_PROMPT_PARITY_OPTIONAL_FIELDS if field in trained_on
+    ]
+    skipped = [f for f in ADAPTER_PROMPT_PARITY_OPTIONAL_FIELDS if f not in trained_on]
+    record["fields_compared"] = compared
+    record["fields_not_in_training_record"] = skipped
+    if skipped:
+        record["note"] = (
+            "unchecked (not a refusal): the training record carries no "
+            + ", ".join(skipped)
+            + f", so only {len(compared)} field(s) were compared. {TRAINING_SCRIPT_NAME} "
+            "records it from 2026-08-19 onwards; records written before that (exp-001) "
+            "predate it."
+        )
     mismatches = [
         {"field": field, "trained_on": trained_on.get(field), "this_run": run_selection.get(field)}
-        for field in ADAPTER_PROMPT_PARITY_FIELDS
+        for field in compared
         if trained_on.get(field) != run_selection.get(field)
     ]
     record["mismatches"] = mismatches
@@ -1184,36 +1330,113 @@ def check_adapter_prompt_parity(
 
     if mismatches:
         listing = "\n".join(
-            f"  {m['field']}: trained on {m['trained_on']!r}, this run {m['this_run']!r}"
+            f"  {m['field']}: trained on {_parity_value(m['trained_on'])}, this run "
+            f"{_parity_value(m['this_run'])}"
             for m in mismatches
         )
-        message = (
-            "[decomposer] REFUSING TO RUN: adapter prompt mismatch. The adapter was "
-            "fine-tuned on one prompt and this run renders another, so its numbers would not "
-            "be the fine-tuned arm's.\n"
+        body = (
+            "the adapter was fine-tuned on one prompt and this run renders another, so its "
+            "numbers would not be the fine-tuned arm's.\n"
             f"{listing}\n"
-            f"Training record: {found['path']} ({found['source']}).\n"
-            "guided/prompt_file decide whether the prompt carries a hop line - the very "
-            "difference the guided and unguided conditions exist to measure. Select the "
-            "condition (or drop --guided) that renders the prompt the adapter was trained "
-            f"on, or pass {ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} if you deliberately want the "
-            "off-training prompt and will report the run as that, not as the fine-tuned arm."
+            f"Training record: {found['path']} ({found['source']})."
         )
         if not override:
-            raise SystemExit(message)
+            raise SystemExit(
+                f"[decomposer] REFUSING TO RUN: adapter prompt mismatch - {body}\n"
+                "guided/prompt_file decide whether the prompt carries a hop line - the very "
+                "difference the guided and unguided conditions exist to measure. Select the "
+                "condition (or drop --guided) that renders the prompt the adapter was trained "
+                f"on, or pass {ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} if you deliberately want "
+                "the off-training prompt and will report the run as that, not as the "
+                "fine-tuned arm."
+            )
         record["note"] = (
             f"prompt mismatch accepted via {ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG}: this run is "
             "not the fine-tuned arm of the comparison"
         )
-        print("WARNING: " + message)
+        print(
+            f"WARNING: running --adapter on a MISMATCHED prompt "
+            f"({ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG}): {body}\n"
+            "The run proceeds and is recorded as adapter_prompt_parity.mismatches in the "
+            "config snapshot and the metrics: it is not the fine-tuned arm of the comparison."
+        )
         return record
 
     print(
         "[decomposer] adapter prompt parity OK: "
-        + ", ".join(f"{field}={run_selection.get(field)!r}" for field in ADAPTER_PROMPT_PARITY_FIELDS)
+        + ", ".join(f"{field}={_parity_value(run_selection.get(field))}" for field in compared)
         + f" (training record: {found['path']})"
+        + (f"; not in the record: {', '.join(skipped)}" if skipped else "")
     )
     return record
+
+
+def adapter_note_lines(
+    *,
+    adapter: str | None,
+    no_few_shot: bool,
+    parity: dict[str, Any],
+    base_model: dict[str, Any] | None,
+    base_model_note: str | None,
+) -> list[str]:
+    """The run note's adapter bullets: which adapter, and what was actually checked.
+
+    The two guards are refusals, so a run that reached the note either passed them or was
+    overridden - and the note has to say which, in the same voice as the few-shot override
+    line. A reader of ``notes.md`` should not have to open ``metrics.json`` to find out
+    whether the fine-tuned arm was verified as such.
+    """
+    head = "- Adapter: " + (f"`{adapter}`" if adapter else "none (prompting arm)")
+    if adapter and not no_few_shot:
+        head += (
+            f" - run WITH few-shot examples via {ADAPTER_FEW_SHOT_OVERRIDE_FLAG}: this is "
+            "not the fine-tuned arm of the comparison."
+        )
+    if not adapter:
+        return [head]
+
+    if parity.get("checked"):
+        compared = parity.get("fields_compared") or list(ADAPTER_PROMPT_PARITY_FIELDS)
+        record = parity.get("training_record") or {}
+        parity_line = (
+            f"- Adapter prompt parity: checked OK on {len(compared)} field(s) "
+            f"({', '.join(compared)}) against `{record.get('path')}` "
+            f"({record.get('source')})"
+        )
+        skipped = parity.get("fields_not_in_training_record") or []
+        if skipped:
+            parity_line += (
+                f"; not in that record, so not compared: {', '.join(skipped)}"
+            )
+    elif parity.get("mismatches"):
+        listing = "; ".join(
+            f"{m['field']} (trained on {_parity_value(m['trained_on'])}, this run "
+            f"{_parity_value(m['this_run'])})"
+            for m in parity["mismatches"]
+        )
+        parity_line = (
+            f"- Adapter prompt parity: MISMATCHED and overridden via "
+            f"{ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} - {listing}: this run is not the "
+            "fine-tuned arm of the comparison."
+        )
+    else:
+        parity_line = (
+            f"- Adapter prompt parity: UNCHECKED and overridden via "
+            f"{ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} - no usable training record beside the "
+            "adapter, so the prompt is not known to be the one it was trained on: this run "
+            "is not the fine-tuned arm of the comparison."
+        )
+
+    if base_model:
+        base_line = (
+            f"- Adapter base model: asserted - `{base_model['adapter_base_model']}` "
+            f"({ADAPTER_CONFIG_FILE}) == run model_id `{base_model['run_model_id']}`"
+        )
+    else:
+        base_line = "- Adapter base model: " + (
+            base_model_note or "unasserted (no adapter was attached in this run)"
+        )
+    return [head, parity_line, base_line]
 
 
 def generate(
@@ -1388,15 +1611,20 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Deliberately run --adapter WITH few-shot examples. Refused by default (see "
         "check_adapter_few_shot_combination); such a run is not the fine-tuned arm of the "
-        "comparison and is recorded as an override.",
+        "comparison and is recorded as an override. NOTE: few-shot examples are also a "
+        "prompt difference from the zero-shot prompt the adapter was trained on, so the "
+        f"prompt-parity guard refuses too - this flag alone is not enough, and "
+        f"{ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} has to be passed with it.",
     )
     p.add_argument(
         ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG,
         action="store_true",
         help="Deliberately run --adapter on a prompt it was not trained on (a different "
-        "guided setting or prompt file), or with no training record to check against. "
-        "Refused by default (see check_adapter_prompt_parity); such a run is not the "
-        "fine-tuned arm of the comparison and is recorded as an override.",
+        "guided setting, prompt file, prompt style, prompt content or few-shot setting), or "
+        "with no usable training record to check against. Refused by default (see "
+        "check_adapter_prompt_parity); such a run is not the fine-tuned arm of the "
+        "comparison and is recorded as an override. This is also the second flag needed "
+        f"alongside {ADAPTER_FEW_SHOT_OVERRIDE_FLAG}.",
     )
     p.add_argument("--output-root", default=None)
     p.add_argument(
@@ -1764,6 +1992,11 @@ def main() -> None:
         and not args.no_few_shot
     )
 
+    # Computed once here rather than inline in the snapshot: the adapter prompt-parity guard
+    # below compares it against the training record's own prompt_sha256 when that record
+    # carries one, so both must be the same number.
+    prompt_sha256 = sha256_file(prompt_path)
+
     # Still before the model is loaded: an adapter evaluated on a prompt it never saw during
     # training is refused here, next to the prompt selection it is checked against.
     adapter_prompt_parity = check_adapter_prompt_parity(
@@ -1773,6 +2006,7 @@ def main() -> None:
             "prompt_file": prompt_file,
             "prompt_style": prompt_style,
             "few_shot_examples_in_prompt": bool(few_shot_enabled),
+            "prompt_sha256": prompt_sha256,
         },
         override=bool(args.adapter_prompt_mismatch_i_know),
     )
@@ -1809,7 +2043,7 @@ def main() -> None:
         "prompt_style": prompt_style,
         "prompt_file": prompt_file,
         "prompt_path": str(prompt_path),
-        "prompt_sha256": sha256_file(prompt_path),
+        "prompt_sha256": prompt_sha256,
         "unguided_prompt_invariant": prompt_invariant,
         "condition": condition_name,
         "condition_settings": condition,
@@ -2385,13 +2619,12 @@ def main() -> None:
         note_lines=[
             f"- Model folder: `{args.model}`"
             + ("" if not args.dry_run else " (model not loaded)"),
-            "- Adapter: "
-            + (f"`{args.adapter}`" if args.adapter else "none (prompting arm)")
-            + (
-                f" - run WITH few-shot examples via {ADAPTER_FEW_SHOT_OVERRIDE_FLAG}: this is "
-                "not the fine-tuned arm of the comparison."
-                if args.adapter and not args.no_few_shot
-                else ""
+            *adapter_note_lines(
+                adapter=args.adapter,
+                no_few_shot=bool(args.no_few_shot),
+                parity=adapter_prompt_parity,
+                base_model=adapter_base_model_record,
+                base_model_note=metrics.get("adapter_base_model_note"),
             ),
             f"- Prompt: `{prompt_path}` (style: {prompt_style})",
             f"- Condition: {condition_name or 'none (no conditions block)'}; guided: {guided}; "

--- a/components/decomposer/run_decomposer.py
+++ b/components/decomposer/run_decomposer.py
@@ -35,6 +35,13 @@ second way. The unguided arms therefore need a model folder that ships an
         --adapter runs/finetune_decomposer/pool_2000/mistral_7b_instruct/<run>/adapter \\
         --no-few-shot --retrieval-input <the evaluation-set query file>
 
+An adapter run is checked against the training run's own record before anything is loaded:
+the prompt it renders must be the prompt the adapter was trained on (guided flag, prompt
+file, prompt style, few-shot examples - :func:`check_adapter_prompt_parity`), and the base
+model the adapter names must be the base model this run loads
+(:func:`assert_adapter_base_model`). Both are refusals, because both would otherwise produce
+numbers that silently answer a different question.
+
 Every run writes a config snapshot, a metrics JSON and a run note, and asserts the
 model's parameter count against the ceiling in ``configs/model_limits.json`` (with a LoRA
 adapter attached, the count asserted is the base plus the adapter).
@@ -838,15 +845,80 @@ def load_model(model_id: str, loader: dict, device: str, quantization: str):
     return tokenizer, model
 
 
-def attach_adapter(model, adapter_path: str | Path):
+#: peft's own record of the base model an adapter was trained on, written into the adapter
+#: directory by ``save_pretrained``. Read by :func:`assert_adapter_base_model`.
+ADAPTER_CONFIG_FILE = "adapter_config.json"
+ADAPTER_BASE_MODEL_FIELD = "base_model_name_or_path"
+
+
+def assert_adapter_base_model(adapter_path: str | Path, *, model_id: str) -> dict[str, Any]:
+    """Refuse an adapter trained on a different base model than the one loaded.
+
+    LoRA weights attach by module name and shape, so an adapter trained on a
+    same-architecture *different* base model (another Mistral-7B fine-tune, a different
+    revision) attaches without error and silently produces numbers attributed to the wrong
+    base. ``adapter_config.json`` records what it was trained on; this compares that against
+    the run's ``model_id`` and fails hard, in the style of the ``src/model_size.py`` gate.
+
+    Returns the record for the run's metrics; raises ``SystemExit`` on a mismatch, and also
+    when the field is absent (an unverifiable adapter is not a silently accepted one).
+    """
+    path = Path(adapter_path)
+    config_path = path / ADAPTER_CONFIG_FILE
+    if not config_path.exists():
+        raise SystemExit(
+            f"[decomposer] REFUSING TO RUN: no {ADAPTER_CONFIG_FILE} in adapter {path}, so "
+            f"the base model it was trained on cannot be checked against {model_id!r}. A "
+            "peft adapter directory always carries that file; point --adapter at the "
+            "directory train_lora.py wrote."
+        )
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"[decomposer] {config_path} is not valid JSON: {exc}") from exc
+    trained_on = payload.get(ADAPTER_BASE_MODEL_FIELD) if isinstance(payload, dict) else None
+    if not trained_on:
+        raise SystemExit(
+            f"[decomposer] REFUSING TO RUN: {config_path} has no "
+            f"{ADAPTER_BASE_MODEL_FIELD!r}, so the adapter's base model cannot be checked "
+            f"against {model_id!r}. LoRA weights attach by module name and shape, so an "
+            "adapter from a different base would load without complaint."
+        )
+    if str(trained_on) != str(model_id):
+        raise SystemExit(
+            f"[decomposer] REFUSING TO RUN: adapter base-model mismatch.\n"
+            f"  adapter {path} was trained on: {trained_on}\n"
+            f"  this run loads:                {model_id}\n"
+            f"({config_path}, field {ADAPTER_BASE_MODEL_FIELD!r}.) LoRA weights attach by "
+            "module name and shape, so the wrong base of the same architecture would attach "
+            "silently and the run's numbers would be attributed to a model that never "
+            "produced them. Run the adapter on its own base model, or point --adapter at the "
+            "adapter trained on this one."
+        )
+    print(
+        f"[decomposer] adapter base model OK: {trained_on} == run model_id "
+        f"({config_path.name})"
+    )
+    return {
+        "adapter_config_path": str(config_path),
+        "adapter_base_model": str(trained_on),
+        "run_model_id": str(model_id),
+        "base_model_asserted": True,
+    }
+
+
+def attach_adapter(model, adapter_path: str | Path, *, model_id: str):
     """Attach a trained LoRA adapter (the fine-tuned arm of issue #13).
 
     Loaded on top of the same base model the prompting arm uses, so the two arms differ in
-    the adapter and nothing else.
+    the adapter and nothing else. That "same base model" is asserted, not assumed:
+    :func:`assert_adapter_base_model` refuses before ``PeftModel.from_pretrained`` when the
+    adapter names a different base. Returns ``(model, base_model_record)``.
     """
     path = Path(adapter_path)
     if not path.exists():
         raise SystemExit(f"[decomposer] adapter not found: {path}")
+    base_model_record = assert_adapter_base_model(path, model_id=model_id)
     try:
         from peft import PeftModel
     except ImportError as exc:
@@ -856,7 +928,7 @@ def attach_adapter(model, adapter_path: str | Path):
         ) from exc
     model = PeftModel.from_pretrained(model, str(path))
     model.eval()
-    return model
+    return model, base_model_record
 
 
 #: The loud opt-out for running an adapter with few-shot examples anyway. Named so that it
@@ -907,6 +979,240 @@ def check_adapter_few_shot_combination(
             "run is not the fine-tuned arm of the comparison. It is recorded as "
             "adapter_few_shot_override: true in the config snapshot and the metrics."
         )
+    return record
+
+
+#: The loud opt-out for running an adapter on a prompt it was not trained on. Named the same
+#: way as ADAPTER_FEW_SHOT_OVERRIDE_FLAG: it cannot be typed by accident, and it is recorded.
+ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG = "--adapter-prompt-mismatch-i-know"
+
+#: Written into the adapter directory by ``train_lora.py`` so a later evaluation run can
+#: check prompt parity even when the training run directory is not around it.
+ADAPTER_PROVENANCE_FILE = "training_provenance.json"
+
+#: The training run's config snapshot, which sits next to the adapter directory
+#: (``<run>/config.json``, ``<run>/adapter/``). This is what makes the guard work for
+#: adapters trained before ADAPTER_PROVENANCE_FILE existed (exp-001).
+TRAINING_SNAPSHOT_FILE = "config.json"
+TRAINING_SCRIPT_NAME = "train_lora.py"
+
+#: The prompt choices that must match between training and an adapter's evaluation run.
+#: ``few_shot_examples_in_prompt`` is here as well as in
+#: :func:`check_adapter_few_shot_combination` because the two guards answer different
+#: questions: that one refuses a combination of flags, this one compares against what the
+#: adapter actually saw.
+ADAPTER_PROMPT_PARITY_FIELDS = (
+    "guided",
+    "prompt_file",
+    "prompt_style",
+    "few_shot_examples_in_prompt",
+)
+
+
+def training_prompt_selection(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """The prompt choices a training record states, as ``(selection, problems)``.
+
+    Accepts both records ``train_lora.py`` writes, because they carry the same ``prompt``
+    block: :data:`ADAPTER_PROVENANCE_FILE` inside the adapter directory, and the training
+    run's config snapshot next to it. ``few_shot_examples_in_prompt`` is read directly when
+    present and otherwise derived from the rendered ``few_shot_examples`` string (empty
+    string = trained zero-shot), so an adapter trained before the provenance file existed is
+    still checkable.
+    """
+    prompt = payload.get("prompt") if isinstance(payload, dict) else None
+    if not isinstance(prompt, dict):
+        return {}, ["no 'prompt' block"]
+    selection: dict[str, Any] = {}
+    problems: list[str] = []
+    for field in ADAPTER_PROMPT_PARITY_FIELDS:
+        if field == "few_shot_examples_in_prompt":
+            if field in prompt:
+                selection[field] = bool(prompt[field])
+            elif "few_shot_examples" in prompt:
+                selection[field] = bool(str(prompt["few_shot_examples"]).strip())
+            else:
+                problems.append(
+                    "no 'prompt.few_shot_examples_in_prompt' or 'prompt.few_shot_examples'"
+                )
+            continue
+        if field not in prompt:
+            problems.append(f"no 'prompt.{field}'")
+            continue
+        value = prompt[field]
+        selection[field] = bool(value) if field == "guided" else str(value)
+    return selection, problems
+
+
+def read_adapter_training_record(adapter_path: str | Path) -> dict[str, Any]:
+    """Find what an adapter was trained on: the provenance file, then the run snapshot.
+
+    Looked at in this order, first usable one wins:
+
+    1. ``<adapter>/training_provenance.json`` - written by ``train_lora.py`` next to the
+       weights, so a copied adapter directory carries its own provenance;
+    2. ``<adapter>/../config.json`` - the training run's config snapshot, required to be a
+       ``train_lora.py`` snapshot so an unrelated ``config.json`` cannot be mistaken for one.
+
+    Returns a record for the run artifacts; never raises. The refusal is
+    :func:`check_adapter_prompt_parity`'s, which needs the record either way.
+    """
+    path = Path(adapter_path)
+    candidates = [
+        ("adapter_provenance", path / ADAPTER_PROVENANCE_FILE),
+        ("training_run_config", path.parent / TRAINING_SNAPSHOT_FILE),
+    ]
+    looked_at = [str(p) for _, p in candidates]
+    problems: list[str] = []
+    for source, candidate in candidates:
+        if not candidate.exists():
+            problems.append(f"{candidate}: not found")
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            problems.append(f"{candidate}: unreadable ({exc})")
+            continue
+        if not isinstance(payload, dict):
+            problems.append(f"{candidate}: not a JSON object")
+            continue
+        script = str(payload.get("script") or "")
+        if source == "training_run_config" and script != TRAINING_SCRIPT_NAME:
+            problems.append(
+                f"{candidate}: script is {script!r}, not {TRAINING_SCRIPT_NAME!r} (not a "
+                "training run's snapshot)"
+            )
+            continue
+        selection, field_problems = training_prompt_selection(payload)
+        if field_problems:
+            problems.append(f"{candidate}: " + "; ".join(field_problems))
+            continue
+        return {
+            "found": True,
+            "source": source,
+            "path": str(candidate),
+            "trained_on": selection,
+            "training_run_id": payload.get("run_id"),
+            "training_arm": payload.get("arm"),
+            "looked_at": looked_at,
+            "problems": problems,
+        }
+    return {
+        "found": False,
+        "source": None,
+        "path": None,
+        "trained_on": None,
+        "training_run_id": None,
+        "training_arm": None,
+        "looked_at": looked_at,
+        "problems": problems,
+    }
+
+
+def check_adapter_prompt_parity(
+    *,
+    adapter: str | None,
+    run_selection: dict[str, Any],
+    override: bool,
+) -> dict[str, Any]:
+    """Refuse an adapter run whose prompt selection is not the one it was trained on.
+
+    ``check_adapter_few_shot_combination`` covers one dimension of prompt parity (few-shot
+    examples). It does not cover the others: ``--adapter --no-few-shot --guided`` was
+    accepted, and it feeds the adapter a *guided* template with a hop line, while
+    ``train_lora.py`` renders the unguided file (``prompt.guided`` false for exp-001). The
+    hop line is exactly the difference the guided/unguided conditions exist to measure, so
+    an adapter evaluated on the template it never saw produces a number that answers neither
+    question.
+
+    Ground truth is the training run's own record, not an assumption about what training
+    does - see :func:`read_adapter_training_record`. No record found is also a refusal: an
+    unverifiable adapter run is not a checked one.
+
+    Returns a record for the config snapshot and the metrics; raises ``SystemExit`` on a
+    mismatch (or an unreadable record) unless ``override``.
+    """
+    record: dict[str, Any] = {
+        "checked": False,
+        "override": bool(override),
+        "run": dict(run_selection),
+        "mismatches": [],
+    }
+    if not adapter:
+        record["note"] = "no --adapter in this run, so there is no training prompt to match"
+        return record
+
+    found = read_adapter_training_record(adapter)
+    record["training_record"] = {
+        k: found[k]
+        for k in ("found", "source", "path", "training_run_id", "training_arm", "looked_at",
+                  "problems")
+    }
+    record["trained_on"] = found["trained_on"]
+
+    if not found["found"]:
+        detail = "\n  ".join(found["problems"]) or "no candidate paths"
+        message = (
+            f"[decomposer] REFUSING TO RUN: cannot tell what adapter {adapter} was trained "
+            f"on, so its prompt cannot be checked against this run's.\n"
+            f"  {detail}\n"
+            f"Expected {ADAPTER_PROVENANCE_FILE} in the adapter directory (written by "
+            f"{TRAINING_SCRIPT_NAME}) or the training run's {TRAINING_SNAPSHOT_FILE} next to "
+            f"it. Point --adapter at the directory {TRAINING_SCRIPT_NAME} wrote, or pass "
+            f"{ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} to run unchecked (recorded in the config "
+            "snapshot and the metrics)."
+        )
+        if not override:
+            raise SystemExit(message)
+        record["note"] = (
+            "unchecked: no training record found and "
+            f"{ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} was passed, so this run's prompt is not "
+            "known to be the one the adapter was trained on"
+        )
+        print("WARNING: " + message)
+        return record
+
+    trained_on = found["trained_on"]
+    mismatches = [
+        {"field": field, "trained_on": trained_on.get(field), "this_run": run_selection.get(field)}
+        for field in ADAPTER_PROMPT_PARITY_FIELDS
+        if trained_on.get(field) != run_selection.get(field)
+    ]
+    record["mismatches"] = mismatches
+    # "checked" means verified to match, the same way unguided_prompt_invariant uses it: an
+    # overridden mismatch is a recorded mismatch, not a passed check.
+    record["checked"] = not mismatches
+
+    if mismatches:
+        listing = "\n".join(
+            f"  {m['field']}: trained on {m['trained_on']!r}, this run {m['this_run']!r}"
+            for m in mismatches
+        )
+        message = (
+            "[decomposer] REFUSING TO RUN: adapter prompt mismatch. The adapter was "
+            "fine-tuned on one prompt and this run renders another, so its numbers would not "
+            "be the fine-tuned arm's.\n"
+            f"{listing}\n"
+            f"Training record: {found['path']} ({found['source']}).\n"
+            "guided/prompt_file decide whether the prompt carries a hop line - the very "
+            "difference the guided and unguided conditions exist to measure. Select the "
+            "condition (or drop --guided) that renders the prompt the adapter was trained "
+            f"on, or pass {ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG} if you deliberately want the "
+            "off-training prompt and will report the run as that, not as the fine-tuned arm."
+        )
+        if not override:
+            raise SystemExit(message)
+        record["note"] = (
+            f"prompt mismatch accepted via {ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG}: this run is "
+            "not the fine-tuned arm of the comparison"
+        )
+        print("WARNING: " + message)
+        return record
+
+    print(
+        "[decomposer] adapter prompt parity OK: "
+        + ", ".join(f"{field}={run_selection.get(field)!r}" for field in ADAPTER_PROMPT_PARITY_FIELDS)
+        + f" (training record: {found['path']})"
+    )
     return record
 
 
@@ -1083,6 +1389,14 @@ def _parse_args() -> argparse.Namespace:
         help="Deliberately run --adapter WITH few-shot examples. Refused by default (see "
         "check_adapter_few_shot_combination); such a run is not the fine-tuned arm of the "
         "comparison and is recorded as an override.",
+    )
+    p.add_argument(
+        ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG,
+        action="store_true",
+        help="Deliberately run --adapter on a prompt it was not trained on (a different "
+        "guided setting or prompt file), or with no training record to check against. "
+        "Refused by default (see check_adapter_prompt_parity); such a run is not the "
+        "fine-tuned arm of the comparison and is recorded as an override.",
     )
     p.add_argument("--output-root", default=None)
     p.add_argument(
@@ -1441,6 +1755,28 @@ def main() -> None:
             f"{len(prompt_invariant['hop_lines_removed'])} hop-bearing line(s)"
         )
 
+    # Whether this run's prompt will actually carry few-shot examples. Computed here, before
+    # the adapter prompt-parity guard, because that guard compares it against what the
+    # adapter was trained on; the few-shot machinery below reads the same value.
+    few_shot_enabled = (
+        bool(require(few_shot_cfg, "enabled"))
+        and "{few_shot_examples}" in prompt_template
+        and not args.no_few_shot
+    )
+
+    # Still before the model is loaded: an adapter evaluated on a prompt it never saw during
+    # training is refused here, next to the prompt selection it is checked against.
+    adapter_prompt_parity = check_adapter_prompt_parity(
+        adapter=args.adapter,
+        run_selection={
+            "guided": bool(guided),
+            "prompt_file": prompt_file,
+            "prompt_style": prompt_style,
+            "few_shot_examples_in_prompt": bool(few_shot_enabled),
+        },
+        override=bool(args.adapter_prompt_mismatch_i_know),
+    )
+
     chat_marker = None
     if prompt_style == "chat_template":
         chat_marker = require(model_cfg, "chat_template.split_marker")
@@ -1489,10 +1825,15 @@ def main() -> None:
         "device": device,
         "quantization": quantization,
         **adapter_record,
+        "adapter_prompt_parity": adapter_prompt_parity,
         "embed_model": embed_key,
         "embed_model_id": embed_model_id,
         "retrieval": {
-            "input": str(retrieval_input) if retrieval_input else None,
+            # The config's own literal value, null included: this slot says what the
+            # committed config sets, and the path this run actually read is
+            # 'input_resolved' (plus its sha256). Recording the resolved absolute path here
+            # made the snapshot disagree with the config it names.
+            "input": require(cfg, "retrieval.input"),
             "input_key": optional(cfg, "retrieval.input_key"),
             "input_resolved": str(retrieval_path) if retrieval_path else None,
             "input_sha256": retrieval_sha256,
@@ -1521,11 +1862,8 @@ def main() -> None:
     data_root = Path(paths_cfg["data_root_resolved"])
 
     # ---- few-shot machinery (only when the prompt actually takes examples) ----
-    few_shot_enabled = (
-        bool(require(few_shot_cfg, "enabled"))
-        and "{few_shot_examples}" in prompt_template
-        and not args.no_few_shot
-    )
+    # few_shot_enabled was computed above, next to the adapter prompt-parity guard that
+    # compares it against the adapter's training record.
     few_shot_k = int(require(few_shot_cfg, "k"))
     few_shot_data: dict = {}
     decomposer_items: list[dict] = []
@@ -1741,13 +2079,16 @@ def main() -> None:
     # ---- model ----
     model = tokenizer = None
     size_record = unasserted_note("decomposer", require(model_cfg, "model_id"))
+    adapter_base_model_record: dict[str, Any] | None = None
     if not args.dry_run:
         model_id = require(model_cfg, "model_id")
         print(f"Loading model: {model_id} on {device} (quantization={quantization}) ...")
         tokenizer, model = load_model(model_id, loader, device, quantization)
         if args.adapter:
             print(f"Attaching LoRA adapter: {args.adapter}")
-            model = attach_adapter(model, args.adapter)
+            model, adapter_base_model_record = attach_adapter(
+                model, args.adapter, model_id=model_id
+            )
             model_id = f"{model_id}+adapter"
         # With an adapter attached this counts base + adapter parameters, which is the
         # thing the ~8B ceiling is about.
@@ -1993,7 +2334,12 @@ def main() -> None:
             ),
         },
         "seed": seed,
+        # Which exemplar-hop rule produced these numbers. In the config snapshot too, but a
+        # metrics file read on its own has to state the rule its numbers were scored under.
+        "few_shot_exemplar_hop_count": exemplar_hop_mode,
         **adapter_record,
+        "adapter_prompt_parity": adapter_prompt_parity,
+        "adapter_base_model": adapter_base_model_record,
         "no_few_shot_ineffective": no_few_shot_ineffective,
         "model_size": size_record,
         "embedding_model_size": embed_size_record,
@@ -2013,6 +2359,11 @@ def main() -> None:
             f"--no-few-shot was passed but the prompt ({prompt_file}) has no "
             "'{few_shot_examples}' placeholder, so this run is not necessarily zero-shot: "
             "any examples the prompt shows are part of its text."
+        )
+    if args.adapter and adapter_base_model_record is None:
+        metrics["adapter_base_model_note"] = (
+            "unasserted: no model was loaded in this run (--dry-run), so the adapter's "
+            "base_model_name_or_path was not checked against model_id"
         )
     if embed_size_record is None:
         metrics["embedding_model_size_note"] = (

--- a/components/decomposer/train_lora.py
+++ b/components/decomposer/train_lora.py
@@ -33,7 +33,10 @@ Guarantees, all of them hard:
   LoRA-wrapped model is asserted again after the adapter is attached;
 - training ids are asserted disjoint from the ADR 0007 evaluation ids, naming offenders;
 - adapters and checkpoints are written under the gitignored ``runs/`` root, and the run
-  leaves a config snapshot, a metrics JSON and a run note.
+  leaves a config snapshot, a metrics JSON and a run note;
+- the prompt this run trained on is written *inside* the adapter directory
+  (``training_provenance.json``), so the evaluation run can refuse an adapter evaluated on a
+  prompt it never saw (``run_decomposer.check_adapter_prompt_parity``).
 
 Evaluation is **not** done here: the adapter is scored by running
 ``components/decomposer/run_decomposer.py --adapter <adapter dir> --no-few-shot`` over the
@@ -234,6 +237,50 @@ def trainable_parameter_record(model: Any) -> dict[str, Any]:
     }
 
 
+#: Prompt provenance, written *inside* the adapter directory. The training run's config
+#: snapshot next to it says the same thing, but an adapter is a directory that gets copied
+#: and moved; this file travels with the weights, and it is what
+#: ``run_decomposer.check_adapter_prompt_parity`` reads to refuse evaluating an adapter on a
+#: prompt it was never trained on. Same filename as
+#: ``run_decomposer.ADAPTER_PROVENANCE_FILE``.
+ADAPTER_PROVENANCE_FILE = "training_provenance.json"
+
+
+def adapter_provenance(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """The prompt this run trained on, in the shape the evaluation-side guard reads.
+
+    ``few_shot_examples_in_prompt`` is derived from the rendered ``few_shot_examples`` string
+    (this script trains zero-shot, i.e. an empty block) so the guard compares a boolean
+    rather than re-deriving the rule.
+    """
+    prompt = dict(require(snapshot, "prompt"))
+    prompt["few_shot_examples_in_prompt"] = bool(str(prompt.get("few_shot_examples", "")).strip())
+    return {
+        "script": snapshot.get("script"),
+        "created_utc": snapshot.get("created_utc"),
+        "run_id": snapshot.get("run_id"),
+        "arm": snapshot.get("arm"),
+        "model": snapshot.get("model"),
+        "model_id": snapshot.get("model_id"),
+        "prompt": prompt,
+        "_note": (
+            "What this adapter was trained on, for run_decomposer.py's adapter prompt-parity "
+            "guard. The base model is checked separately, from adapter_config.json's "
+            "base_model_name_or_path."
+        ),
+    }
+
+
+def write_adapter_provenance(adapter_dir: Path, snapshot: dict[str, Any]) -> Path:
+    """Write :func:`adapter_provenance` into the adapter directory. Returns the path."""
+    path = Path(adapter_dir) / ADAPTER_PROVENANCE_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(adapter_provenance(snapshot), indent=2, default=str) + "\n", encoding="utf-8"
+    )
+    return path
+
+
 # -------------------------------------------------------------------------------- args
 
 
@@ -432,6 +479,7 @@ def main() -> None:
     train_result: dict[str, Any] | None = None
     peak_gpu_bytes: int | None = None
     wall_clock_seconds: float | None = None
+    adapter_provenance_path: Path | None = None
 
     if not args.dry_run:
         import torch
@@ -478,6 +526,8 @@ def main() -> None:
 
         trainer.save_model(str(adapter_dir))
         tokenizer.save_pretrained(str(adapter_dir))
+        adapter_provenance_path = write_adapter_provenance(adapter_dir, snapshot)
+        print(f"[finetune] adapter prompt provenance -> {adapter_provenance_path}")
         train_result = {
             "global_step": int(result.global_step),
             "training_loss": float(result.training_loss) if result.training_loss is not None else None,
@@ -518,6 +568,9 @@ def main() -> None:
             round(peak_gpu_bytes / (1024**3), 3) if peak_gpu_bytes is not None else None
         ),
         "adapter_path": str(adapter_dir) if not args.dry_run else None,
+        "adapter_provenance_path": (
+            str(adapter_provenance_path) if adapter_provenance_path else None
+        ),
         "formatted_examples_path": str(sample_path),
         "decomposition_quality": None,
         "decomposition_quality_note": (

--- a/components/decomposer/train_lora.py
+++ b/components/decomposer/train_lora.py
@@ -62,6 +62,7 @@ from finetune_data import (  # noqa: E402
     build_training_rows,
     load_eval_ids,
     load_jsonl,
+    prompt_file_sha256,
     resolve_arm,
     select_arm_examples,
     select_prompt_file,
@@ -418,6 +419,11 @@ def main() -> None:
             **prompt_cfg,
             "prompt_file": prompt_file,
             "prompt_path": str(prompt_path),
+            # Content, not just name: the evaluation-side parity guard compares this against
+            # the prompt file it renders, so an edited prompt that kept its file name is
+            # caught. Absent from records written before 2026-08-19 (exp-001), where the
+            # guard reports it as not compared rather than refusing.
+            "prompt_sha256": prompt_file_sha256(prompt_path),
             "prompt_style": prompt_style,
             "unguided_hop_placeholder": unguided_hop_placeholder,
         },

--- a/scripts/compare_decomposer_arms.py
+++ b/scripts/compare_decomposer_arms.py
@@ -35,9 +35,12 @@ nothing in the output saying so.
 Two things it deliberately does not do:
 
 - **It reads the evaluator's per-item file only for item ids.** Nothing else in it is
-  parsed, and both shapes are accepted - the bare list of earlier runs and the stamped
-  object of PR #22 (``{"schema": ..., "items": [...]}``) - so the schema change is still
-  the evaluator's business.
+  parsed: the shape of record is the versioned object of ADR 0011 section 2
+  (``{"schema": "musique_decomposition_per_item/1", ..., "items": [...]}``), and what the
+  items say is the evaluator's business, not this script's. The id reader also tolerates a
+  bare top-level list, but that pre-PR-#22 shape is retired: ``--compare``, which this
+  script runs on every non-baseline arm, refuses it, so such an arm cannot reach a
+  comparison here - it must be re-scored.
 - **It never compares runs scored under different settings.** All arms are scored by one
   invocation config, which is also what the evaluator's ``--compare`` requires.
 """
@@ -101,8 +104,11 @@ def _cost_block(run_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
 def per_item_ids(path: Path) -> list[str]:
     """The ``item_id`` of every scored item, in file order.
 
-    Accepts both per-item shapes: a bare JSON list (runs before PR #22) and the stamped
-    object ``{"schema": ..., "items": [...]}`` (PR #22 onward). Only the ids are read.
+    Reads the versioned object of ADR 0011 section 2
+    (``{"schema": "musique_decomposition_per_item/1", ..., "items": [...]}``). A bare
+    top-level list is still tolerated *here* (only ids are read, and this check should not
+    be the thing that fails on an old file), but that shape is retired: the evaluator's
+    ``--compare`` refuses it, so an arm scored under it cannot be compared without re-scoring.
     """
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     rows = payload.get("items") if isinstance(payload, dict) else payload
@@ -192,6 +198,30 @@ def assert_items_within_eval_hops(
         "hop_counts": {k: hop_counts[k] for k in sorted(hop_counts, key=int)},
         "asserted": True,
     }
+
+
+def cost_definition_groups(
+    per_arm: dict[str, dict[str, Any]],
+) -> list[tuple[list[str], dict[str, Any]]]:
+    """Group arm names by the cost definitions their runs recorded.
+
+    The cost columns of the table are per-query aggregates; what they aggregate (a prompt
+    token, a latency second) is defined by the decomposer run that measured it, and each run
+    writes those definitions into its own ``cost`` block. Printing them next to the numbers
+    is what makes the table readable on its own.
+
+    Normally there is exactly one group: every arm was produced by the same runner. More than
+    one group is the interesting case and is reported as such - it means a cost column does
+    not mean the same thing on both sides of the comparison.
+    """
+    groups: dict[str, tuple[list[str], dict[str, Any]]] = {}
+    for name, record in per_arm.items():
+        definitions = record.get("cost_definitions")
+        if not isinstance(definitions, dict) or not definitions:
+            continue
+        key = json.dumps(definitions, sort_keys=True, default=str)
+        groups.setdefault(key, ([], definitions))[0].append(name)
+    return list(groups.values())
 
 
 def _fmt(value: Any) -> str:
@@ -302,6 +332,9 @@ def main() -> None:
             "eval_hops_check": hop_record,
             "quality": {key: arm_metrics.get(key) for key in quality_keys},
             "cost": ({key: cost.get(key) for key in cost_keys} if cost else None),
+            # The run's own definitions of what its cost numbers measure, carried through so
+            # this comparison's metrics and note state it too.
+            "cost_definitions": (cost.get("definitions") if cost else None),
             "cost_note": cost_note,
         }
 
@@ -355,6 +388,40 @@ def main() -> None:
             _fmt(record["cost"].get(k)) if record["cost"] else "unmeasured" for k in cost_keys
         ]
         note_lines.append(f"| {name} | " + " | ".join(cells) + " |")
+    note_lines.append("")
+
+    # What the cost columns mean, printed where they are reported: the numbers above are
+    # per-query aggregates (mean/median over the rows that generated; a row with no
+    # measurement, e.g. from a --dry-run, is excluded), and each arm's run recorded what the
+    # per-row measurements are.
+    note_lines.append(
+        "- Cost columns are per-query aggregates of each arm's own `cost` block: "
+        "`mean_*_per_query` / `median_*_per_query` over `rows_measured` rows, "
+        "`total_generation_seconds` summed over the same rows. The per-row measurements they "
+        "aggregate, as defined by the run that measured them:"
+    )
+    groups = cost_definition_groups(per_arm)
+    for names, definitions in groups:
+        if len(names) == len(per_arm):
+            scope = "all arms"
+        else:
+            label = "arm" if len(names) == 1 else "arms"
+            scope = f"{label} " + ", ".join(f"`{n}`" for n in names)
+        note_lines.append(f"  - {scope}:")
+        for key in sorted(definitions):
+            note_lines.append(f"    - `{key}`: {definitions[key]}")
+    if len(groups) > 1:
+        note_lines.append(
+            "  - NOTE: the arms above do not agree on what their cost numbers measure, so "
+            "the cost columns are not comparable across them as they stand."
+        )
+    undefined = [name for name, record in per_arm.items() if not record.get("cost_definitions")]
+    if undefined:
+        note_lines.append(
+            "  - no cost definitions recorded by: "
+            + ", ".join(f"`{n}`" for n in undefined)
+            + " (no cost block in that run's metrics.json, so its cost cells are unmeasured)"
+        )
     note_lines.append("")
 
     for key, record in comparisons.items():

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -540,7 +540,7 @@ def _stages() -> list[Stage]:
                 "--model", "mistral_7b_instruct", "--dry-run", "--dry-run-limit", "2",
                 "--retrieval-input", FIXTURES / "retrieval" / "top20.jsonl",
                 "--retrieval-mode", "uniform", "--retrieval-k", "5",
-                "--adapter", FIXTURES / "decomposer_arms" / "finetuned",
+                "--adapter", FIXTURES / "adapter",
                 "--no-few-shot",
                 "--output-root", decomposer_dry / "adapter",
             ],
@@ -549,7 +549,8 @@ def _stages() -> list[Stage]:
                 (decomposer_dry / "adapter", "*/metrics.json"),
             ],
             note="fine-tuned arm plumbing: --adapter recorded, --no-few-shot empties the "
-            "few-shot block, cost block written (no weights, so cost is unmeasured)",
+            "few-shot block, prompt parity checked against the fixture adapter's training "
+            "provenance, cost block written (no weights, so cost is unmeasured)",
         ),
         Stage(
             name="finetune_dry_run_pool_2000",

--- a/src/finetune_data.py
+++ b/src/finetune_data.py
@@ -490,6 +490,17 @@ def _run_decomposer():
     return run_decomposer
 
 
+def prompt_file_sha256(prompt_path: Path) -> str:
+    """Content address of a prompt file, through the runner's own hash helper.
+
+    Delegated rather than reimplemented for the same reason the template helpers are: the
+    training record's ``prompt_sha256`` is compared against the evaluation run's by
+    ``run_decomposer.check_adapter_prompt_parity``, so the two numbers have to come from one
+    function.
+    """
+    return str(_run_decomposer().sha256_file(Path(prompt_path)))
+
+
 def select_prompt_file(model_cfg: dict[str, Any], *, guided: bool) -> str:
     """The prompt file ``run_decomposer.py`` would use for this guidance setting."""
     unguided_prompt_file = require(model_cfg, "unguided_prompt_file")

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -46,11 +46,18 @@ decomposer_arms/               # two fabricated "arms" (metrics.json only) for
                                # deliberately has none, to exercise the cost-unmeasured
                                # branch.
 adapter/                       # a fabricated LoRA adapter directory with NO weights:
-                               # adapter_config.json (base_model_name_or_path) and
-                               # training_provenance.json (the prompt it was "trained" on),
-                               # which is what the smoke test's --adapter dry run is checked
-                               # against by run_decomposer's base-model and prompt-parity
-                               # guards
+                               # training_provenance.json (the prompt it was "trained" on)
+                               # and adapter_config.json (base_model_name_or_path).
+                               # The smoke test's --adapter dry run exercises the PROMPT-
+                               # PARITY guard only: it is a dry run, so no model is loaded,
+                               # attach_adapter is never called and the base-model assertion
+                               # does not execute — that guard's coverage is
+                               # tests/test_finetune_lora.py::TestAdapterBaseModelAssertion.
+                               # adapter_config.json is still needed here, because the parity
+                               # guard cross-checks the provenance model_id against it.
+                               # It deliberately carries NO prompt_sha256, which is the
+                               # exp-001 case: an optional field absent from the record is
+                               # reported as not compared, not refused.
 retrieval/
   top20.jsonl                  # a similarity top-k file (also used as decomposer input)
   top5_musique_conditions.jsonl # retrieval input for the three MuSiQue conditions: one row

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -40,9 +40,17 @@ predictions/                   # decomposer-shaped prediction files
 decomposer_arms/               # two fabricated "arms" (metrics.json only) for
                                # scripts/compare_decomposer_arms.py; the smoke test copies
                                # the same predictions file into both, so every comparison
-                               # difference is exactly 0 by construction. The finetuned arm
-                               # deliberately has no cost block, to exercise the
-                               # cost-unmeasured branch.
+                               # difference is exactly 0 by construction. The prompting arm
+                               # carries a cost block with its 'definitions' (so the note's
+                               # cost-column definitions are exercised); the finetuned arm
+                               # deliberately has none, to exercise the cost-unmeasured
+                               # branch.
+adapter/                       # a fabricated LoRA adapter directory with NO weights:
+                               # adapter_config.json (base_model_name_or_path) and
+                               # training_provenance.json (the prompt it was "trained" on),
+                               # which is what the smoke test's --adapter dry run is checked
+                               # against by run_decomposer's base-model and prompt-parity
+                               # guards
 retrieval/
   top20.jsonl                  # a similarity top-k file (also used as decomposer input)
   top5_musique_conditions.jsonl # retrieval input for the three MuSiQue conditions: one row

--- a/tests/fixtures/adapter/adapter_config.json
+++ b/tests/fixtures/adapter/adapter_config.json
@@ -1,0 +1,19 @@
+{
+  "_note": "FABRICATED fixture, not a trained adapter: there are no weights in this directory. It exists so the smoke test's --adapter dry run has an adapter directory whose base model and training prompt can be checked (run_decomposer.assert_adapter_base_model, run_decomposer.check_adapter_prompt_parity). base_model_name_or_path matches components/decomposer/models/mistral_7b_instruct/config.json model_id, which is what the parity/base-model guards compare against.",
+  "peft_type": "LORA",
+  "task_type": "CAUSAL_LM",
+  "base_model_name_or_path": "mistralai/Mistral-7B-Instruct-v0.3",
+  "r": 16,
+  "lora_alpha": 32,
+  "lora_dropout": 0.05,
+  "bias": "none",
+  "target_modules": [
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj"
+  ]
+}

--- a/tests/fixtures/adapter/training_provenance.json
+++ b/tests/fixtures/adapter/training_provenance.json
@@ -1,0 +1,19 @@
+{
+  "_note": "FABRICATED fixture, not a run. Same shape train_lora.py writes into a real adapter directory (train_lora.adapter_provenance): the prompt selection an evaluation run is checked against by run_decomposer.check_adapter_prompt_parity. The values are the unguided zero-shot prompt of components/decomposer/models/mistral_7b_instruct, which is what the smoke test's --adapter dry run renders.",
+  "script": "train_lora.py",
+  "created_utc": "2026-08-19T00:00:00+00:00",
+  "run_id": "00000000_000000",
+  "arm": "smoke_fixture",
+  "model": "mistral_7b_instruct",
+  "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+  "prompt": {
+    "guided": false,
+    "few_shot_examples": "",
+    "few_shot_examples_in_prompt": false,
+    "target_reference_style": "as_is",
+    "number_target_lines": false,
+    "prompt_file": "prompt_unguided.md",
+    "prompt_style": "plain",
+    "unguided_hop_placeholder": "Unknown"
+  }
+}

--- a/tests/fixtures/decomposer_arms/prompting/metrics.json
+++ b/tests/fixtures/decomposer_arms/prompting/metrics.json
@@ -14,6 +14,12 @@
     "mean_total_tokens_per_query": 560.0,
     "mean_latency_seconds_per_query": 1.25,
     "median_latency_seconds_per_query": 1.25,
-    "total_generation_seconds": 5.0
+    "total_generation_seconds": 5.0,
+    "definitions": {
+      "prompt_tokens": "tokenizer token count of the rendered prompt for that row",
+      "completion_tokens": "number of newly generated tokens for that row",
+      "latency_seconds": "wall clock around model.generate for that row (CUDA synchronized), excluding tokenization and decoding",
+      "excluded_rows": "rows without a measurement (e.g. a --dry-run) are excluded"
+    }
   }
 }

--- a/tests/test_decomposer_conditions.py
+++ b/tests/test_decomposer_conditions.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """Checks for the MuSiQue decomposer conditions (issue #12). No GPU, no model weights.
 
-pytest is not in the environment, so this is a plain script: every check is an assertion
-with a hand-computed expectation, and the exit code is the result.
+This is a plain script: every check is an assertion with a hand-computed expectation, and the
+exit code is the result. It is also importable by pytest, so the harness functions that take
+arguments are named ``check_*`` rather than ``test_*``: pytest reads a parameter on a
+``test_*`` function as a request for a fixture, and those five functions turned
+``pytest tests/`` into five collection errors (PR #21 review, M-3). ``main()`` below is the
+order they run in.
 
 What it covers:
 
@@ -146,7 +150,7 @@ def test_musique_config() -> dict:
     return cfg
 
 
-def test_conditions(cfg: dict) -> None:
+def check_conditions(cfg: dict) -> None:
     print("[conditions]")
     conditions = require(cfg, "conditions")
     check(
@@ -218,7 +222,7 @@ def test_conditions(cfg: dict) -> None:
         check("rejects an override key the model does not define", False)
 
 
-def test_prompt_invariant(cfg: dict) -> None:
+def check_prompt_invariant(cfg: dict) -> None:
     """The unguided prompt of every folder that has one == guided minus hop-bearing lines.
 
     This is the mechanical form of Jahid's design (plan prompt 4): three conditions on the
@@ -405,7 +409,7 @@ def test_exemplar_hop_lines() -> None:
         check("an unknown exemplar hop mode is refused", False)
 
 
-def test_prompt_selection(cfg: dict) -> None:
+def check_prompt_selection(cfg: dict) -> None:
     """Guided vs unguided picks a different prompt file when the model folder has both."""
     print("[prompt selection]")
     models_dir = MODELS_DIR
@@ -500,7 +504,7 @@ def test_prompt_selection(cfg: dict) -> None:
     )
 
 
-def test_guided_cli_cannot_override_a_condition(cfg: dict) -> None:
+def check_guided_cli_cannot_override_a_condition(cfg: dict) -> None:
     """--guided must not silently relabel an arm."""
     print("[--guided vs condition]")
     conditions = require(cfg, "conditions")
@@ -1305,7 +1309,7 @@ def test_retrieval_input_resolution() -> None:
     )
 
 
-def test_eval_set_resolves(cfg: dict) -> None:
+def check_eval_set_resolves(cfg: dict) -> None:
     print("[evaluation set]")
     paths_cfg = load_paths(require(cfg, "paths_config"))
     template = require(paths_cfg, "datasets." + require(cfg, "questions_template_key"))
@@ -1355,12 +1359,12 @@ def main() -> int:
 
     test_metaqa_defaults_unchanged()
     cfg = test_musique_config()
-    test_conditions(cfg)
-    test_prompt_invariant(cfg)
+    check_conditions(cfg)
+    check_prompt_invariant(cfg)
     test_compound_hop_lines_are_refused()
     test_exemplar_hop_lines()
-    test_prompt_selection(cfg)
-    test_guided_cli_cannot_override_a_condition(cfg)
+    check_prompt_selection(cfg)
+    check_guided_cli_cannot_override_a_condition(cfg)
     test_shared_step_normalization()
     test_completed_step_line_count()
     test_trim_to_step_lines()
@@ -1374,7 +1378,7 @@ def main() -> int:
     if args.skip_data_checks:
         print("[evaluation set] skipped (--skip-data-checks)")
     else:
-        test_eval_set_resolves(cfg)
+        check_eval_set_resolves(cfg)
 
     print(f"\n{len(CHECKS)} checks passed")
     return 0

--- a/tests/test_finetune_lora.py
+++ b/tests/test_finetune_lora.py
@@ -20,6 +20,8 @@ Run::
 """
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import sys
 import tempfile
@@ -27,6 +29,9 @@ import unittest
 import unittest.mock
 from pathlib import Path
 from typing import Any
+
+#: Sentinel for "leave this key out of the fabricated record entirely".
+_ABSENT = object()
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
@@ -816,13 +821,21 @@ class TestCostReporting(unittest.TestCase):
 
 
 #: The prompt an unguided zero-shot adapter was trained on. Every expectation in the
-#: prompt-parity tests is computed against this by hand.
+#: prompt-parity tests is computed against this by hand. ``prompt_sha256`` is deliberately
+#: absent: these four fields are the ones every record must carry.
 TRAINED_ON = {
     "guided": False,
     "prompt_file": "prompt_unguided.md",
     "prompt_style": "plain",
     "few_shot_examples_in_prompt": False,
 }
+
+#: The base model both the fabricated adapter_config.json and the fabricated training records
+#: name, so the record-vs-adapter cross-check passes unless a test changes one of them.
+FIXTURE_MODEL_ID = "mistralai/Mistral-7B-Instruct-v0.3"
+
+#: A fabricated prompt-file hash. Not a real sha256 of anything - the guard compares strings.
+FIXTURE_PROMPT_SHA = "a" * 64
 
 
 class TestAdapterPromptParity(unittest.TestCase):
@@ -840,24 +853,41 @@ class TestAdapterPromptParity(unittest.TestCase):
         self.run_dir = Path(self._tmp.name) / "20260818_222259"
         self.adapter_dir = self.run_dir / "adapter"
         self.adapter_dir.mkdir(parents=True)
+        # Every adapter directory carries one; the record-vs-adapter cross-check reads it.
+        self._write_adapter_config()
 
     def tearDown(self) -> None:
         self._tmp.cleanup()
 
-    def _write_provenance(self, **prompt_overrides: Any) -> Path:
+    def _write_adapter_config(self, base_model: str = FIXTURE_MODEL_ID) -> Path:
+        path = self.adapter_dir / self.rd.ADAPTER_CONFIG_FILE
+        path.write_text(
+            json.dumps({self.rd.ADAPTER_BASE_MODEL_FIELD: base_model}), encoding="utf-8"
+        )
+        return path
+
+    def _write_provenance(
+        self, *, payload_overrides: dict[str, Any] | None = None, **prompt_overrides: Any
+    ) -> Path:
         """The file train_lora.py writes into the adapter directory."""
         prompt = {**TRAINED_ON, **prompt_overrides}
+        payload = {
+            "script": "train_lora.py",
+            "run_id": "r1",
+            "arm": "full_train",
+            "model_id": FIXTURE_MODEL_ID,
+            "prompt": prompt,
+        }
+        payload.update(payload_overrides or {})
+        payload = {k: v for k, v in payload.items() if v is not _ABSENT}
         path = self.adapter_dir / self.rd.ADAPTER_PROVENANCE_FILE
-        path.write_text(
-            json.dumps({"script": "train_lora.py", "run_id": "r1", "arm": "full_train",
-                        "prompt": prompt}),
-            encoding="utf-8",
-        )
+        path.write_text(json.dumps(payload), encoding="utf-8")
         return path
 
     def _write_training_snapshot(self, *, script: str = "train_lora.py", **prompt_overrides: Any) -> Path:
         """The training run's config snapshot, next to the adapter dir (the exp-001 shape:
-        ``prompt.few_shot_examples`` as an empty string rather than a boolean)."""
+        ``prompt.few_shot_examples`` as an empty string rather than a boolean, and no
+        ``prompt_sha256``)."""
         prompt = {
             "guided": TRAINED_ON["guided"],
             "few_shot_examples": "",
@@ -868,7 +898,7 @@ class TestAdapterPromptParity(unittest.TestCase):
         path = self.run_dir / self.rd.TRAINING_SNAPSHOT_FILE
         path.write_text(
             json.dumps({"script": script, "run_id": "20260818_222259", "arm": "full_train",
-                        "prompt": prompt}),
+                        "model_id": FIXTURE_MODEL_ID, "prompt": prompt}),
             encoding="utf-8",
         )
         return path
@@ -877,6 +907,12 @@ class TestAdapterPromptParity(unittest.TestCase):
         return self.rd.check_adapter_prompt_parity(
             adapter=str(self.adapter_dir), run_selection=run_selection, override=override
         )
+
+    def _check_capturing_stdout(self, **kwargs: Any) -> tuple[dict[str, Any], str]:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            record = self._check(**kwargs)
+        return record, buffer.getvalue()
 
     # ---- the record is found ----
 
@@ -953,7 +989,9 @@ class TestAdapterPromptParity(unittest.TestCase):
         self._write_training_snapshot(script="run_decomposer.py")
         with self.assertRaises(SystemExit) as ctx:
             self._check(run_selection=dict(TRAINED_ON))
-        self.assertIn("not a training run's snapshot", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("'script' is 'run_decomposer.py'", message)
+        self.assertIn("not a record written by train_lora.py", message)
 
     def test_a_record_missing_a_prompt_field_is_not_usable(self) -> None:
         path = self.adapter_dir / self.rd.ADAPTER_PROVENANCE_FILE
@@ -966,6 +1004,132 @@ class TestAdapterPromptParity(unittest.TestCase):
         message = str(ctx.exception)
         self.assertIn("no 'prompt.prompt_file'", message)
         self.assertIn("no 'prompt.prompt_style'", message)
+
+    # ---- the provenance file is validated, not trusted for sitting there ----
+
+    def test_a_provenance_file_with_no_script_field_is_not_a_training_record(self) -> None:
+        """The provenance file is a plain JSON file in a directory anyone can copy into."""
+        self._write_provenance(payload_overrides={"script": _ABSENT})
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        message = str(ctx.exception)
+        self.assertIn("'script' is None", message)
+        self.assertIn("not a record written by train_lora.py", message)
+
+    def test_a_provenance_file_claiming_another_script_is_refused(self) -> None:
+        self._write_provenance(payload_overrides={"script": "run_decomposer.py"})
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        self.assertIn("'script' is 'run_decomposer.py'", str(ctx.exception))
+
+    def test_a_provenance_file_for_a_different_base_model_is_refused(self) -> None:
+        """A stale or copied provenance file must not pass because it sits beside weights."""
+        self._write_provenance(payload_overrides={"model_id": "some/other-base"})
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        message = str(ctx.exception)
+        self.assertIn("'model_id' is 'some/other-base'", message)
+        self.assertIn(FIXTURE_MODEL_ID, message)
+        self.assertIn("does not describe this adapter", message)
+
+    def test_the_model_id_cross_check_is_recorded_when_it_passes(self) -> None:
+        self._write_provenance()
+        record = self._check(run_selection=dict(TRAINED_ON))
+        cross = record["training_record"]["model_id_cross_check"]
+        self.assertTrue(cross["checked"])
+        self.assertEqual(cross["record_model_id"], FIXTURE_MODEL_ID)
+        self.assertEqual(cross["adapter_base_model"], FIXTURE_MODEL_ID)
+
+    def test_the_cross_check_says_so_when_it_cannot_be_done(self) -> None:
+        """No adapter_config.json: the record is still usable, and the record says why."""
+        (self.adapter_dir / self.rd.ADAPTER_CONFIG_FILE).unlink()
+        self._write_provenance()
+        record = self._check(run_selection=dict(TRAINED_ON))
+        cross = record["training_record"]["model_id_cross_check"]
+        self.assertTrue(record["checked"])
+        self.assertFalse(cross["checked"])
+        self.assertIsNone(cross["adapter_base_model"])
+        self.assertIn("unchecked", cross["note"])
+
+    def test_a_record_with_no_model_id_is_usable_and_says_it_was_not_cross_checked(self) -> None:
+        self._write_provenance(payload_overrides={"model_id": _ABSENT})
+        record = self._check(run_selection=dict(TRAINED_ON))
+        self.assertTrue(record["checked"])
+        cross = record["training_record"]["model_id_cross_check"]
+        self.assertFalse(cross["checked"])
+        self.assertIn("no 'model_id'", cross["note"])
+
+    # ---- strict types: no coercion of a malformed record ----
+
+    def test_a_string_guided_value_is_malformed_not_true(self) -> None:
+        """bool("false") is True, which would invert the condition being claimed."""
+        self._write_provenance(guided="false")
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        message = str(ctx.exception)
+        self.assertIn("'prompt.guided' is 'false' (str), not a boolean", message)
+        self.assertIn("cannot tell what adapter", message)
+
+    def test_a_null_prompt_file_is_malformed_rather_than_the_string_none(self) -> None:
+        self._write_provenance(prompt_file=None)
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        self.assertIn(
+            "'prompt.prompt_file' is None (NoneType), not a non-empty string",
+            str(ctx.exception),
+        )
+
+    def test_a_non_boolean_few_shot_flag_is_malformed(self) -> None:
+        self._write_provenance(few_shot_examples_in_prompt="no")
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        self.assertIn(
+            "'prompt.few_shot_examples_in_prompt' is 'no' (str), not a boolean",
+            str(ctx.exception),
+        )
+
+    def test_an_absent_field_renders_as_null_not_as_the_string_none(self) -> None:
+        self.assertEqual(self.rd._parity_value(None), "null (absent)")
+        self.assertEqual(self.rd._parity_value("prompt.md"), "'prompt.md'")
+
+    # ---- content-level parity: prompt_sha256, compared only when recorded ----
+
+    def test_a_matching_prompt_sha256_is_compared_and_passes(self) -> None:
+        self._write_provenance(prompt_sha256=FIXTURE_PROMPT_SHA)
+        record = self._check(
+            run_selection={**TRAINED_ON, "prompt_sha256": FIXTURE_PROMPT_SHA}
+        )
+        self.assertTrue(record["checked"])
+        self.assertIn("prompt_sha256", record["fields_compared"])
+        self.assertEqual(record["fields_compared"], list(TRAINED_ON) + ["prompt_sha256"])
+        self.assertEqual(record["fields_not_in_training_record"], [])
+
+    def test_an_edited_prompt_file_with_the_same_name_is_refused(self) -> None:
+        """The point of the content check: same prompt_file, different bytes."""
+        self._write_provenance(prompt_sha256=FIXTURE_PROMPT_SHA)
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection={**TRAINED_ON, "prompt_sha256": "b" * 64})
+        message = str(ctx.exception)
+        self.assertIn("prompt_sha256: trained on", message)
+        self.assertIn("adapter prompt mismatch", message)
+
+    def test_a_record_without_a_prompt_sha256_is_not_refused_but_recorded(self) -> None:
+        """The exp-001 case: retraining for a field added later is not acceptable."""
+        self._write_training_snapshot()  # no prompt_sha256, like exp-001's snapshot
+        record = self._check(
+            run_selection={**TRAINED_ON, "prompt_sha256": FIXTURE_PROMPT_SHA}
+        )
+        self.assertTrue(record["checked"])
+        self.assertEqual(record["mismatches"], [])
+        self.assertEqual(record["fields_compared"], list(TRAINED_ON))
+        self.assertEqual(record["fields_not_in_training_record"], ["prompt_sha256"])
+        self.assertIn("not a refusal", record["note"])
+
+    def test_a_malformed_prompt_sha256_is_refused_rather_than_skipped(self) -> None:
+        self._write_provenance(prompt_sha256="")
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection={**TRAINED_ON, "prompt_sha256": FIXTURE_PROMPT_SHA})
+        self.assertIn("'prompt.prompt_sha256' is ''", str(ctx.exception))
 
     # ---- the override, and the prompting arm ----
 
@@ -1008,6 +1172,129 @@ class TestAdapterPromptParity(unittest.TestCase):
             self.rd.ADAPTER_PROMPT_PARITY_FIELDS,
             ("guided", "prompt_file", "prompt_style", "few_shot_examples_in_prompt"),
         )
+        self.assertEqual(self.rd.ADAPTER_PROMPT_PARITY_OPTIONAL_FIELDS, ("prompt_sha256",))
+
+    # ---- a run that proceeds must not print a refusal ----
+
+    def test_an_overridden_mismatch_warns_without_claiming_a_refusal(self) -> None:
+        self._write_provenance()
+        record, printed = self._check_capturing_stdout(
+            run_selection={**TRAINED_ON, "guided": True}, override=True
+        )
+        self.assertNotIn("REFUSING TO RUN", printed)
+        self.assertIn("WARNING:", printed)
+        self.assertIn("MISMATCHED", printed)
+        self.assertIn("The run proceeds", printed)
+        self.assertEqual([m["field"] for m in record["mismatches"]], ["guided"])
+
+    def test_an_overridden_missing_record_warns_without_claiming_a_refusal(self) -> None:
+        _record, printed = self._check_capturing_stdout(
+            run_selection=dict(TRAINED_ON), override=True
+        )
+        self.assertNotIn("REFUSING TO RUN", printed)
+        self.assertIn("UNCHECKED", printed)
+        self.assertIn("The run proceeds", printed)
+
+    def test_the_refusals_still_say_refusing_to_run(self) -> None:
+        """The string is reserved for runs that actually stop."""
+        self._write_provenance()
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection={**TRAINED_ON, "guided": True})
+        self.assertIn("REFUSING TO RUN", str(ctx.exception))
+
+
+class TestAdapterRunNoteStatesWhatWasChecked(unittest.TestCase):
+    """notes.md says whether the two adapter guards passed, were overridden, or did not run."""
+
+    def setUp(self) -> None:
+        import run_decomposer
+
+        self.rd = run_decomposer
+
+    def _lines(self, **kwargs: Any) -> list[str]:
+        defaults: dict[str, Any] = {
+            "adapter": "runs/exp-001/x/adapter",
+            "no_few_shot": True,
+            "parity": {"checked": True, "override": False, "mismatches": []},
+            "base_model": None,
+            "base_model_note": None,
+        }
+        return self.rd.adapter_note_lines(**{**defaults, **kwargs})
+
+    def test_the_prompting_arm_gets_one_line_and_no_guard_lines(self) -> None:
+        lines = self._lines(adapter=None, no_few_shot=False)
+        self.assertEqual(lines, ["- Adapter: none (prompting arm)"])
+
+    def test_a_passed_parity_check_names_the_fields_and_the_record(self) -> None:
+        lines = self._lines(
+            parity={
+                "checked": True,
+                "override": False,
+                "mismatches": [],
+                "fields_compared": list(TRAINED_ON) + ["prompt_sha256"],
+                "fields_not_in_training_record": [],
+                "training_record": {"path": "/runs/x/config.json", "source": "training_run_config"},
+            },
+            base_model={
+                "adapter_base_model": FIXTURE_MODEL_ID,
+                "run_model_id": FIXTURE_MODEL_ID,
+            },
+        )
+        parity_line = next(ln for ln in lines if "prompt parity" in ln)
+        self.assertIn("checked OK on 5 field(s)", parity_line)
+        self.assertIn("prompt_sha256", parity_line)
+        self.assertIn("/runs/x/config.json", parity_line)
+        base_line = next(ln for ln in lines if "base model" in ln)
+        self.assertIn("asserted", base_line)
+        self.assertIn(FIXTURE_MODEL_ID, base_line)
+
+    def test_a_field_the_record_lacks_is_reported_as_not_compared(self) -> None:
+        lines = self._lines(
+            parity={
+                "checked": True,
+                "override": False,
+                "mismatches": [],
+                "fields_compared": list(TRAINED_ON),
+                "fields_not_in_training_record": ["prompt_sha256"],
+                "training_record": {"path": "/runs/x/config.json", "source": "training_run_config"},
+            },
+            base_model_note="unasserted: no model was loaded in this run (--dry-run)",
+        )
+        parity_line = next(ln for ln in lines if "prompt parity" in ln)
+        self.assertIn("checked OK on 4 field(s)", parity_line)
+        self.assertIn("not compared: prompt_sha256", parity_line)
+        base_line = next(ln for ln in lines if "base model" in ln)
+        self.assertIn("unasserted", base_line)
+        self.assertIn("--dry-run", base_line)
+
+    def test_an_overridden_mismatch_is_stated_with_its_mismatches(self) -> None:
+        lines = self._lines(
+            parity={
+                "checked": False,
+                "override": True,
+                "mismatches": [
+                    {"field": "guided", "trained_on": False, "this_run": True},
+                    {"field": "prompt_file", "trained_on": "prompt_unguided.md", "this_run": None},
+                ],
+            }
+        )
+        parity_line = next(ln for ln in lines if "prompt parity" in ln)
+        self.assertIn("MISMATCHED and overridden", parity_line)
+        self.assertIn(self.rd.ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG, parity_line)
+        self.assertIn("guided (trained on False, this run True)", parity_line)
+        self.assertIn("this run null (absent)", parity_line)
+        self.assertIn("not the fine-tuned arm", parity_line)
+
+    def test_an_overridden_missing_record_is_stated_as_unchecked(self) -> None:
+        lines = self._lines(parity={"checked": False, "override": True, "mismatches": []})
+        parity_line = next(ln for ln in lines if "prompt parity" in ln)
+        self.assertIn("UNCHECKED and overridden", parity_line)
+        self.assertIn("no usable training record", parity_line)
+
+    def test_the_few_shot_override_line_is_kept(self) -> None:
+        lines = self._lines(no_few_shot=False)
+        self.assertIn(self.rd.ADAPTER_FEW_SHOT_OVERRIDE_FLAG, lines[0])
+        self.assertIn("not the fine-tuned arm", lines[0])
 
 
 class TestAdapterBaseModelAssertion(unittest.TestCase):
@@ -1147,6 +1434,28 @@ class TestAdapterProvenanceIsWritten(unittest.TestCase):
 
     def test_the_two_modules_agree_on_the_filename(self) -> None:
         self.assertEqual(train_lora.ADAPTER_PROVENANCE_FILE, self.rd.ADAPTER_PROVENANCE_FILE)
+
+    def test_the_prompt_content_hash_travels_into_the_provenance(self) -> None:
+        payload = train_lora.adapter_provenance(
+            self._snapshot(prompt_sha256=FIXTURE_PROMPT_SHA)
+        )
+        self.assertEqual(payload["prompt"]["prompt_sha256"], FIXTURE_PROMPT_SHA)
+        train_lora.write_adapter_provenance(
+            self.adapter_dir, self._snapshot(prompt_sha256=FIXTURE_PROMPT_SHA)
+        )
+        found = self.rd.read_adapter_training_record(self.adapter_dir)
+        self.assertEqual(found["trained_on"]["prompt_sha256"], FIXTURE_PROMPT_SHA)
+
+    def test_training_and_inference_hash_a_prompt_file_with_one_function(self) -> None:
+        """Content parity is only meaningful if both sides compute the same number."""
+        prompt_path = (
+            REPO_ROOT / "components" / "decomposer" / "models" / "mistral_7b_instruct"
+            / "prompt_unguided.md"
+        )
+        self.assertTrue(prompt_path.exists(), str(prompt_path))
+        self.assertEqual(
+            fd.prompt_file_sha256(prompt_path), self.rd.sha256_file(prompt_path)
+        )
 
     def test_the_committed_fixture_provenance_is_readable_by_the_guard(self) -> None:
         found = self.rd.read_adapter_training_record(REPO_ROOT / "tests" / "fixtures" / "adapter")

--- a/tests/test_finetune_lora.py
+++ b/tests/test_finetune_lora.py
@@ -7,6 +7,12 @@ and names the offending ids, the prompt/completion formatting matches what the r
 produce at inference, and the parameter-ceiling gate in ``train_lora.py`` is wired to
 ``src/model_size.py`` (both directions: within the ceiling and over it).
 
+It also covers the two guards on the adapter *evaluation* path (PR #24 re-review): an
+adapter may only be evaluated on the prompt its training run recorded
+(``check_adapter_prompt_parity``), and it may only attach to the base model
+``adapter_config.json`` names (``assert_adapter_base_model``). Their fixtures are fabricated
+JSON in a temp directory - no weights, no run directory, no data.
+
 Run::
 
     .venv/bin/python -m unittest discover -s tests -v
@@ -16,7 +22,9 @@ from __future__ import annotations
 
 import json
 import sys
+import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 from typing import Any
 
@@ -805,6 +813,394 @@ class TestCostReporting(unittest.TestCase):
         self.assertIsNone(summary["mean_prompt_tokens_per_query"])
         self.assertIsNone(summary["mean_latency_seconds_per_query"])
         self.assertIn("unmeasured", summary["note"])
+
+
+#: The prompt an unguided zero-shot adapter was trained on. Every expectation in the
+#: prompt-parity tests is computed against this by hand.
+TRAINED_ON = {
+    "guided": False,
+    "prompt_file": "prompt_unguided.md",
+    "prompt_style": "plain",
+    "few_shot_examples_in_prompt": False,
+}
+
+
+class TestAdapterPromptParity(unittest.TestCase):
+    """An adapter may only be evaluated on the prompt its training run recorded.
+
+    All fixtures here are fabricated JSON in a temp directory: no adapter weights, no real
+    run directory, no data.
+    """
+
+    def setUp(self) -> None:
+        import run_decomposer
+
+        self.rd = run_decomposer
+        self._tmp = tempfile.TemporaryDirectory()
+        self.run_dir = Path(self._tmp.name) / "20260818_222259"
+        self.adapter_dir = self.run_dir / "adapter"
+        self.adapter_dir.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _write_provenance(self, **prompt_overrides: Any) -> Path:
+        """The file train_lora.py writes into the adapter directory."""
+        prompt = {**TRAINED_ON, **prompt_overrides}
+        path = self.adapter_dir / self.rd.ADAPTER_PROVENANCE_FILE
+        path.write_text(
+            json.dumps({"script": "train_lora.py", "run_id": "r1", "arm": "full_train",
+                        "prompt": prompt}),
+            encoding="utf-8",
+        )
+        return path
+
+    def _write_training_snapshot(self, *, script: str = "train_lora.py", **prompt_overrides: Any) -> Path:
+        """The training run's config snapshot, next to the adapter dir (the exp-001 shape:
+        ``prompt.few_shot_examples`` as an empty string rather than a boolean)."""
+        prompt = {
+            "guided": TRAINED_ON["guided"],
+            "few_shot_examples": "",
+            "prompt_file": TRAINED_ON["prompt_file"],
+            "prompt_style": TRAINED_ON["prompt_style"],
+            **prompt_overrides,
+        }
+        path = self.run_dir / self.rd.TRAINING_SNAPSHOT_FILE
+        path.write_text(
+            json.dumps({"script": script, "run_id": "20260818_222259", "arm": "full_train",
+                        "prompt": prompt}),
+            encoding="utf-8",
+        )
+        return path
+
+    def _check(self, *, run_selection: dict[str, Any], override: bool = False) -> dict[str, Any]:
+        return self.rd.check_adapter_prompt_parity(
+            adapter=str(self.adapter_dir), run_selection=run_selection, override=override
+        )
+
+    # ---- the record is found ----
+
+    def test_the_provenance_file_in_the_adapter_dir_is_preferred(self) -> None:
+        provenance = self._write_provenance()
+        self._write_training_snapshot()
+        record = self._check(run_selection=dict(TRAINED_ON))
+        self.assertTrue(record["checked"])
+        self.assertEqual(record["mismatches"], [])
+        self.assertEqual(record["training_record"]["source"], "adapter_provenance")
+        self.assertEqual(record["training_record"]["path"], str(provenance))
+        self.assertEqual(record["trained_on"], TRAINED_ON)
+
+    def test_the_training_run_snapshot_next_to_the_adapter_is_the_fallback(self) -> None:
+        """The exp-001 case: an adapter trained before the provenance file existed."""
+        snapshot = self._write_training_snapshot()
+        record = self._check(run_selection=dict(TRAINED_ON))
+        self.assertTrue(record["checked"])
+        self.assertEqual(record["training_record"]["source"], "training_run_config")
+        self.assertEqual(record["training_record"]["path"], str(snapshot))
+        # few_shot_examples "" (the training block) -> few_shot_examples_in_prompt False.
+        self.assertEqual(record["trained_on"], TRAINED_ON)
+
+    def test_a_non_empty_few_shot_block_reads_as_trained_with_examples(self) -> None:
+        self._write_training_snapshot(few_shot_examples="Q: ...\nSteps: ...")
+        record = self._check(
+            run_selection={**TRAINED_ON, "few_shot_examples_in_prompt": True}
+        )
+        self.assertTrue(record["checked"])
+        self.assertTrue(record["trained_on"]["few_shot_examples_in_prompt"])
+
+    # ---- the refusals ----
+
+    def test_a_guided_run_against_an_unguided_adapter_is_refused(self) -> None:
+        """The finding: --adapter --no-few-shot --guided used to be accepted."""
+        self._write_provenance()
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(
+                run_selection={**TRAINED_ON, "guided": True, "prompt_file": "prompt.md"}
+            )
+        message = str(ctx.exception)
+        self.assertIn("REFUSING TO RUN", message)
+        self.assertIn("adapter prompt mismatch", message)
+        self.assertIn("guided: trained on False, this run True", message)
+        self.assertIn("prompt_file: trained on 'prompt_unguided.md', this run 'prompt.md'", message)
+        self.assertIn(self.rd.ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG, message)
+
+    def test_exactly_the_mismatching_fields_are_named(self) -> None:
+        self._write_provenance()
+        with self.assertRaises(SystemExit):
+            self._check(run_selection={**TRAINED_ON, "prompt_style": "chat_template"})
+        record = self._check(
+            run_selection={**TRAINED_ON, "prompt_style": "chat_template"}, override=True
+        )
+        self.assertEqual([m["field"] for m in record["mismatches"]], ["prompt_style"])
+        self.assertEqual(record["mismatches"][0]["trained_on"], "plain")
+        self.assertEqual(record["mismatches"][0]["this_run"], "chat_template")
+
+    def test_a_few_shot_prompt_against_a_zero_shot_adapter_is_refused(self) -> None:
+        self._write_provenance()
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection={**TRAINED_ON, "few_shot_examples_in_prompt": True})
+        self.assertIn("few_shot_examples_in_prompt", str(ctx.exception))
+
+    def test_no_training_record_at_all_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        message = str(ctx.exception)
+        self.assertIn("cannot tell what adapter", message)
+        self.assertIn(self.rd.ADAPTER_PROVENANCE_FILE, message)
+        self.assertIn(self.rd.TRAINING_SNAPSHOT_FILE, message)
+
+    def test_a_config_json_from_another_script_is_not_a_training_record(self) -> None:
+        self._write_training_snapshot(script="run_decomposer.py")
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        self.assertIn("not a training run's snapshot", str(ctx.exception))
+
+    def test_a_record_missing_a_prompt_field_is_not_usable(self) -> None:
+        path = self.adapter_dir / self.rd.ADAPTER_PROVENANCE_FILE
+        path.write_text(
+            json.dumps({"script": "train_lora.py", "prompt": {"guided": False}}),
+            encoding="utf-8",
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            self._check(run_selection=dict(TRAINED_ON))
+        message = str(ctx.exception)
+        self.assertIn("no 'prompt.prompt_file'", message)
+        self.assertIn("no 'prompt.prompt_style'", message)
+
+    # ---- the override, and the prompting arm ----
+
+    def test_the_named_override_runs_and_is_recorded(self) -> None:
+        self._write_provenance()
+        record = self._check(run_selection={**TRAINED_ON, "guided": True}, override=True)
+        self.assertTrue(record["override"])
+        # An overridden mismatch is a recorded mismatch, not a passed check.
+        self.assertFalse(record["checked"])
+        self.assertEqual([m["field"] for m in record["mismatches"]], ["guided"])
+        self.assertIn("not the fine-tuned arm", record["note"])
+
+    def test_the_override_also_covers_a_missing_record(self) -> None:
+        record = self._check(run_selection=dict(TRAINED_ON), override=True)
+        self.assertFalse(record["checked"])
+        self.assertIsNone(record["trained_on"])
+        self.assertIn("unchecked", record["note"])
+
+    def test_a_run_without_an_adapter_is_not_checked(self) -> None:
+        record = self.rd.check_adapter_prompt_parity(
+            adapter=None, run_selection=dict(TRAINED_ON), override=False
+        )
+        self.assertFalse(record["checked"])
+        self.assertIn("no --adapter", record["note"])
+
+    def test_the_override_flag_is_named_and_on_the_parser(self) -> None:
+        self.assertEqual(
+            self.rd.ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG, "--adapter-prompt-mismatch-i-know"
+        )
+        argv = [
+            "run_decomposer.py", "--model", "mistral_7b_instruct", "--adapter", "a",
+            "--no-few-shot", self.rd.ADAPTER_PROMPT_PARITY_OVERRIDE_FLAG,
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            args = self.rd._parse_args()
+        self.assertTrue(args.adapter_prompt_mismatch_i_know)
+
+    def test_the_parity_fields_are_the_four_prompt_choices(self) -> None:
+        self.assertEqual(
+            self.rd.ADAPTER_PROMPT_PARITY_FIELDS,
+            ("guided", "prompt_file", "prompt_style", "few_shot_examples_in_prompt"),
+        )
+
+
+class TestAdapterBaseModelAssertion(unittest.TestCase):
+    """An adapter attaches by module name and shape, so its base model is asserted."""
+
+    def setUp(self) -> None:
+        import run_decomposer
+
+        self.rd = run_decomposer
+        self._tmp = tempfile.TemporaryDirectory()
+        self.adapter_dir = Path(self._tmp.name) / "adapter"
+        self.adapter_dir.mkdir()
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _write_adapter_config(self, payload: dict[str, Any]) -> Path:
+        path = self.adapter_dir / self.rd.ADAPTER_CONFIG_FILE
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_the_matching_base_model_is_asserted_and_recorded(self) -> None:
+        path = self._write_adapter_config(
+            {"base_model_name_or_path": "mistralai/Mistral-7B-Instruct-v0.3"}
+        )
+        record = self.rd.assert_adapter_base_model(
+            self.adapter_dir, model_id="mistralai/Mistral-7B-Instruct-v0.3"
+        )
+        self.assertTrue(record["base_model_asserted"])
+        self.assertEqual(record["adapter_base_model"], "mistralai/Mistral-7B-Instruct-v0.3")
+        self.assertEqual(record["run_model_id"], "mistralai/Mistral-7B-Instruct-v0.3")
+        self.assertEqual(record["adapter_config_path"], str(path))
+
+    def test_a_different_base_model_is_refused_and_both_are_named(self) -> None:
+        self._write_adapter_config(
+            {"base_model_name_or_path": "mistralai/Mistral-7B-Instruct-v0.2"}
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            self.rd.assert_adapter_base_model(
+                self.adapter_dir, model_id="mistralai/Mistral-7B-Instruct-v0.3"
+            )
+        message = str(ctx.exception)
+        self.assertIn("REFUSING TO RUN", message)
+        self.assertIn("mistralai/Mistral-7B-Instruct-v0.2", message)
+        self.assertIn("mistralai/Mistral-7B-Instruct-v0.3", message)
+
+    def test_an_absent_field_is_refused_rather_than_skipped(self) -> None:
+        self._write_adapter_config({"peft_type": "LORA"})
+        with self.assertRaises(SystemExit) as ctx:
+            self.rd.assert_adapter_base_model(self.adapter_dir, model_id="m")
+        self.assertIn("base_model_name_or_path", str(ctx.exception))
+
+    def test_a_missing_adapter_config_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            self.rd.assert_adapter_base_model(self.adapter_dir, model_id="m")
+        self.assertIn(self.rd.ADAPTER_CONFIG_FILE, str(ctx.exception))
+
+    def test_attach_adapter_asserts_before_loading_anything(self) -> None:
+        """The guard is wired into attach_adapter, not only available beside it."""
+        self._write_adapter_config({"base_model_name_or_path": "some/other-base"})
+        with self.assertRaises(SystemExit) as ctx:
+            self.rd.attach_adapter(object(), self.adapter_dir, model_id="m")
+        self.assertIn("adapter base-model mismatch", str(ctx.exception))
+
+    def test_the_field_name_is_pefts_own(self) -> None:
+        self.assertEqual(self.rd.ADAPTER_CONFIG_FILE, "adapter_config.json")
+        self.assertEqual(self.rd.ADAPTER_BASE_MODEL_FIELD, "base_model_name_or_path")
+
+    def test_the_committed_fixture_adapter_names_the_model_folders_base(self) -> None:
+        """The smoke test's --adapter fixture must match the model folder it runs against."""
+        fixture = json.loads(
+            (REPO_ROOT / "tests" / "fixtures" / "adapter" / self.rd.ADAPTER_CONFIG_FILE)
+            .read_text(encoding="utf-8")
+        )
+        model_cfg = load_config(
+            REPO_ROOT / "components" / "decomposer" / "models" / "mistral_7b_instruct"
+            / "config.json"
+        )
+        self.assertEqual(
+            fixture[self.rd.ADAPTER_BASE_MODEL_FIELD], require(model_cfg, "model_id")
+        )
+
+
+class TestAdapterProvenanceIsWritten(unittest.TestCase):
+    """``train_lora.py`` records the training prompt where the evaluation guard reads it."""
+
+    def setUp(self) -> None:
+        import run_decomposer
+
+        self.rd = run_decomposer
+        self._tmp = tempfile.TemporaryDirectory()
+        self.adapter_dir = Path(self._tmp.name) / "adapter"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _snapshot(self, **prompt_overrides: Any) -> dict[str, Any]:
+        return {
+            "script": "train_lora.py",
+            "created_utc": "2026-08-19T00:00:00+00:00",
+            "run_id": "20260819_000000",
+            "arm": "full_train",
+            "model": "mistral_7b_instruct",
+            "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+            "prompt": {
+                "guided": False,
+                "few_shot_examples": "",
+                "prompt_file": "prompt_unguided.md",
+                "prompt_style": "plain",
+                **prompt_overrides,
+            },
+        }
+
+    def test_a_zero_shot_training_prompt_records_no_examples(self) -> None:
+        payload = train_lora.adapter_provenance(self._snapshot())
+        self.assertFalse(payload["prompt"]["few_shot_examples_in_prompt"])
+        self.assertEqual(payload["run_id"], "20260819_000000")
+        self.assertEqual(payload["model_id"], "mistralai/Mistral-7B-Instruct-v0.3")
+
+    def test_a_non_empty_few_shot_block_records_examples(self) -> None:
+        payload = train_lora.adapter_provenance(self._snapshot(few_shot_examples="Q: x"))
+        self.assertTrue(payload["prompt"]["few_shot_examples_in_prompt"])
+
+    def test_what_training_writes_is_what_the_guard_reads(self) -> None:
+        path = train_lora.write_adapter_provenance(self.adapter_dir, self._snapshot())
+        self.assertEqual(path.name, self.rd.ADAPTER_PROVENANCE_FILE)
+        found = self.rd.read_adapter_training_record(self.adapter_dir)
+        self.assertTrue(found["found"])
+        self.assertEqual(found["source"], "adapter_provenance")
+        self.assertEqual(found["trained_on"], TRAINED_ON)
+        # And the run that renders that same prompt passes the guard.
+        record = self.rd.check_adapter_prompt_parity(
+            adapter=str(self.adapter_dir), run_selection=dict(TRAINED_ON), override=False
+        )
+        self.assertTrue(record["checked"])
+        self.assertEqual(record["mismatches"], [])
+
+    def test_the_two_modules_agree_on_the_filename(self) -> None:
+        self.assertEqual(train_lora.ADAPTER_PROVENANCE_FILE, self.rd.ADAPTER_PROVENANCE_FILE)
+
+    def test_the_committed_fixture_provenance_is_readable_by_the_guard(self) -> None:
+        found = self.rd.read_adapter_training_record(REPO_ROOT / "tests" / "fixtures" / "adapter")
+        self.assertTrue(found["found"])
+        self.assertEqual(found["trained_on"], TRAINED_ON)
+
+
+class TestCostColumnDefinitionsAreReported(unittest.TestCase):
+    """The arms note prints what its cost columns measure, taken from the runs themselves."""
+
+    def setUp(self) -> None:
+        import compare_decomposer_arms
+
+        self.mod = compare_decomposer_arms
+        self.definitions = {"prompt_tokens": "tokens in the rendered prompt"}
+
+    def test_arms_that_agree_are_one_group(self) -> None:
+        groups = self.mod.cost_definition_groups(
+            {
+                "prompting": {"cost_definitions": dict(self.definitions)},
+                "finetuned": {"cost_definitions": dict(self.definitions)},
+            }
+        )
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(sorted(groups[0][0]), ["finetuned", "prompting"])
+        self.assertEqual(groups[0][1], self.definitions)
+
+    def test_arms_that_disagree_are_separate_groups(self) -> None:
+        groups = self.mod.cost_definition_groups(
+            {
+                "prompting": {"cost_definitions": dict(self.definitions)},
+                "finetuned": {"cost_definitions": {"prompt_tokens": "something else"}},
+            }
+        )
+        self.assertEqual(len(groups), 2)
+
+    def test_an_arm_without_definitions_is_left_out_rather_than_invented(self) -> None:
+        groups = self.mod.cost_definition_groups(
+            {
+                "prompting": {"cost_definitions": dict(self.definitions)},
+                "finetuned": {"cost_definitions": None},
+            }
+        )
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0][0], ["prompting"])
+
+    def test_the_runner_writes_the_definitions_the_note_reports(self) -> None:
+        import run_decomposer
+
+        summary = run_decomposer.cost_summary(
+            [{"prompt_tokens": 10, "completion_tokens": 2, "latency_seconds": 0.5}]
+        )
+        for key in ("prompt_tokens", "completion_tokens", "latency_seconds"):
+            self.assertIn(key, summary["definitions"])
 
 
 if __name__ == "__main__":

--- a/tests/test_suite_collectability.py
+++ b/tests/test_suite_collectability.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""The test suites stay collectable by pytest. No GPU, no weights, no subprocess.
+
+Why this file exists. Two suites here are *script-style*: they are plain scripts whose
+harness functions take arguments (a loaded config) and whose ``main()`` calls them in order.
+pytest also imports every ``tests/test_*.py``, and it reads a parameter on a module-level
+``test_*`` function as a request for a **fixture** — so one such function turns
+``python -m pytest tests/`` into a collection error that has nothing to do with the code under
+test. That is exactly what happened (PR #21 review, M-3: five errors), and renaming those
+functions ``check_*`` fixed it.
+
+This check is the regression guard for the *next* one. It reproduces the rule with ``ast``
+rather than shelling out to pytest, for two measured reasons:
+
+1. ``pytest --collect-only -q`` does **not** catch this shape. Measured on 2026-08-19 against
+   a probe module containing exactly ``def test_regression(cfg): pass``:
+   ``pytest -q --collect-only`` → *1 test collected*, exit 0; ``pytest -q`` → *1 error*,
+   exit 1. The missing fixture is raised when the test is **set up**, not when it is
+   collected, so a collect-only gate would pass a suite that a real run errors on.
+2. pytest is not installed in the project venv (``.venv``) that runs the other suites, so a
+   pytest-shelling check would silently depend on which interpreter invoked it. An ast check
+   runs everywhere, including under plain ``unittest``.
+
+Run::
+
+    .venv/bin/python tests/test_suite_collectability.py
+    .venv/bin/python -m unittest discover -s tests
+"""
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+#: pytest collects module-level functions whose name starts with this.
+PYTEST_FUNCTION_PREFIX = "test_"
+
+
+def required_parameters(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Parameter names pytest would have to supply as fixtures.
+
+    Positional and keyword-only parameters **without** a default. ``*args``/``**kwargs`` and
+    defaulted parameters do not make pytest look for a fixture, so they are not reported.
+    """
+    args = func.args
+    positional = args.posonlyargs + args.args
+    without_default = positional[: len(positional) - len(args.defaults)]
+    kwonly = [
+        arg
+        for arg, default in zip(args.kwonlyargs, args.kw_defaults)
+        if default is None
+    ]
+    return [arg.arg for arg in without_default + kwonly]
+
+
+def fixture_requesting_test_functions(path: Path) -> list[tuple[str, list[str]]]:
+    """``(function name, required parameters)`` for every collection error in one module."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    offenders: list[tuple[str, list[str]]] = []
+    for node in tree.body:  # module level only: methods on a TestCase take self legitimately
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.name.startswith(PYTEST_FUNCTION_PREFIX):
+            continue
+        params = required_parameters(node)
+        if params:
+            offenders.append((node.name, params))
+    return offenders
+
+
+class TestEveryTestModuleIsCollectable(unittest.TestCase):
+    """No module-level ``test_*`` function takes an argument pytest would call a fixture."""
+
+    def test_the_suites_are_found(self) -> None:
+        """A vacuous pass is the one failure mode this check cannot report on its own."""
+        modules = sorted(TESTS_DIR.glob("test_*.py"))
+        self.assertGreaterEqual(len(modules), 4, f"only found {[m.name for m in modules]}")
+        self.assertIn("test_decomposer_conditions.py", [m.name for m in modules])
+
+    def test_no_test_function_requests_a_fixture(self) -> None:
+        offenders = {
+            path.name: found
+            for path in sorted(TESTS_DIR.glob("test_*.py"))
+            if (found := fixture_requesting_test_functions(path))
+        }
+        self.assertEqual(
+            offenders,
+            {},
+            "these module-level test_* functions take arguments, so pytest will treat them as "
+            "fixture requests and report collection errors (PR #21 review, M-3): "
+            f"{offenders}. A harness function that takes a config belongs under a check_* "
+            "name, called from the module's own main().",
+        )
+
+    def test_the_rule_catches_the_shape_it_is_meant_to(self) -> None:
+        """Hand-computed: the M-3 shape is caught, the legitimate shapes are not."""
+        source = (
+            "def test_broken(cfg):\n    pass\n"
+            "def test_also_broken(a, b=1, *args, **kw):\n    pass\n"
+            "def test_kwonly_broken(*, cfg):\n    pass\n"
+            "def test_fine():\n    pass\n"
+            "def test_defaulted_is_fine(cfg=None):\n    pass\n"
+            "def check_helper(cfg):\n    pass\n"
+            "class T:\n    def test_method(self):\n        pass\n"
+        )
+        path = TESTS_DIR / "_collectability_probe.py"
+        path.write_text(source, encoding="utf-8")
+        try:
+            found = fixture_requesting_test_functions(path)
+        finally:
+            path.unlink()
+        self.assertEqual(
+            found,
+            [
+                ("test_broken", ["cfg"]),
+                ("test_also_broken", ["a"]),
+                ("test_kwonly_broken", ["cfg"]),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Refs #13, refs #12

The two Important findings from the PR #24 re-review, required before the exp-001 adapter is evaluated:
- **Prompt-parity guard covering `--guided`**: an adapter run whose `guided`/`prompt_file`/`prompt_style`/`few_shot_examples_in_prompt` (and, when recorded, `prompt_sha256`) differ from the adapter's training record is refused before any model loads. Ground truth: `training_provenance.json` written by `train_lora.py` into the adapter dir (validated: `script == train_lora.py` + model_id cross-checked against `adapter_config.json`), falling back to the sibling training snapshot — the already-trained exp-001 adapter passes without retraining. Override: `--adapter-prompt-mismatch-i-know`, recorded in snapshot and metrics.
- **`attach_adapter` asserts the adapter's recorded base model** against the run's `model_id` (SystemExit on mismatch/missing).

Plus the PR #21 final-review minors: config snapshot's `retrieval.input` records the config's literal value (resolved path stays in `input_resolved`); the five cfg-taking harness functions renamed so `pytest tests/` is green (153 passed, 0 errors, was 5 collection errors), with a new AST regression guard (`tests/test_suite_collectability.py`); `few_shot_exemplar_hop_count` now in metrics.json; compare-script docstring and cost-column definitions corrected.

Gate 1: initial review (no Critical, 1 Important + minors) → fix pass `07ac0a25` → delta re-review **PASS** (all probes re-run against the real exp-001 adapter; counts: 261 harness checks, 116 LoRA tests, 153 pytest, smoke 33/33 with 0 GPU MiB).

ADR 0012 amendment (the recording debt both review passes flagged) follows as a docs commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)