### PR TITLE
Significance battery over v1's masking and retrieval comparisons (Refs #6)

### DIFF
--- a/docs/adr/0005-seed-before-sampling-v1-sampled-results-not-reproducible.md
+++ b/docs/adr/0005-seed-before-sampling-v1-sampled-results-not-reproducible.md
@@ -3,6 +3,8 @@
 - **Status**: Accepted
 - **Date**: 2026-08-12
 
+*(Amended 2026-08-20 by [0020](./0020-prior-work-re-analysis-convention.md): v1 runs remain non-reproducible, but their surviving per-item artifacts may be re-analyzed as prior work under that ADR's conditions.)*
+
 ## Context
 
 During the v1→v2 port (PR #7, issue #3), the ml-engineer found and the independent review confirmed a v1 reproducibility bug: v1's router runners called `random.sample` on their evaluation questions **before** calling `set_seed`. All ten per-model copies of `router.py` carry the bug (verified in review); line numbers cited from `components/router/models/qwen2_5_0_5b/router.py` — sampling at lines 181–183, `set_seed` at line 217. Any v1 router result produced with `--sample_size` therefore used an unseeded draw — the sampled subset was never reproducible, in v1 or anywhere else. v2's operating contract (CLAUDE.md, Reproducibility) requires fixed seeds threaded through all randomness, and ADR [0001](./0001-v1-to-v2-migration-scope-and-method.md) governs how v1 results may be compared against.

--- a/docs/adr/0011-comparison-artifact-conventions-and-the-significance-claim-floor.md
+++ b/docs/adr/0011-comparison-artifact-conventions-and-the-significance-claim-floor.md
@@ -5,6 +5,8 @@
 
 Amends [0009](./0009-paired-bootstrap-and-mcnemar-as-the-significance-protocol.md) (the significance protocol of record) with three conventions established by PR #22 (issue #20 hardening). PR #22's Gate-1 review found the conventions sound but unrecorded; this ADR is that record. None of these came from the supervisor.
 
+*(Amended 2026-08-20 by [0020](./0020-prior-work-re-analysis-convention.md): analysis notes reporting a statistics battery carry a machine-readable JSON companion beside the note.)*
+
 ## Context
 
 PR #22 hardened `--compare` in `scripts/musique_decompositions_evaluator.py`. Three of its choices are protocol-shaped — they will appear in every run's config snapshot and every comparison output, and in November they would read as settled decisions unless their provenance is recorded.

--- a/docs/adr/0020-prior-work-re-analysis-convention.md
+++ b/docs/adr/0020-prior-work-re-analysis-convention.md
@@ -1,0 +1,52 @@
+# 0020. Prior-Work Re-Analysis Convention
+
+- **Status**: Accepted
+- **Date**: 2026-08-20
+
+Amends [0005](./0005-seed-before-sampling-v1-sampled-results-not-reproducible.md) (v1
+results stay non-reproducible as *runs*; their surviving per-item artifacts may still be
+re-analyzed) and [0011](./0011-comparison-artifact-conventions-and-the-significance-claim-floor.md)
+(analysis notes reporting a statistics battery carry a machine-readable companion).
+
+## Context
+
+The first re-analysis of v1 artifacts under v2's statistical protocol
+(`docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md`, PR #33, analyst lane
+approved by Jahid 2026-08-20) established a method its Gate-1 review found sound but
+unrecorded, and warned would read as settled in November unless written down. This is that
+record. The method will recur (the note's own §7.6 anticipates follow-ups).
+
+## Decision
+
+v1 per-item artifacts **may** be re-analyzed with v2's committed statistical protocol
+(ADR 0009 as amended), under all of the following:
+
+1. **v1 stays read-only** — nothing in `/cta/users/fyilmaz/Thesis---QA` is modified.
+2. **Inputs are pinned by content**: sha256 (+ mtime) of every input file is recorded in
+   the note, since v1 artifacts carry no commit SHA.
+3. **Alignment is stated**: how per-item rows of the compared runs were paired (key and
+   order), because bootstrap CI digits are alignment-dependent in the 3rd–4th decimal.
+4. **A machine-readable JSON companion** sits beside the note carrying every reported
+   statistic and the inputs' hashes — statistics only, never dataset content.
+5. **The no-SHA caveat leads the note**: results are citable *prior work*, never v2
+   measurements; Gate 2 is not satisfied; no `experiments/log.md` entry exists because
+   nothing was run.
+6. **Findings are options, not decisions** — imperative recommendations are recast as
+   conditionals; which baselines the thesis leans on stays Jahid's call with his
+   supervisor.
+
+## Consequences
+
+v1's measured comparisons become statistically characterizable without pretending they are
+v2 evidence. The one open gap is re-derivability from committed code: until a `--compare`
+shim accepts v1-format per-item files (note §7.6(b), unscheduled), the JSON is the
+verifiable artifact and independent recomputation is the check — as performed by the PR #33
+review.
+
+## Alternatives considered
+
+- Forbidding any use of v1 numbers — loses real, per-item-verifiable evidence that directly
+  informs open decisions (masking default, CE, primary metric).
+- Re-running the comparisons in v2 — the right long-term answer where they matter, but GPU
+  time is contended and several v1 questions (e.g. typed vs uniform) need larger n than a
+  re-run would grant anyway.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,6 +45,7 @@ When **not** to write one:
 | [0017](./0017-triage-of-the-2026-08-12-transcript-cross-check.md) | Triage of the 2026-08-12 Transcript Cross-Check | Accepted (Jahid, 2026-08-20) |
 | [0018](./0018-resolve-the-carried-v1-research-decisions.md) | Resolve the Carried v1 Research Decisions | Accepted (Jahid, 2026-08-20; embedding model pending supervisor confirmation) |
 | [0019](./0019-musique-answering-backend-conventions.md) | MuSiQue Answering-Backend Conventions: Reader, Context and Scoring | Accepted (Jahid, 2026-08-20, in session; pending supervisor confirmation) |
+| [0020](./0020-prior-work-re-analysis-convention.md) | Prior-Work Re-Analysis Convention | Accepted |
 
 ---
 

--- a/docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.json
+++ b/docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.json
@@ -1,0 +1,10764 @@
+{
+ "schema": "v1-significance-analysis/1",
+ "companion_note": "docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md",
+ "generated_utc": "2026-08-20T08:06:29Z",
+ "contents": "statistics only \u2014 no dataset content (no questions, no steps, no predictions)",
+ "prior_work_caveat": "Every input is a v1 artifact from /cta/users/fyilmaz/Thesis---QA (read-only, unmodified). v1's runs/ is gitignored and untracked (git ls-files runs/ returns 0), so these per-item files carry no commit SHA (ADR 0005 context). These are citable prior-work results, not v2 experimental claims, and satisfy no part of Gate 2. No experiment was run, so there is no experiments/log.md entry.",
+ "protocol": {
+  "source_of_truth": "scripts/musique_decompositions_evaluator.py --compare (v2, committed); ADR 0009 as amended 2026-08-20 (bootstrap + exact McNemar, paired t-test alongside per issue #30)",
+  "bootstrap_iterations": 10000,
+  "bootstrap_chunk_size": 1000,
+  "alpha": 0.05,
+  "seed": 42,
+  "rng": "numpy.random.default_rng, one index matrix applied to both systems",
+  "confidence_interval": "percentile interval of (system_a - system_b)",
+  "per_stratum_seeding": "each per-hop stratum bootstraps its own subset with the same seed",
+  "composite_score_weights": {
+   "step_f1_macro": 0.4,
+   "ordered_step_accuracy_macro": 0.3,
+   "reference_validity_micro": 0.2,
+   "step_count_error": 0.1
+  },
+  "composite_step_count_error_scale": 3.0,
+  "composite_weights_identical_in_v1": "Thesis---QA/scripts/musique_decompositions_evaluator.py:411-416",
+  "composite_no_ref_renorm": {
+   "what": "diagnostic constructed for this note, NOT a house metric: the composite with the reference_validity_micro term dropped and the remaining weights renormalized to sum to 1",
+   "weights": {
+    "step_f1_macro": 0.5,
+    "ordered_step_accuracy_macro": 0.37499999999999994,
+    "step_count_error": 0.125
+   }
+  },
+  "paired_t_test": "scipy.stats.ttest_rel (scipy 1.17.1)",
+  "exact_mcnemar": "two-sided exact binomial on discordant pairs, v2's _mcnemar_exact_p (integer arithmetic; b+c=0 => p=1.0)",
+  "power_calculation": "paired, alpha two-sided + 80% power: mde = z * sd(diff) / sqrt(n), n_needed = ceil((z * sd(diff) / observed_diff)^2), z = 2.801585 = norm.ppf(1-alpha/2) + norm.ppf(0.80)",
+  "multiple_comparison_correction": "none in the headline (ADR 0009); Holm-Bonferroni reported separately per stated family",
+  "numpy_version": "2.4.1",
+  "python": "3.13.9",
+  "harness": "session-local; imports v2's _paired_bootstrap / _statistic_arrays / _mcnemar_exact_p and re-implements only the alignment step. Not committed (analyst output is analysis, not code) \u2014 see the note's recommendation 6(b).",
+  "validated_bit_identical_against_v2_paired_bootstrap": {
+   "statistics_checked": [
+    "rouge_l_f1",
+    "step_f1",
+    "ordered_step_accuracy",
+    "composite_score"
+   ],
+   "fields_checked": [
+    "difference",
+    "ci_low",
+    "ci_high"
+   ],
+   "tolerance": "abs_tol=0 (exact equality)",
+   "task_a_pair_ok": true,
+   "task_b_pair_ok": true
+  },
+  "independently_recomputed_in_review": "PR #33 delta review at 74b82cb recomputed this battery and reproduced it; the review's only statistical finding was the 4th-decimal row-order dependence of the CI bounds, recorded under task_a.row_order_sensitivity"
+ },
+ "inputs": {
+  "v1_repo": "/cta/users/fyilmaz/Thesis---QA",
+  "v1_head_commit": "a020fd6",
+  "v1_head_does_not_pin_these_files": "runs/ is gitignored and untracked in v1; git ls-files runs/ returns 0 files",
+  "task_a_masking": {
+   "typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/musique_decomposition_eval/eval_typed_unguided_per_item.json",
+    "sha256": "53ab0a08f380db9ae29dc1b4212f7e9141b5da64f98c95fb506d1a524be0aeea",
+    "mtime_utc": "2026-04-13T10:07:57Z"
+   },
+   "uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/musique_decomposition_eval/eval_uniform_unguided_per_item.json",
+    "sha256": "a0348260dd4a7d737504dee86f5316e3c8ca50d86791200421499da62904650a",
+    "mtime_utc": "2026-04-13T10:08:14Z"
+   },
+   "raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/musique_decomposition_eval/eval_raw_unguided_per_item.json",
+    "sha256": "80e64a38b7934c52afe52ff84ac6da3086f2938e5ebf836a366793ef9050f07f",
+    "mtime_utc": "2026-04-13T10:07:52Z"
+   }
+  },
+  "task_a_predictions_paths_from_v1_eval_configs": {
+   "typed": "runs/decomposer_raw_unguided/typed/results.json",
+   "uniform": "runs/decomposer_raw_unguided/masked/results.json",
+   "raw": "runs/decomposer_raw_unguided/raw/results.json"
+  },
+  "task_b_pool_sweep": {
+   "size1000_balanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "ee64da7b422fb297e5c38cfdd00b1fad82b937158d1683958124e3dc03fd21cc",
+    "mtime_utc": "2026-04-20T18:24:03Z"
+   },
+   "size1000_balanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "43231fdbb102fbb90ac71b544a1917e02f0ae6877d6fe7f0c980d3fbe02344ba",
+    "mtime_utc": "2026-04-20T18:49:53Z"
+   },
+   "size1000_balanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "5792aa706a922eb09ed96a793debb1cff8caa8d2846c314bd8e22bfc414116e7",
+    "mtime_utc": "2026-04-20T19:16:08Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "2e5530974c1e5d62b135ac21ca4b742a06e1b1a3f795ab89f5e042a04aee2c3c",
+    "mtime_utc": "2026-04-20T19:41:03Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "f911796f96a4851ca0508b49b692fe27bea52bb6723913f2dbc73734644c58ae",
+    "mtime_utc": "2026-04-20T20:05:27Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "4c3fc18b7138f33a8c10997b44b0f9d408f6f7bd8c091c6441728163aee5ac23",
+    "mtime_utc": "2026-04-20T20:30:46Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "7144c097bfe47250c5f538b176bbc543606bc4eddc89d1f7cc0cfb16f8b8f523",
+    "mtime_utc": "2026-04-20T02:32:52Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "e353c76ae359e8ad3af38ab279e00c0c5d3edb151994b461332a86b90ef7fbf1",
+    "mtime_utc": "2026-04-20T02:58:15Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "9547be04e6eae412fdd3eb4aee6872a9e64c00c47e2d39910909e414eea79069",
+    "mtime_utc": "2026-04-20T02:05:33Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "648a213520d07dfbc4a84d8960e43de8a10882e5fa62c6f34ee15469823d8269",
+    "mtime_utc": "2026-04-20T03:23:36Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "bd2f1d6fd49901bcb9e2d3bff0c3ca0556aa2ebf641317d5eb696115f2f2baac",
+    "mtime_utc": "2026-04-20T03:47:31Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "c1e6f975938596db9f7b3d14222110ee7466defb3ba5dc2a7d5759e7fe79cab6",
+    "mtime_utc": "2026-04-20T04:12:07Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "70e58b63076cd33dc16df27f9a9046d8971bf9b59cce2830a12023eb62248415",
+    "mtime_utc": "2026-04-20T20:57:38Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "5fad3c5f009ec09a0a556b32b18766f4ed4fe84ac0d20c6f43f7bdc9a082fcac",
+    "mtime_utc": "2026-04-20T21:24:18Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "dc5abb6406e03bff23fa8fcbd26b155af11e9195fd399f152db84d6764cfccfc",
+    "mtime_utc": "2026-04-20T21:51:10Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "b2bfd5eda5d8a721d860f0b8969cee0da0ea572f9460a2e37a6730f28b574cb0",
+    "mtime_utc": "2026-04-20T04:37:19Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "b054f418dd52ba3484d44b45f123468026aafc4aa7c2714d780bf833fbed4ec3",
+    "mtime_utc": "2026-04-20T05:02:19Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "543f4cfc77c7863ab3afcee8ca0429012dcb61d9d2d710b8babe2d673d17f707",
+    "mtime_utc": "2026-04-20T05:27:50Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "e06ffc80a9c15be24ff7248712787292aba2809c4160b3af92d4543e4c0a1665",
+    "mtime_utc": "2026-04-20T05:53:28Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "fd64acc34395a0434b9c95fe3c9fa513ca923b66afdd270b1099969cba738f0e",
+    "mtime_utc": "2026-04-20T06:17:55Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "21fd8dd22295ddbead1f298aa5cf58e55174590de7c92fb9c2fce04bd048a18b",
+    "mtime_utc": "2026-04-20T06:42:23Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "a53aabd9f3ccb6a9107d64463533443d01fe33cb74786efb2d116635ae2a72bb",
+    "mtime_utc": "2026-04-20T07:07:32Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "3a0fb90b6f0c1ed798cf0c4aa0d121ce68b7c8d57ee28ca61727cd27c7ab62ce",
+    "mtime_utc": "2026-04-20T07:33:32Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "6ac7af550531c9a1d887d3049e6f6c13d088ccf8d8ced0abc9b200d5af1ed684",
+    "mtime_utc": "2026-04-20T07:58:55Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "1ab9623bce72b4b2f7e04f09f719dae0093087008074ffc6b56c22cc5e0c2a55",
+    "mtime_utc": "2026-04-20T08:23:25Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "5444b2e2a60e701598d5d6c67344873e0d729033cf8fb46452b0612dc1fc8af9",
+    "mtime_utc": "2026-04-20T08:48:29Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "18451b8cfe7b1f74f07c85b1f7e73e6af56b07a0ebd19f1214f03f855912d3a0",
+    "mtime_utc": "2026-04-20T09:12:47Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "0c5bf23b087a077102313430b2fc85cc9c9adf615b3bcee58ac7887a4202c60c",
+    "mtime_utc": "2026-04-20T09:38:25Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "2a2dd118ee3293408d0d1ce2e3a848cebc044c98463bec9dd3a01c6a9a1929c0",
+    "mtime_utc": "2026-04-20T10:04:36Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "18fcac5e02139f6047f0922ae39924b97b75de063deee10cf21f71b99a9c326f",
+    "mtime_utc": "2026-04-20T10:29:56Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "fb5399e1ddc2d4e71bf627eddca8616aa2436869734e99e37478a0db0e6e417f",
+    "mtime_utc": "2026-04-20T10:54:19Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "a0df3f17bbd7dc2f716494736919e7c02181e5a688a69f222a1cd974781d1980",
+    "mtime_utc": "2026-04-20T11:19:06Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "c5ccdb504f2398e9368506b9bce5f248dac63f3996690589750526f7e0d279f8",
+    "mtime_utc": "2026-04-20T11:44:19Z"
+   }
+  },
+  "task_b_aggregate_csv_not_used_for_any_statistic": {
+   "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/summary/all_runs.csv",
+   "sha256": "89c5e923ddbb2a8737c12bda160e12b7df7d4f1ed7add3767604b6419ba51e6e"
+  }
+ },
+ "task_a_masking": {
+  "alignment": {
+   "key": "normalized question text (strip, lowercase, collapse whitespace)",
+   "order": "sorted by the normalized question text",
+   "why_not_item_id": "v1 per-item files are bare JSON lists with no item_id and no stamped composite weights, so v2's --compare refuses them",
+   "rows_per_file": {
+    "typed": 600,
+    "uniform": 600,
+    "raw": 600
+   },
+   "distinct_normalized_questions_per_file": {
+    "typed": 600,
+    "uniform": 600,
+    "raw": 600
+   },
+   "item_sets_identical_across_all_three": true,
+   "aligned_n": 600,
+   "intersection_fallback_used": false,
+   "gold_identical_across_files": true,
+   "gold_hop_distribution": {
+    "2": 200,
+    "3": 200,
+    "4": 200
+   }
+  },
+  "aggregate_crosscheck_against_committed_v1_metrics": {
+   "typed": {
+    "committed_v1_metrics_file": "/cta/users/fyilmaz/Thesis---QA/runs/musique_decomposition_eval/eval_typed_unguided_metrics.json",
+    "recomputed_vs_file": {
+     "exact_match": {
+      "recomputed": 0.058333333333333334,
+      "in_file": 0.058333333333333334
+     },
+     "step_f1": {
+      "recomputed": 0.2006292596292596,
+      "in_file": 0.20062925962925993
+     },
+     "ordered_step_accuracy": {
+      "recomputed": 0.17938217338217338,
+      "in_file": 0.17938217338217338
+     },
+     "rouge_l_f1": {
+      "recomputed": 0.5441600102676278,
+      "in_file": 0.5441600102676277
+     },
+     "hop_count_exact_match": {
+      "recomputed": 0.5216666666666666,
+      "in_file": 0.5216666666666666
+     },
+     "composite_score": {
+      "recomputed": 0.3606219114219114,
+      "in_file": 0.3606219114219115
+     },
+     "reference_validity_micro": {
+      "recomputed": 0.75,
+      "in_file": 0.75
+     },
+     "step_count_abs_error_mae": {
+      "recomputed": 0.7033333333333334,
+      "in_file": 0.7033333333333334
+     }
+    },
+    "max_abs_delta": 3.3306690738754696e-16
+   },
+   "uniform": {
+    "committed_v1_metrics_file": "/cta/users/fyilmaz/Thesis---QA/runs/musique_decomposition_eval/eval_uniform_unguided_metrics.json",
+    "recomputed_vs_file": {
+     "exact_match": {
+      "recomputed": 0.055,
+      "in_file": 0.055
+     },
+     "step_f1": {
+      "recomputed": 0.1895677008177008,
+      "in_file": 0.18956770081770102
+     },
+     "ordered_step_accuracy": {
+      "recomputed": 0.16621031746031747,
+      "in_file": 0.1662103174603174
+     },
+     "rouge_l_f1": {
+      "recomputed": 0.543078832255379,
+      "in_file": 0.5430788322553788
+     },
+     "hop_count_exact_match": {
+      "recomputed": 0.505,
+      "in_file": 0.505
+     },
+     "composite_score": {
+      "recomputed": 0.3553568422318423,
+      "in_file": 0.3553568422318423
+     },
+     "reference_validity_micro": {
+      "recomputed": 0.7777777777777778,
+      "in_file": 0.7777777777777778
+     },
+     "step_count_abs_error_mae": {
+      "recomputed": 0.7766666666666666,
+      "in_file": 0.7766666666666666
+     }
+    },
+    "max_abs_delta": 2.220446049250313e-16
+   },
+   "raw": {
+    "committed_v1_metrics_file": "/cta/users/fyilmaz/Thesis---QA/runs/musique_decomposition_eval/eval_raw_unguided_metrics.json",
+    "recomputed_vs_file": {
+     "exact_match": {
+      "recomputed": 0.03666666666666667,
+      "in_file": 0.03666666666666667
+     },
+     "step_f1": {
+      "recomputed": 0.17747402597402598,
+      "in_file": 0.17747402597402626
+     },
+     "ordered_step_accuracy": {
+      "recomputed": 0.15811724386724385,
+      "in_file": 0.1581172438672439
+     },
+     "rouge_l_f1": {
+      "recomputed": 0.5315321917101113,
+      "in_file": 0.531532191710111
+     },
+     "hop_count_exact_match": {
+      "recomputed": 0.485,
+      "in_file": 0.485
+     },
+     "composite_score": {
+      "recomputed": 0.18881367243867245,
+      "in_file": 0.18881367243867256
+     },
+     "reference_validity_micro": {
+      "recomputed": 0.0,
+      "in_file": 0.0
+     },
+     "step_count_abs_error_mae": {
+      "recomputed": 0.8883333333333333,
+      "in_file": 0.8883333333333333
+     }
+    },
+    "max_abs_delta": 3.3306690738754696e-16
+   }
+  },
+  "reference_emission": {
+   "typed": {
+    "valid_references": 6,
+    "total_references": 8,
+    "items_emitting_at_least_one_reference": 3,
+    "reference_validity_micro": 0.75,
+    "per_gold_hop": {
+     "2": {
+      "valid_references": 6,
+      "total_references": 6,
+      "items_emitting_at_least_one_reference": 1
+     },
+     "3": {
+      "valid_references": 0,
+      "total_references": 1,
+      "items_emitting_at_least_one_reference": 1
+     },
+     "4": {
+      "valid_references": 0,
+      "total_references": 1,
+      "items_emitting_at_least_one_reference": 1
+     }
+    }
+   },
+   "uniform": {
+    "valid_references": 7,
+    "total_references": 9,
+    "items_emitting_at_least_one_reference": 4,
+    "reference_validity_micro": 0.7777777777777778,
+    "per_gold_hop": {
+     "2": {
+      "valid_references": 0,
+      "total_references": 1,
+      "items_emitting_at_least_one_reference": 1
+     },
+     "3": {
+      "valid_references": 0,
+      "total_references": 1,
+      "items_emitting_at_least_one_reference": 1
+     },
+     "4": {
+      "valid_references": 7,
+      "total_references": 7,
+      "items_emitting_at_least_one_reference": 2
+     }
+    }
+   },
+   "raw": {
+    "valid_references": 0,
+    "total_references": 4,
+    "items_emitting_at_least_one_reference": 1,
+    "reference_validity_micro": 0.0,
+    "per_gold_hop": {
+     "2": {
+      "valid_references": 0,
+      "total_references": 0,
+      "items_emitting_at_least_one_reference": 0
+     },
+     "3": {
+      "valid_references": 0,
+      "total_references": 0,
+      "items_emitting_at_least_one_reference": 0
+     },
+     "4": {
+      "valid_references": 0,
+      "total_references": 4,
+      "items_emitting_at_least_one_reference": 1
+     }
+    }
+   }
+  },
+  "pairs": {
+   "typed_vs_raw": {
+    "system_a": "typed",
+    "system_b": "raw",
+    "overall": {
+     "n": 600,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.058333333333333334,
+       "system_b": 0.03666666666666667,
+       "mean_difference": 0.021666666666666667,
+       "bootstrap_ci_low": 0.003333333333333334,
+       "bootstrap_ci_high": 0.039999999999999994,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.4238264605156536,
+        "dof": 599,
+        "p_value": 0.015653035262437828,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 21,
+        "correct_only_in_b": 8,
+        "discordant_pairs": 29,
+        "p_value": 0.0241195447742939,
+        "significant_at_alpha": true,
+        "min_attainable_p_value": 3.725290298461914e-09
+       },
+       "power": {
+        "sd_of_paired_differences": 0.2189607161438918,
+        "mde_at_this_n_80pct_power": 0.02504346497075561,
+        "n_needed_for_observed_difference_80pct_power": 802
+       }
+      },
+      "step_f1": {
+       "system_a": 0.2006292596292596,
+       "system_b": 0.17747402597402598,
+       "mean_difference": 0.023155233655233615,
+       "bootstrap_ci_low": 0.005252678340178338,
+       "bootstrap_ci_high": 0.041184740259740275,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.545172955023128,
+        "dof": 599,
+        "p_value": 0.011171962703556648,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.22284735981617115,
+        "mde_at_this_n_80pct_power": 0.025487996877550125,
+        "n_needed_for_observed_difference_80pct_power": 727
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.17938217338217338,
+       "system_b": 0.15811724386724385,
+       "mean_difference": 0.02126492951492953,
+       "bootstrap_ci_low": 0.003866287878787891,
+       "bootstrap_ci_high": 0.03875723651348651,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.385010052361847,
+        "dof": 599,
+        "p_value": 0.017388672230834314,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.21839835298071278,
+        "mde_at_this_n_80pct_power": 0.024979145112719238,
+        "n_needed_for_observed_difference_80pct_power": 828
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5441600102676278,
+       "system_b": 0.5315321917101113,
+       "mean_difference": 0.01262781855751649,
+       "bootstrap_ci_low": 0.00014485478537320566,
+       "bootstrap_ci_high": 0.025011834888883314,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 1.9969794035396755,
+        "dof": 599,
+        "p_value": 0.04627939773474908,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.15489249401139038,
+        "mde_at_this_n_80pct_power": 0.017715710910710038,
+        "n_needed_for_observed_difference_80pct_power": 1181
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5216666666666666,
+       "system_b": 0.485,
+       "mean_difference": 0.036666666666666625,
+       "bootstrap_ci_low": -0.008333333333333304,
+       "bootstrap_ci_high": 0.08166666666666672,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.5897326517723105,
+        "dof": 599,
+        "p_value": 0.11242270585571894,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 107,
+        "correct_only_in_b": 85,
+        "discordant_pairs": 192,
+        "p_value": 0.1294189315157586,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 3.1861838222649046e-58
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5649668439653687,
+        "mde_at_this_n_80pct_power": 0.06461765204123242,
+        "n_needed_for_observed_difference_80pct_power": 1864
+       }
+      },
+      "composite_score": {
+       "system_a": 0.3606219114219114,
+       "system_b": 0.18881367243867245,
+       "mean_difference": 0.17180823898323896,
+       "bootstrap_ci_low": -0.18418214671902178,
+       "bootstrap_ci_high": 0.2259290978465979,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.26327738927738925,
+       "system_b": 0.23601709054834058,
+       "mean_difference": 0.02726029872904867,
+       "bootstrap_ci_low": 0.01068906452343951,
+       "bootstrap_ci_high": 0.04399674119283491,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.75,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.7655555555555555,
+      "b_step_count_term": 0.7038888888888889,
+      "a_mae": 0.7033333333333334,
+      "b_mae": 0.8883333333333333
+     },
+     "composite_difference_decomposition": {
+      "total": 0.17180823898323896,
+      "contributions": {
+       "w_step_f1_x_delta": 0.009262093462093446,
+       "w_ordered_x_delta": 0.006379478854478859,
+       "w_reference_micro_x_delta": 0.15000000000000002,
+       "w_step_count_x_delta": 0.006166666666666665
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.05390948371804815,
+       "w_ordered_x_delta": 0.03713139074256631,
+       "w_reference_micro_x_delta": 0.8730663959289724,
+       "w_step_count_x_delta": 0.035892729610413295
+      },
+      "sum_of_contributions_check": 0.171808238983239
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.125,
+        "system_b": 0.095,
+        "mean_difference": 0.03,
+        "bootstrap_ci_low": -0.010000000000000009,
+        "bootstrap_ci_high": 0.07,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4177803109441924,
+         "dof": 199,
+         "p_value": 0.15781883619217793,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 12,
+         "correct_only_in_b": 6,
+         "discordant_pairs": 18,
+         "p_value": 0.237884521484375,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 7.62939453125e-06
+        }
+       },
+       "step_f1": {
+        "system_a": 0.32183333333333336,
+        "system_b": 0.2821666666666667,
+        "mean_difference": 0.03966666666666668,
+        "bootstrap_ci_low": 0.0008333333333333526,
+        "bootstrap_ci_high": 0.07850416666666662,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.012856230728259,
+         "dof": 199,
+         "p_value": 0.04547735293337435,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.31166666666666665,
+        "system_b": 0.2725,
+        "mean_difference": 0.03916666666666663,
+        "bootstrap_ci_low": -0.0004166666666667318,
+        "bootstrap_ci_high": 0.07916666666666669,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.9334696279585744,
+         "dof": 199,
+         "p_value": 0.054597178029208944,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6215416928091033,
+        "system_b": 0.6031964480753375,
+        "mean_difference": 0.018345244733765864,
+        "bootstrap_ci_low": -0.007049124714867475,
+        "bootstrap_ci_high": 0.04363785359235165,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4089193318353659,
+         "dof": 199,
+         "p_value": 0.16041963766990355,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.72,
+        "system_b": 0.68,
+        "mean_difference": 0.039999999999999925,
+        "bootstrap_ci_low": -0.030000000000000027,
+        "bootstrap_ci_high": 0.10999999999999999,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.1100442074146692,
+         "dof": 199,
+         "p_value": 0.2683195101650251,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 30,
+         "correct_only_in_b": 22,
+         "discordant_pairs": 52,
+         "p_value": 0.3317497633694906,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 4.440892098500626e-16
+        }
+       },
+       "composite_score": {
+        "system_a": 0.5084,
+        "system_b": 0.4786166666666667,
+        "mean_difference": 0.029783333333333273,
+        "bootstrap_ci_low": 0.0008908333333333456,
+        "bootstrap_ci_high": 0.058809166666666565,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.38550000000000006,
+        "system_b": 0.34827083333333336,
+        "mean_difference": 0.0372291666666667,
+        "bootstrap_ci_low": 0.0011135416666666976,
+        "bootstrap_ci_high": 0.0735114583333333,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8616666666666667,
+       "b_step_count_term": 0.84,
+       "a_mae": 0.415,
+       "b_mae": 0.48
+      }
+     },
+     "3": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.025,
+        "system_b": 0.01,
+        "mean_difference": 0.015000000000000001,
+        "bootstrap_ci_low": -0.01,
+        "bootstrap_ci_high": 0.04,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.1347082904365042,
+         "dof": 199,
+         "p_value": 0.25786249432572356,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 5,
+         "correct_only_in_b": 2,
+         "discordant_pairs": 7,
+         "p_value": 0.453125,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.015625
+        }
+       },
+       "step_f1": {
+        "system_a": 0.17111507936507933,
+        "system_b": 0.14705555555555555,
+        "mean_difference": 0.02405952380952378,
+        "bootstrap_ci_low": -0.00028303571428570323,
+        "bootstrap_ci_high": 0.0489612103174603,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.902980197300296,
+         "dof": 199,
+         "p_value": 0.05848668602360651,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.14475,
+        "system_b": 0.11933333333333333,
+        "mean_difference": 0.025416666666666657,
+        "bootstrap_ci_low": 0.002500000000000002,
+        "bootstrap_ci_high": 0.04916666666666668,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.11520974178488,
+         "dof": 199,
+         "p_value": 0.035656124386035166,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5372125249640507,
+        "system_b": 0.5187015825981122,
+        "mean_difference": 0.018510942365938532,
+        "bootstrap_ci_low": -0.0009333944981920383,
+        "bootstrap_ci_high": 0.037647931189265654,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.8643910699310036,
+         "dof": 199,
+         "p_value": 0.06373936011393627,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.525,
+        "system_b": 0.49,
+        "mean_difference": 0.03500000000000003,
+        "bootstrap_ci_low": -0.04500000000000004,
+        "bootstrap_ci_high": 0.11500000000000005,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.842087919743017,
+         "dof": 199,
+         "p_value": 0.4007496085879682,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 38,
+         "correct_only_in_b": 31,
+         "discordant_pairs": 69,
+         "p_value": 0.4703685318581444,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.3881317890172014e-21
+        }
+       },
+       "composite_score": {
+        "system_a": 0.18787103174603176,
+        "system_b": 0.3647888888888889,
+        "mean_difference": -0.17691785714285713,
+        "bootstrap_ci_low": -0.19342791666666664,
+        "bootstrap_ci_high": 0.037942222222222204,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2348387896825397,
+        "system_b": 0.20598611111111112,
+        "mean_difference": 0.02885267857142859,
+        "bootstrap_ci_low": 0.005639074900793679,
+        "bootstrap_ci_high": 0.05209882192460318,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.76,
+       "b_step_count_term": 0.7016666666666667,
+       "a_mae": 0.72,
+       "b_mae": 0.895
+      }
+     },
+     "4": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.025,
+        "system_b": 0.005,
+        "mean_difference": 0.02,
+        "bootstrap_ci_low": 0.004999999999999999,
+        "bootstrap_ci_high": 0.04,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.0152479970951265,
+         "dof": 199,
+         "p_value": 0.04522398498260695,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 4,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 4,
+         "p_value": 0.125,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.125
+        }
+       },
+       "step_f1": {
+        "system_a": 0.10893936618936621,
+        "system_b": 0.1031998556998557,
+        "mean_difference": 0.005739510489510519,
+        "bootstrap_ci_low": -0.021648412698412698,
+        "bootstrap_ci_high": 0.034214192057942065,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.40963937335638356,
+         "dof": 199,
+         "p_value": 0.682511110855222,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08172985347985348,
+        "system_b": 0.08251839826839825,
+        "mean_difference": -0.0007885447885447733,
+        "bootstrap_ci_low": -0.024928409090909095,
+        "bootstrap_ci_high": 0.02461807359307358,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.0625392359228281,
+         "dof": 199,
+         "p_value": 0.950196187053987,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.47372581302972966,
+        "system_b": 0.47269854445688436,
+        "mean_difference": 0.0010272685728452968,
+        "bootstrap_ci_low": -0.017908728201471814,
+        "bootstrap_ci_high": 0.019682311830897786,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.10713116052061337,
+         "dof": 199,
+         "p_value": 0.9147928538453274,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.32,
+        "system_b": 0.285,
+        "mean_difference": 0.03500000000000003,
+        "bootstrap_ci_low": -0.04999999999999999,
+        "bootstrap_ci_high": 0.11500000000000002,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.8301011446775782,
+         "dof": 199,
+         "p_value": 0.40747632208272955,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 39,
+         "correct_only_in_b": 32,
+         "discordant_pairs": 71,
+         "p_value": 0.4766877934342755,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 8.470329472543003e-22
+        }
+       },
+       "composite_score": {
+        "system_a": 0.13559470251970254,
+        "system_b": 0.12303546176046176,
+        "mean_difference": 0.01255924075924078,
+        "bootstrap_ci_low": -0.2030542977855478,
+        "bootstrap_ci_high": 0.22680079496892003,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1694933781496282,
+        "system_b": 0.1537943272005772,
+        "mean_difference": 0.015699050949050997,
+        "bootstrap_ci_low": -0.009817718913031457,
+        "bootstrap_ci_high": 0.04203268554362307,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.675,
+       "b_step_count_term": 0.5700000000000001,
+       "a_mae": 0.975,
+       "b_mae": 1.29
+      }
+     }
+    }
+   },
+   "typed_vs_uniform": {
+    "system_a": "typed",
+    "system_b": "uniform",
+    "overall": {
+     "n": 600,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.058333333333333334,
+       "system_b": 0.055,
+       "mean_difference": 0.003333333333333334,
+       "bootstrap_ci_low": -0.013333333333333336,
+       "bootstrap_ci_high": 0.020000000000000004,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.3776943375562478,
+        "dof": 599,
+        "p_value": 0.7057914665452403,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 15,
+        "correct_only_in_b": 13,
+        "discordant_pairs": 28,
+        "p_value": 0.8505540192127228,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 7.450580596923828e-09
+       },
+       "power": {
+        "sd_of_paired_differences": 0.21617919564550794,
+        "mde_at_this_n_80pct_power": 0.024725330684416603,
+        "n_needed_for_observed_difference_80pct_power": 33013
+       }
+      },
+      "step_f1": {
+       "system_a": 0.2006292596292596,
+       "system_b": 0.1895677008177008,
+       "mean_difference": 0.011061558811558792,
+       "bootstrap_ci_low": -0.006432865745365737,
+       "bootstrap_ci_high": 0.028965640378140357,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.224763260932191,
+        "dof": 599,
+        "p_value": 0.22114585500400843,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.22122785449559879,
+        "mde_at_this_n_80pct_power": 0.02530276719123939,
+        "n_needed_for_observed_difference_80pct_power": 3140
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.17938217338217338,
+       "system_b": 0.16621031746031747,
+       "mean_difference": 0.013171855921855907,
+       "bootstrap_ci_low": -0.0037811507936507693,
+       "bootstrap_ci_high": 0.03033196733821733,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.5152546980096704,
+        "dof": 599,
+        "p_value": 0.13023541041325412,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.21293005074581878,
+        "mde_at_this_n_80pct_power": 0.02435371221370059,
+        "n_needed_for_observed_difference_80pct_power": 2052
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5441600102676278,
+       "system_b": 0.543078832255379,
+       "mean_difference": 0.001081178012248829,
+       "bootstrap_ci_low": -0.01074709877351861,
+       "bootstrap_ci_high": 0.012668881286306733,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.17782463381224123,
+        "dof": 599,
+        "p_value": 0.8589208189133506,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.14892956022744888,
+        "mde_at_this_n_80pct_power": 0.017033704905381947,
+        "n_needed_for_observed_difference_80pct_power": 148928
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5216666666666666,
+       "system_b": 0.505,
+       "mean_difference": 0.016666666666666607,
+       "bootstrap_ci_low": -0.02833333333333332,
+       "bootstrap_ci_high": 0.06166666666666665,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.7409707013112258,
+        "dof": 599,
+        "p_value": 0.4590015743976261,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 96,
+        "correct_only_in_b": 86,
+        "discordant_pairs": 182,
+        "p_value": 0.5048025229491022,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 3.2626522339992623e-55
+       },
+       "power": {
+        "sd_of_paired_differences": 0.550964147086281,
+        "mde_at_this_n_80pct_power": 0.06301610426150607,
+        "n_needed_for_observed_difference_80pct_power": 8578
+       }
+      },
+      "composite_score": {
+       "system_a": 0.3606219114219114,
+       "system_b": 0.3553568422318423,
+       "mean_difference": 0.005265069190069138,
+       "bootstrap_ci_low": -0.18408572087634584,
+       "bootstrap_ci_high": 0.18678443144818144,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.26327738927738925,
+       "system_b": 0.24975160834535834,
+       "mean_difference": 0.013525780932030912,
+       "bootstrap_ci_low": -0.0029356846856846675,
+       "bootstrap_ci_high": 0.03010549291564918,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.75,
+      "b_ref_micro": 0.7777777777777778,
+      "a_step_count_term": 0.7655555555555555,
+      "b_step_count_term": 0.741111111111111,
+      "a_mae": 0.7033333333333334,
+      "b_mae": 0.7766666666666666
+     },
+     "composite_difference_decomposition": {
+      "total": 0.005265069190069138,
+      "contributions": {
+       "w_step_f1_x_delta": 0.004424623524623516,
+       "w_ordered_x_delta": 0.003951556776556772,
+       "w_reference_micro_x_delta": -0.005555555555555558,
+       "w_step_count_x_delta": 0.002444444444444449
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.8403732913841184,
+       "w_ordered_x_delta": 0.750523237949107,
+       "w_reference_micro_x_delta": -1.0551723738093184,
+       "w_step_count_x_delta": 0.4642758444761008
+      },
+      "sum_of_contributions_check": 0.00526506919006918
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.125,
+        "system_b": 0.135,
+        "mean_difference": -0.010000000000000009,
+        "bootstrap_ci_low": -0.05499999999999999,
+        "bootstrap_ci_high": 0.030000000000000013,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.4704859864053147,
+         "dof": 199,
+         "p_value": 0.6385230949185164,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 8,
+         "correct_only_in_b": 10,
+         "discordant_pairs": 18,
+         "p_value": 0.8145294189453125,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 7.62939453125e-06
+        }
+       },
+       "step_f1": {
+        "system_a": 0.32183333333333336,
+        "system_b": 0.3199444444444445,
+        "mean_difference": 0.0018888888888888844,
+        "bootstrap_ci_low": -0.03505833333333328,
+        "bootstrap_ci_high": 0.038556944444444484,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.100237222320695,
+         "dof": 199,
+         "p_value": 0.9202569069193594,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.31166666666666665,
+        "system_b": 0.3044642857142857,
+        "mean_difference": 0.00720238095238096,
+        "bootstrap_ci_low": -0.030059523809523814,
+        "bootstrap_ci_high": 0.04470238095238094,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.37543045065910735,
+         "dof": 199,
+         "p_value": 0.707740222511433,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6215416928091033,
+        "system_b": 0.6269272630993886,
+        "mean_difference": -0.005385570290285302,
+        "bootstrap_ci_low": -0.03097273924349521,
+        "bootstrap_ci_high": 0.01926780365179554,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.4209551362267203,
+         "dof": 199,
+         "p_value": 0.674242116221066,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.72,
+        "system_b": 0.695,
+        "mean_difference": 0.025000000000000022,
+        "bootstrap_ci_low": -0.040000000000000036,
+        "bootstrap_ci_high": 0.09000000000000008,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.7445250491061522,
+         "dof": 199,
+         "p_value": 0.4574371924746868,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 25,
+         "correct_only_in_b": 20,
+         "discordant_pairs": 45,
+         "p_value": 0.5514843298025198,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 5.684341886080802e-14
+        }
+       },
+       "composite_score": {
+        "system_a": 0.5084,
+        "system_b": 0.3054837301587302,
+        "mean_difference": 0.20291626984126976,
+        "bootstrap_ci_low": -0.02017764880952385,
+        "bootstrap_ci_high": 0.22845736111111117,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.38550000000000006,
+        "system_b": 0.3818546626984128,
+        "mean_difference": 0.0036453373015872814,
+        "bootstrap_ci_low": -0.031636458333333416,
+        "bootstrap_ci_high": 0.03834301835317459,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.8616666666666667,
+       "b_step_count_term": 0.8616666666666667,
+       "a_mae": 0.415,
+       "b_mae": 0.415
+      }
+     },
+     "3": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.025,
+        "system_b": 0.02,
+        "mean_difference": 0.005000000000000001,
+        "bootstrap_ci_low": -0.02,
+        "bootstrap_ci_high": 0.030000000000000002,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.3771530993228165,
+         "dof": 199,
+         "p_value": 0.706461723072912,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 4,
+         "correct_only_in_b": 3,
+         "discordant_pairs": 7,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.015625
+        }
+       },
+       "step_f1": {
+        "system_a": 0.17111507936507933,
+        "system_b": 0.15666269841269842,
+        "mean_difference": 0.014452380952380911,
+        "bootstrap_ci_low": -0.011120238095238088,
+        "bootstrap_ci_high": 0.04054880952380949,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0837440656339785,
+         "dof": 199,
+         "p_value": 0.2797895897721325,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.14475,
+        "system_b": 0.12058333333333332,
+        "mean_difference": 0.02416666666666667,
+        "bootstrap_ci_low": 0.00024791666666664267,
+        "bootstrap_ci_high": 0.04916666666666665,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 1.9196624808843998,
+         "dof": 199,
+         "p_value": 0.05633075420413569,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5372125249640507,
+        "system_b": 0.531595752717047,
+        "mean_difference": 0.005616772247003743,
+        "bootstrap_ci_low": -0.013171432349296118,
+        "bootstrap_ci_high": 0.02482306983150769,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5811376427337467,
+         "dof": 199,
+         "p_value": 0.5618053024977789,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.525,
+        "system_b": 0.495,
+        "mean_difference": 0.030000000000000027,
+        "bootstrap_ci_low": -0.04500000000000004,
+        "bootstrap_ci_high": 0.10500000000000004,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.7738193517659676,
+         "dof": 199,
+         "p_value": 0.4399559269329624,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 33,
+         "correct_only_in_b": 27,
+         "discordant_pairs": 60,
+         "p_value": 0.5189580031896518,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.734723475976807e-18
+        }
+       },
+       "composite_score": {
+        "system_a": 0.18787103174603176,
+        "system_b": 0.1741734126984127,
+        "mean_difference": 0.01369761904761907,
+        "bootstrap_ci_low": -0.005286071428571425,
+        "bootstrap_ci_high": 0.0330227380952381,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2348387896825397,
+        "system_b": 0.2177167658730159,
+        "mean_difference": 0.017122023809523823,
+        "bootstrap_ci_low": -0.006607589285714295,
+        "bootstrap_ci_high": 0.041278422619047676,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.76,
+       "b_step_count_term": 0.7533333333333333,
+       "a_mae": 0.72,
+       "b_mae": 0.74
+      }
+     },
+     "4": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.025,
+        "system_b": 0.01,
+        "mean_difference": 0.015000000000000001,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.034999999999999996,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.740820741142487,
+         "dof": 199,
+         "p_value": 0.08326060366701063,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 3,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 3,
+         "p_value": 0.25,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.25
+        }
+       },
+       "step_f1": {
+        "system_a": 0.10893936618936621,
+        "system_b": 0.0920959595959596,
+        "mean_difference": 0.016843406593406607,
+        "bootstrap_ci_low": -0.010763607226107228,
+        "bootstrap_ci_high": 0.04586794663669664,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.1821882067704081,
+         "dof": 199,
+         "p_value": 0.2385416802078649,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08172985347985348,
+        "system_b": 0.07358333333333333,
+        "mean_difference": 0.008146520146520148,
+        "bootstrap_ci_low": -0.015341575091575091,
+        "bootstrap_ci_high": 0.03398003663003661,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.6544895669853111,
+         "dof": 199,
+         "p_value": 0.5135521553749588,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.47372581302972966,
+        "system_b": 0.47071348094970134,
+        "mean_difference": 0.0030123320800283238,
+        "bootstrap_ci_low": -0.01413541231192965,
+        "bootstrap_ci_high": 0.019817488421869336,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.34465684048302797,
+         "dof": 199,
+         "p_value": 0.7307163386905721,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.32,
+        "system_b": 0.325,
+        "mean_difference": -0.0050000000000000044,
+        "bootstrap_ci_low": -0.09000000000000002,
+        "bootstrap_ci_high": 0.08000000000000002,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.11367900893541068,
+         "dof": 199,
+         "p_value": 0.9096068572664802,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 38,
+         "correct_only_in_b": 39,
+         "discordant_pairs": 77,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.3234889800848443e-23
+        }
+       },
+       "composite_score": {
+        "system_a": 0.13559470251970254,
+        "system_b": 0.3197467171717172,
+        "mean_difference": -0.18415201465201467,
+        "bootstrap_ci_low": -0.20161803515928514,
+        "bootstrap_ci_high": 0.030392206404706364,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1694933781496282,
+        "system_b": 0.1496833964646465,
+        "mean_difference": 0.019809981684981687,
+        "bootstrap_ci_low": -0.005389459412115665,
+        "bootstrap_ci_high": 0.046216216942779456,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.675,
+       "b_step_count_term": 0.6083333333333334,
+       "a_mae": 0.975,
+       "b_mae": 1.175
+      }
+     }
+    }
+   },
+   "uniform_vs_raw": {
+    "system_a": "uniform",
+    "system_b": "raw",
+    "overall": {
+     "n": 600,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.055,
+       "system_b": 0.03666666666666667,
+       "mean_difference": 0.018333333333333333,
+       "bootstrap_ci_low": 0.003333333333333334,
+       "bootstrap_ci_high": 0.03333333333333333,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.409995346534539,
+        "dof": 599,
+        "p_value": 0.016253121490226657,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 16,
+        "correct_only_in_b": 5,
+        "discordant_pairs": 21,
+        "p_value": 0.02660369873046875,
+        "significant_at_alpha": true,
+        "min_attainable_p_value": 9.5367431640625e-07
+       },
+       "power": {
+        "sd_of_paired_differences": 0.18633775378695044,
+        "mde_at_this_n_80pct_power": 0.02131223852330717,
+        "n_needed_for_observed_difference_80pct_power": 811
+       }
+      },
+      "step_f1": {
+       "system_a": 0.1895677008177008,
+       "system_b": 0.17747402597402598,
+       "mean_difference": 0.012093674843674823,
+       "bootstrap_ci_low": -0.0038280002405002315,
+       "bootstrap_ci_high": 0.027879614598364594,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.4843192513132926,
+        "dof": 599,
+        "p_value": 0.1382502569319004,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.19957520901198597,
+        "mde_at_this_n_80pct_power": 0.02282626237228046,
+        "n_needed_for_observed_difference_80pct_power": 2138
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.16621031746031747,
+       "system_b": 0.15811724386724385,
+       "mean_difference": 0.008093073593073624,
+       "bootstrap_ci_low": -0.007516666666666683,
+       "bootstrap_ci_high": 0.023570220057720047,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.0319968432323263,
+        "dof": 599,
+        "p_value": 0.30249008647274545,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.19209264915707067,
+        "mde_at_this_n_80pct_power": 0.021970450293665362,
+        "n_needed_for_observed_difference_80pct_power": 4422
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.543078832255379,
+       "system_b": 0.5315321917101113,
+       "mean_difference": 0.011546640545267661,
+       "bootstrap_ci_low": -0.0010140848061380352,
+       "bootstrap_ci_high": 0.024435586758145358,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.7854587449338837,
+        "dof": 599,
+        "p_value": 0.07469277392216261,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.15840958330451277,
+        "mde_at_this_n_80pct_power": 0.018117975317141044,
+        "n_needed_for_observed_difference_80pct_power": 1478
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.505,
+       "system_b": 0.485,
+       "mean_difference": 0.020000000000000018,
+       "bootstrap_ci_low": -0.02833333333333332,
+       "bootstrap_ci_high": 0.06833333333333336,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.823942809257926,
+        "dof": 599,
+        "p_value": 0.4102999963925623,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 112,
+        "correct_only_in_b": 100,
+        "discordant_pairs": 212,
+        "p_value": 0.4500368401975949,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 3.0385816786431356e-64
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5945776127324374,
+        "mde_at_this_n_80pct_power": 0.06800436114337066,
+        "n_needed_for_observed_difference_80pct_power": 6937
+       }
+      },
+      "composite_score": {
+       "system_a": 0.3553568422318423,
+       "system_b": 0.18881367243867245,
+       "mean_difference": 0.16654316979316983,
+       "bootstrap_ci_low": -0.18748791335978837,
+       "bootstrap_ci_high": 0.214299954004329,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.24975160834535834,
+       "system_b": 0.23601709054834058,
+       "mean_difference": 0.013734517797017759,
+       "bootstrap_ci_low": -0.001477258447570924,
+       "bootstrap_ci_high": 0.028909524185305416,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.7777777777777778,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.741111111111111,
+      "b_step_count_term": 0.7038888888888889,
+      "a_mae": 0.7766666666666666,
+      "b_mae": 0.8883333333333333
+     },
+     "composite_difference_decomposition": {
+      "total": 0.16654316979316983,
+      "contributions": {
+       "w_step_f1_x_delta": 0.004837469937469929,
+       "w_ordered_x_delta": 0.002427922077922087,
+       "w_reference_micro_x_delta": 0.15555555555555556,
+       "w_step_count_x_delta": 0.0037222222222222157
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.029046342419671665,
+       "w_ordered_x_delta": 0.014578334740099678,
+       "w_reference_micro_x_delta": 0.9340254286545656,
+       "w_step_count_x_delta": 0.022349894185662782
+      },
+      "sum_of_contributions_check": 0.1665431697931698
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.135,
+        "system_b": 0.095,
+        "mean_difference": 0.04000000000000001,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.08499999999999999,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.8978435011220318,
+         "dof": 199,
+         "p_value": 0.05916427145521888,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 13,
+         "correct_only_in_b": 5,
+         "discordant_pairs": 18,
+         "p_value": 0.09625244140625,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 7.62939453125e-06
+        }
+       },
+       "step_f1": {
+        "system_a": 0.3199444444444445,
+        "system_b": 0.2821666666666667,
+        "mean_difference": 0.0377777777777778,
+        "bootstrap_ci_low": 0.0015541666666667008,
+        "bootstrap_ci_high": 0.0741125,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.022329480280066,
+         "dof": 199,
+         "p_value": 0.04448083881691421,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.3044642857142857,
+        "system_b": 0.2725,
+        "mean_difference": 0.03196428571428567,
+        "bootstrap_ci_low": -0.0038720238095238473,
+        "bootstrap_ci_high": 0.06833333333333336,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.7160246762574378,
+         "dof": 199,
+         "p_value": 0.08771377275316207,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6269272630993886,
+        "system_b": 0.6031964480753375,
+        "mean_difference": 0.023730815024051166,
+        "bootstrap_ci_low": -0.002992053736831909,
+        "bootstrap_ci_high": 0.050532042189884246,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.7333493026764757,
+         "dof": 199,
+         "p_value": 0.08458255898128453,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.695,
+        "system_b": 0.68,
+        "mean_difference": 0.014999999999999902,
+        "bootstrap_ci_low": -0.060124999999999935,
+        "bootstrap_ci_high": 0.09499999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.37715309932281654,
+         "dof": 199,
+         "p_value": 0.706461723072912,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 33,
+         "correct_only_in_b": 30,
+         "discordant_pairs": 63,
+         "p_value": 0.8013064925040662,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.168404344971009e-19
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3054837301587302,
+        "system_b": 0.4786166666666667,
+        "mean_difference": -0.17313293650793649,
+        "bootstrap_ci_low": -0.1965242162698413,
+        "bootstrap_ci_high": 0.04834270833333337,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3818546626984128,
+        "system_b": 0.34827083333333336,
+        "mean_difference": 0.03358382936507942,
+        "bootstrap_ci_low": 0.0008737351190476358,
+        "bootstrap_ci_high": 0.06646954365079372,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8616666666666667,
+       "b_step_count_term": 0.84,
+       "a_mae": 0.415,
+       "b_mae": 0.48
+      }
+     },
+     "3": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.01,
+        "mean_difference": 0.01,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.025,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4177803109441922,
+         "dof": 199,
+         "p_value": 0.15781883619217799,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 2,
+         "p_value": 0.5,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.5
+        }
+       },
+       "step_f1": {
+        "system_a": 0.15666269841269842,
+        "system_b": 0.14705555555555555,
+        "mean_difference": 0.00960714285714287,
+        "bootstrap_ci_low": -0.012976785714285684,
+        "bootstrap_ci_high": 0.03292579365079365,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.813111230345394,
+         "dof": 199,
+         "p_value": 0.41712603381912267,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.12058333333333332,
+        "system_b": 0.11933333333333333,
+        "mean_difference": 0.0012499999999999872,
+        "bootstrap_ci_low": -0.020999999999999977,
+        "bootstrap_ci_high": 0.02316875,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.10903251202936298,
+         "dof": 199,
+         "p_value": 0.9132865676395334,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.531595752717047,
+        "system_b": 0.5187015825981122,
+        "mean_difference": 0.012894170118934789,
+        "bootstrap_ci_low": -0.007188746392358205,
+        "bootstrap_ci_high": 0.03323348362444883,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.2496899802020283,
+         "dof": 199,
+         "p_value": 0.21288057097290625,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.495,
+        "system_b": 0.49,
+        "mean_difference": 0.0050000000000000044,
+        "bootstrap_ci_low": -0.07500000000000001,
+        "bootstrap_ci_high": 0.08999999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.11838526717420256,
+         "dof": 199,
+         "p_value": 0.9058818109259029,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 36,
+         "correct_only_in_b": 35,
+         "discordant_pairs": 71,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 8.470329472543003e-22
+        }
+       },
+       "composite_score": {
+        "system_a": 0.1741734126984127,
+        "system_b": 0.3647888888888889,
+        "mean_difference": -0.1906154761904762,
+        "bootstrap_ci_low": -0.20627502976190476,
+        "bootstrap_ci_high": 0.022945158730158708,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2177167658730159,
+        "system_b": 0.20598611111111112,
+        "mean_difference": 0.011730654761904769,
+        "bootstrap_ci_low": -0.0102515376984127,
+        "bootstrap_ci_high": 0.03411879960317459,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.7533333333333333,
+       "b_step_count_term": 0.7016666666666667,
+       "a_mae": 0.74,
+       "b_mae": 0.895
+      }
+     },
+     "4": {
+      "n": 200,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.01,
+        "system_b": 0.005,
+        "mean_difference": 0.005,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.015000000000000001,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0,
+         "dof": 199,
+         "p_value": 0.31852491231977387,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 1,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 1,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.0920959595959596,
+        "system_b": 0.1031998556998557,
+        "mean_difference": -0.011103896103896088,
+        "bootstrap_ci_low": -0.03101595418470418,
+        "bootstrap_ci_high": 0.008787436868686853,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.084405969593282,
+         "dof": 199,
+         "p_value": 0.27949686064701434,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.07358333333333333,
+        "system_b": 0.08251839826839825,
+        "mean_difference": -0.00893506493506492,
+        "bootstrap_ci_low": -0.025471617965367958,
+        "bootstrap_ci_high": 0.008017370129870131,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.0501290605252724,
+         "dof": 199,
+         "p_value": 0.294932384813107,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.47071348094970134,
+        "system_b": 0.47269854445688436,
+        "mean_difference": -0.001985063507183027,
+        "bootstrap_ci_low": -0.019904021820141966,
+        "bootstrap_ci_high": 0.01553258820189684,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.21908718135780555,
+         "dof": 199,
+         "p_value": 0.8268066781127748,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.325,
+        "system_b": 0.285,
+        "mean_difference": 0.040000000000000036,
+        "bootstrap_ci_low": -0.04999999999999999,
+        "bootstrap_ci_high": 0.125,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.9054134025152109,
+         "dof": 199,
+         "p_value": 0.3663413107195315,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 43,
+         "correct_only_in_b": 35,
+         "discordant_pairs": 78,
+         "p_value": 0.4282070357175808,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 6.617444900424222e-24
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3197467171717172,
+        "system_b": 0.12303546176046176,
+        "mean_difference": 0.19671125541125545,
+        "bootstrap_ci_low": -0.01583553481240984,
+        "bootstrap_ci_high": 0.21130826930014432,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1496833964646465,
+        "system_b": 0.1537943272005772,
+        "mean_difference": -0.00411093073593069,
+        "bootstrap_ci_low": -0.025279451884920638,
+        "bootstrap_ci_high": 0.016798230068542537,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.6083333333333334,
+       "b_step_count_term": 0.5700000000000001,
+       "a_mae": 1.175,
+       "b_mae": 1.29
+      }
+     }
+    }
+   }
+  },
+  "verdict_agreement": {
+   "what": "does the bootstrap CI verdict (excludes zero) agree with the paired t-test verdict (p < alpha)? counted where both apply, i.e. the five per-item metrics",
+   "overall_rows_only": {
+    "comparisons": 15,
+    "disagreements": 0,
+    "disagreeing_cells": []
+   },
+   "overall_plus_per_gold_hop": {
+    "comparisons": 60,
+    "disagreements": 1,
+    "disagreeing_cells": [
+     {
+      "pair": "typed_vs_uniform",
+      "stratum": "3",
+      "metric": "ordered_step_accuracy",
+      "bootstrap_ci": [
+       0.00024791666666664267,
+       0.04916666666666665
+      ],
+      "paired_t_p_value": 0.05633075420413569
+     }
+    ]
+   },
+   "mcnemar_vs_ci_on_binary_metrics_overall": {
+    "comparisons": 6,
+    "disagreements": 0,
+    "disagreeing_cells": []
+   }
+  },
+  "row_order_sensitivity": {
+   "what": "the bootstrap resamples row indices, so the CI's low-order digits depend on the row order the aligned matrices were built in; point estimates and every significance verdict are order-invariant",
+   "reported_order": "sorted by normalized question text",
+   "typed_vs_raw_overall": {
+    "exact_match": {
+     "sorted_order_ci": [
+      0.003333333333333334,
+      0.039999999999999994
+     ],
+     "v1_file_order_ci": [
+      0.0049999999999999975,
+      0.04
+     ],
+     "mean_difference_identical": true,
+     "verdict_identical": true
+    },
+    "step_f1": {
+     "sorted_order_ci": [
+      0.005252678340178338,
+      0.041184740259740275
+     ],
+     "v1_file_order_ci": [
+      0.005382658313908315,
+      0.041377347883597926
+     ],
+     "mean_difference_identical": false,
+     "verdict_identical": true
+    },
+    "ordered_step_accuracy": {
+     "sorted_order_ci": [
+      0.003866287878787891,
+      0.03875723651348651
+     ],
+     "v1_file_order_ci": [
+      0.004127317821067813,
+      0.03918062215562218
+     ],
+     "mean_difference_identical": false,
+     "verdict_identical": true
+    },
+    "rouge_l_f1": {
+     "sorted_order_ci": [
+      0.00014485478537320566,
+      0.025011834888883314
+     ],
+     "v1_file_order_ci": [
+      9.345546026643688e-05,
+      0.025333421043662582
+     ],
+     "mean_difference_identical": true,
+     "verdict_identical": true
+    },
+    "hop_count_exact_match": {
+     "sorted_order_ci": [
+      -0.008333333333333304,
+      0.08166666666666672
+     ],
+     "v1_file_order_ci": [
+      -0.008333333333333304,
+      0.08004166666666612
+     ],
+     "mean_difference_identical": true,
+     "verdict_identical": true
+    },
+    "composite_score": {
+     "sorted_order_ci": [
+      -0.18418214671902178,
+      0.2259290978465979
+     ],
+     "v1_file_order_ci": [
+      -0.1843829243672994,
+      0.22638545549358047
+     ],
+     "mean_difference_identical": false,
+     "verdict_identical": true
+    }
+   }
+  },
+  "holm_bonferroni": {
+   "family_15_overall_t_tests_3_pairs_x_5_metrics": {
+    "typed_vs_raw|step_f1": 0.16757944055334972,
+    "typed_vs_raw|exact_match": 0.21914249367412958,
+    "uniform_vs_raw|exact_match": 0.21914249367412958,
+    "typed_vs_raw|ordered_step_accuracy": 0.21914249367412958,
+    "typed_vs_raw|rouge_l_f1": 0.5090733750822399,
+    "uniform_vs_raw|rouge_l_f1": 0.7469277392216261,
+    "typed_vs_raw|hop_count_exact_match": 1.0,
+    "typed_vs_uniform|ordered_step_accuracy": 1.0,
+    "uniform_vs_raw|step_f1": 1.0,
+    "typed_vs_uniform|step_f1": 1.0,
+    "uniform_vs_raw|ordered_step_accuracy": 1.0,
+    "uniform_vs_raw|hop_count_exact_match": 1.0,
+    "typed_vs_uniform|hop_count_exact_match": 1.0,
+    "typed_vs_uniform|exact_match": 1.0,
+    "typed_vs_uniform|rouge_l_f1": 1.0
+   },
+   "family_6_overall_mcnemar_tests": {
+    "typed_vs_raw|exact_match": 0.1447172686457634,
+    "uniform_vs_raw|exact_match": 0.1447172686457634,
+    "typed_vs_raw|hop_count_exact_match": 0.5176757260630344,
+    "uniform_vs_raw|hop_count_exact_match": 1.0,
+    "typed_vs_uniform|hop_count_exact_match": 1.0,
+    "typed_vs_uniform|exact_match": 1.0
+   },
+   "family_5_metrics_within_typed_vs_raw_t_tests": {
+    "step_f1": 0.05585981351778324,
+    "exact_match": 0.06261214104975131,
+    "ordered_step_accuracy": 0.06261214104975131,
+    "rouge_l_f1": 0.09255879546949816,
+    "hop_count_exact_match": 0.11242270585571894
+   }
+  }
+ },
+ "task_b_retrieval": {
+  "per_item_data_available": true,
+  "note": "per-item files exist for all 33 pool-sweep cells, so the 'aggregates only => no test computable' fallback does not apply; no statistic here is computed from all_runs.csv",
+  "cells": [
+   "size1000_balanced_trial0__biencoder_only__raw",
+   "size1000_balanced_trial0__biencoder_only__typed",
+   "size1000_balanced_trial0__biencoder_only__uniform",
+   "size1000_balanced_trial0__biencoder_plus_ce__raw",
+   "size1000_balanced_trial0__biencoder_plus_ce__typed",
+   "size1000_balanced_trial0__biencoder_plus_ce__uniform",
+   "size1000_imbalanced_trial0__biencoder_only__raw",
+   "size1000_imbalanced_trial0__biencoder_only__typed",
+   "size1000_imbalanced_trial0__biencoder_only__uniform",
+   "size1000_imbalanced_trial0__biencoder_plus_ce__raw",
+   "size1000_imbalanced_trial0__biencoder_plus_ce__typed",
+   "size1000_imbalanced_trial0__biencoder_plus_ce__uniform",
+   "size2000_balanced_trial0__biencoder_only__raw",
+   "size2000_balanced_trial0__biencoder_only__typed",
+   "size2000_balanced_trial0__biencoder_only__uniform",
+   "size2000_imbalanced_trial0__biencoder_only__raw",
+   "size2000_imbalanced_trial0__biencoder_only__typed",
+   "size2000_imbalanced_trial0__biencoder_only__uniform",
+   "size2000_imbalanced_trial0__biencoder_plus_ce__raw",
+   "size2000_imbalanced_trial0__biencoder_plus_ce__typed",
+   "size2000_imbalanced_trial0__biencoder_plus_ce__uniform",
+   "size4000_imbalanced_trial0__biencoder_only__raw",
+   "size4000_imbalanced_trial0__biencoder_only__typed",
+   "size4000_imbalanced_trial0__biencoder_only__uniform",
+   "size4000_imbalanced_trial0__biencoder_plus_ce__raw",
+   "size4000_imbalanced_trial0__biencoder_plus_ce__typed",
+   "size4000_imbalanced_trial0__biencoder_plus_ce__uniform",
+   "size8000_imbalanced_trial0__biencoder_only__raw",
+   "size8000_imbalanced_trial0__biencoder_only__typed",
+   "size8000_imbalanced_trial0__biencoder_only__uniform",
+   "size8000_imbalanced_trial0__biencoder_plus_ce__raw",
+   "size8000_imbalanced_trial0__biencoder_plus_ce__typed",
+   "size8000_imbalanced_trial0__biencoder_plus_ce__uniform"
+  ],
+  "num_cells": 33,
+  "matched_pairs": [
+   "size1000_balanced_trial0__raw",
+   "size1000_balanced_trial0__typed",
+   "size1000_balanced_trial0__uniform",
+   "size1000_imbalanced_trial0__raw",
+   "size1000_imbalanced_trial0__typed",
+   "size1000_imbalanced_trial0__uniform",
+   "size2000_imbalanced_trial0__raw",
+   "size2000_imbalanced_trial0__typed",
+   "size2000_imbalanced_trial0__uniform",
+   "size4000_imbalanced_trial0__raw",
+   "size4000_imbalanced_trial0__typed",
+   "size4000_imbalanced_trial0__uniform",
+   "size8000_imbalanced_trial0__raw",
+   "size8000_imbalanced_trial0__typed",
+   "size8000_imbalanced_trial0__uniform"
+  ],
+  "num_matched_pairs": 15,
+  "cells_with_no_retrieval_counterpart": [
+   "size2000_balanced_trial0__biencoder_only__raw",
+   "size2000_balanced_trial0__biencoder_only__typed",
+   "size2000_balanced_trial0__biencoder_only__uniform"
+  ],
+  "rows_per_cell": {
+   "size1000_balanced_trial0__biencoder_only__raw": 750,
+   "size1000_balanced_trial0__biencoder_only__typed": 750,
+   "size1000_balanced_trial0__biencoder_only__uniform": 750,
+   "size1000_balanced_trial0__biencoder_plus_ce__raw": 750,
+   "size1000_balanced_trial0__biencoder_plus_ce__typed": 750,
+   "size1000_balanced_trial0__biencoder_plus_ce__uniform": 750,
+   "size1000_imbalanced_trial0__biencoder_only__raw": 750,
+   "size1000_imbalanced_trial0__biencoder_only__typed": 750,
+   "size1000_imbalanced_trial0__biencoder_only__uniform": 750,
+   "size1000_imbalanced_trial0__biencoder_plus_ce__raw": 750,
+   "size1000_imbalanced_trial0__biencoder_plus_ce__typed": 750,
+   "size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 750,
+   "size2000_balanced_trial0__biencoder_only__raw": 750,
+   "size2000_balanced_trial0__biencoder_only__typed": 750,
+   "size2000_balanced_trial0__biencoder_only__uniform": 750,
+   "size2000_imbalanced_trial0__biencoder_only__raw": 750,
+   "size2000_imbalanced_trial0__biencoder_only__typed": 750,
+   "size2000_imbalanced_trial0__biencoder_only__uniform": 750,
+   "size2000_imbalanced_trial0__biencoder_plus_ce__raw": 750,
+   "size2000_imbalanced_trial0__biencoder_plus_ce__typed": 750,
+   "size2000_imbalanced_trial0__biencoder_plus_ce__uniform": 750,
+   "size4000_imbalanced_trial0__biencoder_only__raw": 750,
+   "size4000_imbalanced_trial0__biencoder_only__typed": 750,
+   "size4000_imbalanced_trial0__biencoder_only__uniform": 750,
+   "size4000_imbalanced_trial0__biencoder_plus_ce__raw": 750,
+   "size4000_imbalanced_trial0__biencoder_plus_ce__typed": 750,
+   "size4000_imbalanced_trial0__biencoder_plus_ce__uniform": 750,
+   "size8000_imbalanced_trial0__biencoder_only__raw": 750,
+   "size8000_imbalanced_trial0__biencoder_only__typed": 750,
+   "size8000_imbalanced_trial0__biencoder_only__uniform": 750,
+   "size8000_imbalanced_trial0__biencoder_plus_ce__raw": 750,
+   "size8000_imbalanced_trial0__biencoder_plus_ce__typed": 750,
+   "size8000_imbalanced_trial0__biencoder_plus_ce__uniform": 750
+  },
+  "question_sequence_identical_across_all_cells": true,
+  "duplicate_normalized_questions_in_eval_sequence": 1,
+  "gold_hop_distribution": {
+   "2": 250,
+   "3": 250,
+   "4": 250
+  },
+  "pairs": {
+   "size1000_balanced_trial0__raw": {
+    "system_a": "size1000_balanced_trial0__biencoder_plus_ce__raw",
+    "system_b": "size1000_balanced_trial0__biencoder_only__raw",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.03333333333333333,
+       "system_b": 0.03866666666666667,
+       "mean_difference": -0.005333333333333336,
+       "bootstrap_ci_low": -0.018666666666666665,
+       "bootstrap_ci_high": 0.007999999999999997,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.8163149556155184,
+        "dof": 749,
+        "p_value": 0.41457956201979995,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 10,
+        "correct_only_in_b": 14,
+        "discordant_pairs": 24,
+        "p_value": 0.5412561893463135,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.1920928955078125e-07
+       },
+       "power": {
+        "sd_of_paired_differences": 0.17892523916569988,
+        "mde_at_this_n_80pct_power": 0.018303949630163782,
+        "n_needed_for_observed_difference_80pct_power": 8834
+       }
+      },
+      "step_f1": {
+       "system_a": 0.1732798460798461,
+       "system_b": 0.16133865393865393,
+       "mean_difference": 0.011941192141192158,
+       "bootstrap_ci_low": -0.0023913403263403194,
+       "bootstrap_ci_high": 0.02583857142857144,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.6520217509471835,
+        "dof": 749,
+        "p_value": 0.09894924132757159,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.19795321385703268,
+        "mde_at_this_n_80pct_power": 0.02025050055801608,
+        "n_needed_for_observed_difference_80pct_power": 2157
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.15338015873015873,
+       "system_b": 0.14889870129870128,
+       "mean_difference": 0.004481457431457447,
+       "bootstrap_ci_low": -0.009650970418470399,
+       "bootstrap_ci_high": 0.018158750000000022,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.6372187899373608,
+        "dof": 749,
+        "p_value": 0.5241770606759377,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1926022399582477,
+        "mde_at_this_n_80pct_power": 0.01970309898866578,
+        "n_needed_for_observed_difference_80pct_power": 14498
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5316132147257073,
+       "system_b": 0.5237267087627537,
+       "mean_difference": 0.007886505962953594,
+       "bootstrap_ci_low": -0.0022068214620191346,
+       "bootstrap_ci_high": 0.018076465077574728,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.505403712628588,
+        "dof": 749,
+        "p_value": 0.1326418929632302,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1434703920141838,
+        "mde_at_this_n_80pct_power": 0.014676939045002505,
+        "n_needed_for_observed_difference_80pct_power": 2598
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.44533333333333336,
+       "system_b": 0.448,
+       "mean_difference": -0.0026666666666666505,
+       "bootstrap_ci_low": -0.043999999999999984,
+       "bootstrap_ci_high": 0.03866666666666668,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.12590546988864457,
+        "dof": 749,
+        "p_value": 0.899840540419368,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 125,
+        "correct_only_in_b": 127,
+        "discordant_pairs": 252,
+        "p_value": 0.9497878353175606,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 2.7635739376302223e-76
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5800357553854673,
+        "mde_at_this_n_80pct_power": 0.05933732602384511,
+        "n_needed_for_observed_difference_80pct_power": 371347
+       }
+      },
+      "composite_score": {
+       "system_a": 0.3644775012025012,
+       "system_b": 0.1762272941872942,
+       "mean_difference": 0.18825020701520703,
+       "bootstrap_ci_low": -0.021628255466755474,
+       "bootstrap_ci_high": 0.2144428740472491,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.22832414923039926,
+       "system_b": 0.22028411773411774,
+       "mean_difference": 0.008040031496281519,
+       "bootstrap_ci_low": -0.0060875788332038425,
+       "bootstrap_ci_high": 0.02203958506771004,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.9090909090909091,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.6733333333333333,
+      "b_step_count_term": 0.6702222222222223,
+      "a_mae": 0.98,
+      "b_mae": 0.9893333333333333
+     },
+     "composite_difference_decomposition": {
+      "total": 0.18825020701520703,
+      "contributions": {
+       "w_step_f1_x_delta": 0.004776476856476863,
+       "w_ordered_x_delta": 0.0013444372294372342,
+       "w_reference_micro_x_delta": 0.18181818181818182,
+       "w_step_count_x_delta": 0.00031111111111110646
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.02537302312815526,
+       "w_ordered_x_delta": 0.007141756977343611,
+       "w_reference_micro_x_delta": 0.9658325730472869,
+       "w_step_count_x_delta": 0.0016526468472142218
+      },
+      "sum_of_contributions_check": 0.18825020701520703
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.072,
+        "system_b": 0.088,
+        "mean_difference": -0.016,
+        "bootstrap_ci_low": -0.048,
+        "bootstrap_ci_high": 0.016,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.0,
+         "dof": 249,
+         "p_value": 0.3182813015158006,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 6,
+         "correct_only_in_b": 10,
+         "discordant_pairs": 16,
+         "p_value": 0.454498291015625,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.0517578125e-05
+        }
+       },
+       "step_f1": {
+        "system_a": 0.2533333333333333,
+        "system_b": 0.24200952380952379,
+        "mean_difference": 0.011323809523809514,
+        "bootstrap_ci_low": -0.020546428571428566,
+        "bootstrap_ci_high": 0.042381428571428535,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.7044921903231167,
+         "dof": 249,
+         "p_value": 0.4817846865662445,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.23266666666666666,
+        "system_b": 0.23298181818181818,
+        "mean_difference": -0.0003151515151515183,
+        "bootstrap_ci_low": -0.03149696969696972,
+        "bootstrap_ci_high": 0.030401363636363626,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.020070994230970304,
+         "dof": 249,
+         "p_value": 0.9840028125063243,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.587109292033726,
+        "system_b": 0.5746685352352963,
+        "mean_difference": 0.012440756798429708,
+        "bootstrap_ci_low": -0.00887637490044023,
+        "bootstrap_ci_high": 0.0338183376517346,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.138226151858723,
+         "dof": 249,
+         "p_value": 0.2561200296113761,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.544,
+        "system_b": 0.576,
+        "mean_difference": -0.03199999999999992,
+        "bootstrap_ci_low": -0.10399999999999998,
+        "bootstrap_ci_high": 0.03600000000000003,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.8940681995381342,
+         "dof": 249,
+         "p_value": 0.37214875601929986,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 36,
+         "correct_only_in_b": 44,
+         "discordant_pairs": 80,
+         "p_value": 0.4340422553454787,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.6543612251060553e-24
+        }
+       },
+       "composite_score": {
+        "system_a": 0.4447333333333333,
+        "system_b": 0.4424316883116883,
+        "mean_difference": 0.002301645021645038,
+        "bootstrap_ci_low": -0.02207315800865807,
+        "bootstrap_ci_high": 0.026574742424242404,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.30591666666666667,
+        "system_b": 0.30303961038961036,
+        "mean_difference": 0.0028770562770563113,
+        "bootstrap_ci_low": -0.027591447510822507,
+        "bootstrap_ci_high": 0.03321842803030299,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.736,
+       "b_step_count_term": 0.7573333333333333,
+       "a_mae": 0.792,
+       "b_mae": 0.728
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.028,
+        "mean_difference": -0.008,
+        "bootstrap_ci_low": -0.028,
+        "bootstrap_ci_high": 0.012,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.8159506119058424,
+         "dof": 249,
+         "p_value": 0.41530824255993326,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 4,
+         "discordant_pairs": 6,
+         "p_value": 0.6875,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.03125
+        }
+       },
+       "step_f1": {
+        "system_a": 0.16711111111111113,
+        "system_b": 0.15595873015873013,
+        "mean_difference": 0.011152380952380997,
+        "bootstrap_ci_low": -0.00977944444444444,
+        "bootstrap_ci_high": 0.03217888888888885,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0459988548098142,
+         "dof": 249,
+         "p_value": 0.2965758917593209,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.14267619047619046,
+        "system_b": 0.13907619047619044,
+        "mean_difference": 0.00360000000000002,
+        "bootstrap_ci_low": -0.016571904761904788,
+        "bootstrap_ci_high": 0.02382857142857142,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.35136944170407963,
+         "dof": 249,
+         "p_value": 0.7256083383111426,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5284465330807627,
+        "system_b": 0.5178867205844552,
+        "mean_difference": 0.010559812496307552,
+        "bootstrap_ci_low": -0.005617697524795439,
+        "bootstrap_ci_high": 0.027570354377913376,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.2444392166062754,
+         "dof": 249,
+         "p_value": 0.21450802949136763,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.468,
+        "system_b": 0.436,
+        "mean_difference": 0.03200000000000003,
+        "bootstrap_ci_low": -0.03200000000000003,
+        "bootstrap_ci_high": 0.09999999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.9425987574171679,
+         "dof": 249,
+         "p_value": 0.34679980599354626,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 40,
+         "correct_only_in_b": 32,
+         "discordant_pairs": 72,
+         "p_value": 0.4095793959270717,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 4.235164736271502e-22
+        }
+       },
+       "composite_score": {
+        "system_a": 0.37898063492063494,
+        "system_b": 0.3685063492063492,
+        "mean_difference": 0.010474285714285714,
+        "bootstrap_ci_low": -0.005564785714285715,
+        "bootstrap_ci_high": 0.02684392063492072,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.22372579365079368,
+        "system_b": 0.2106329365079365,
+        "mean_difference": 0.013092857142857184,
+        "bootstrap_ci_low": -0.006955982142857158,
+        "bootstrap_ci_high": 0.03355490079365078,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.6933333333333334,
+       "b_step_count_term": 0.6439999999999999,
+       "a_mae": 0.92,
+       "b_mae": 1.068
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.0,
+        "mean_difference": 0.008,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.02,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4170619309433985,
+         "dof": 249,
+         "p_value": 0.15771479274702108,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 2,
+         "p_value": 0.5,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.5
+        }
+       },
+       "step_f1": {
+        "system_a": 0.0993950937950938,
+        "system_b": 0.08604770784770785,
+        "mean_difference": 0.01334738594738595,
+        "bootstrap_ci_low": -0.005204093129093127,
+        "bootstrap_ci_high": 0.03348891053391053,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.3385507896422664,
+         "dof": 249,
+         "p_value": 0.18193783488510817,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08479761904761905,
+        "system_b": 0.07463809523809525,
+        "mean_difference": 0.010159523809523799,
+        "bootstrap_ci_low": -0.008062738095238102,
+        "bootstrap_ci_high": 0.0296502380952381,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0445812826753542,
+         "dof": 249,
+         "p_value": 0.2972295572935587,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.47928381906263307,
+        "system_b": 0.47862487046850993,
+        "mean_difference": 0.0006589485941231321,
+        "bootstrap_ci_low": -0.013740393573088936,
+        "bootstrap_ci_high": 0.015197185806858516,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.08815388310971942,
+         "dof": 249,
+         "p_value": 0.929825226447062,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.324,
+        "system_b": 0.332,
+        "mean_difference": -0.008000000000000007,
+        "bootstrap_ci_low": -0.08400000000000002,
+        "bootstrap_ci_high": 0.07200000000000001,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.19961556908234188,
+         "dof": 249,
+         "p_value": 0.841944167443241,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 49,
+         "correct_only_in_b": 51,
+         "discordant_pairs": 100,
+         "p_value": 0.9204107626128213,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.5777218104420236e-30
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3060821717171717,
+        "system_b": 0.11774384504384505,
+        "mean_difference": 0.18833832667332667,
+        "bootstrap_ci_low": -0.02532435732323234,
+        "bootstrap_ci_high": 0.21934902854090357,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1553299873737374,
+        "system_b": 0.14717980630480632,
+        "mean_difference": 0.00815018106893109,
+        "bootstrap_ci_low": -0.012164826562326557,
+        "bootstrap_ci_high": 0.02926963435869681,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.9090909090909091,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.5906666666666667,
+       "b_step_count_term": 0.6093333333333333,
+       "a_mae": 1.228,
+       "b_mae": 1.172
+      }
+     }
+    }
+   },
+   "size1000_balanced_trial0__typed": {
+    "system_a": "size1000_balanced_trial0__biencoder_plus_ce__typed",
+    "system_b": "size1000_balanced_trial0__biencoder_only__typed",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.037333333333333336,
+       "system_b": 0.04133333333333333,
+       "mean_difference": -0.003999999999999997,
+       "bootstrap_ci_low": -0.016033333333333306,
+       "bootstrap_ci_high": 0.008,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.6252892144481924,
+        "dof": 749,
+        "p_value": 0.5319717153037602,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 10,
+        "correct_only_in_b": 13,
+        "discordant_pairs": 23,
+        "p_value": 0.6776394844055176,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 2.384185791015625e-07
+       },
+       "power": {
+        "sd_of_paired_differences": 0.17519015036538652,
+        "mde_at_this_n_80pct_power": 0.01792185218217987,
+        "n_needed_for_observed_difference_80pct_power": 15056
+       }
+      },
+      "step_f1": {
+       "system_a": 0.18273849113849114,
+       "system_b": 0.16963798053798052,
+       "mean_difference": 0.013100510600510623,
+       "bootstrap_ci_low": -0.001250331427831478,
+       "bootstrap_ci_high": 0.027328224368224362,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.772436602927138,
+        "dof": 749,
+        "p_value": 0.07672853952822632,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.20241754088369437,
+        "mde_at_this_n_80pct_power": 0.020707198659466818,
+        "n_needed_for_observed_difference_80pct_power": 1874
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1615867724867725,
+       "system_b": 0.1504810152810153,
+       "mean_difference": 0.01110575720575721,
+       "bootstrap_ci_low": -0.0026766570466570283,
+       "bootstrap_ci_high": 0.024883841251341222,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.5788505366222425,
+        "dof": 749,
+        "p_value": 0.11479254993110638,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.19263614885239,
+        "mde_at_this_n_80pct_power": 0.019706567849142306,
+        "n_needed_for_observed_difference_80pct_power": 2362
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5295583400541953,
+       "system_b": 0.5223531262239297,
+       "mean_difference": 0.007205213830265622,
+       "bootstrap_ci_low": -0.004292590517724579,
+       "bootstrap_ci_high": 0.018776621383574416,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.2295515713658947,
+        "dof": 749,
+        "p_value": 0.21925116696026886,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.16048363640821398,
+        "mde_at_this_n_80pct_power": 0.016417384215767952,
+        "n_needed_for_observed_difference_80pct_power": 3894
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.456,
+       "system_b": 0.43733333333333335,
+       "mean_difference": 0.018666666666666665,
+       "bootstrap_ci_low": -0.02133333333333337,
+       "bootstrap_ci_high": 0.058666666666666645,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.9230415793810305,
+        "dof": 749,
+        "p_value": 0.35628278220433995,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 122,
+        "correct_only_in_b": 108,
+        "discordant_pairs": 230,
+        "p_value": 0.3913839030786501,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.1591269220898192e-69
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5538295692821971,
+        "mde_at_this_n_80pct_power": 0.05665644817413753,
+        "n_needed_for_observed_difference_80pct_power": 6910
+       }
+      },
+      "composite_score": {
+       "system_a": 0.34041587264587264,
+       "system_b": 0.24575505235505235,
+       "mean_difference": 0.09466082029082029,
+       "bootstrap_ci_low": -0.19117589857364856,
+       "bootstrap_ci_high": 0.21428345209420216,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.23801984080734087,
+       "system_b": 0.22386048211048215,
+       "mean_difference": 0.01415935869685872,
+       "bootstrap_ci_low": 0.0004524280696155292,
+       "bootstrap_ci_high": 0.02808638535076038,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.75,
+      "b_ref_micro": 0.3333333333333333,
+      "a_step_count_term": 0.6884444444444444,
+      "b_step_count_term": 0.6608888888888889,
+      "a_mae": 0.9346666666666666,
+      "b_mae": 1.0173333333333334
+     },
+     "composite_difference_decomposition": {
+      "total": 0.09466082029082029,
+      "contributions": {
+       "w_step_f1_x_delta": 0.00524020424020425,
+       "w_ordered_x_delta": 0.003331727161727163,
+       "w_reference_micro_x_delta": 0.08333333333333334,
+       "w_step_count_x_delta": 0.002755555555555556
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.05535768889499489,
+       "w_ordered_x_delta": 0.0351964746501384,
+       "w_reference_micro_x_delta": 0.8803360574872873,
+       "w_step_count_x_delta": 0.029109778967579634
+      },
+      "sum_of_contributions_check": 0.0946608202908203
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.072,
+        "system_b": 0.096,
+        "mean_difference": -0.024000000000000007,
+        "bootstrap_ci_low": -0.05600000000000001,
+        "bootstrap_ci_high": 0.007999999999999993,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.5037792954837925,
+         "dof": 249,
+         "p_value": 0.13390548025153662,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 5,
+         "correct_only_in_b": 11,
+         "discordant_pairs": 16,
+         "p_value": 0.210113525390625,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.0517578125e-05
+        }
+       },
+       "step_f1": {
+        "system_a": 0.2634666666666667,
+        "system_b": 0.2392095238095238,
+        "mean_difference": 0.024257142857142894,
+        "bootstrap_ci_low": -0.006419285714285697,
+        "bootstrap_ci_high": 0.055199999999999944,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.5269197185839005,
+         "dof": 249,
+         "p_value": 0.12805019695075898,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.24333333333333332,
+        "system_b": 0.2253047619047619,
+        "mean_difference": 0.01802857142857142,
+        "bootstrap_ci_low": -0.01190642857142853,
+        "bootstrap_ci_high": 0.04809690476190475,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.1657791538744928,
+         "dof": 249,
+         "p_value": 0.24481920249155126,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5881507064505829,
+        "system_b": 0.5774413470405243,
+        "mean_difference": 0.010709359410058572,
+        "bootstrap_ci_low": -0.015027212879803553,
+        "bootstrap_ci_high": 0.036248766915112474,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.8139597330047775,
+         "dof": 249,
+         "p_value": 0.4164457222688095,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.596,
+        "system_b": 0.576,
+        "mean_difference": 0.020000000000000018,
+        "bootstrap_ci_low": -0.04400000000000004,
+        "bootstrap_ci_high": 0.08799999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.6011599817498456,
+         "dof": 249,
+         "p_value": 0.5482803006772575,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 37,
+         "correct_only_in_b": 32,
+         "discordant_pairs": 69,
+         "p_value": 0.630456491786798,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.3881317890172014e-21
+        }
+       },
+       "composite_score": {
+        "system_a": 0.4543866666666667,
+        "system_b": 0.4388752380952381,
+        "mean_difference": 0.01551142857142862,
+        "bootstrap_ci_low": -0.00823499999999998,
+        "bootstrap_ci_high": 0.03878295238095241,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3179833333333334,
+        "system_b": 0.2985940476190476,
+        "mean_difference": 0.019389285714285776,
+        "bootstrap_ci_low": -0.010293750000000015,
+        "bootstrap_ci_high": 0.04847869047619053,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.76,
+       "b_step_count_term": 0.756,
+       "a_mae": 0.72,
+       "b_mae": 0.732
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.036,
+        "system_b": 0.024,
+        "mean_difference": 0.011999999999999997,
+        "bootstrap_ci_low": -0.004,
+        "bootstrap_ci_high": 0.028000000000000004,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.3438012400514816,
+         "dof": 249,
+         "p_value": 0.18023588114803066,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 4,
+         "correct_only_in_b": 1,
+         "discordant_pairs": 5,
+         "p_value": 0.375,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.0625
+        }
+       },
+       "step_f1": {
+        "system_a": 0.17688282828282828,
+        "system_b": 0.16013333333333332,
+        "mean_difference": 0.01674949494949496,
+        "bootstrap_ci_low": -0.0046003751803752,
+        "bootstrap_ci_high": 0.03826725108225111,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.5174822943745214,
+         "dof": 249,
+         "p_value": 0.13041352460556271,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.14967142857142857,
+        "system_b": 0.13906666666666667,
+        "mean_difference": 0.010604761904761895,
+        "bootstrap_ci_low": -0.009467142857142894,
+        "bootstrap_ci_high": 0.03117154761904763,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0200796889896417,
+         "dof": 249,
+         "p_value": 0.3086807417716517,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5295928029533957,
+        "system_b": 0.5244788966279009,
+        "mean_difference": 0.005113906325494799,
+        "bootstrap_ci_low": -0.011837131854139824,
+        "bootstrap_ci_high": 0.021759508351782166,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5971493316838827,
+         "dof": 249,
+         "p_value": 0.5509502869242987,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.456,
+        "system_b": 0.452,
+        "mean_difference": 0.0040000000000000036,
+        "bootstrap_ci_low": -0.064,
+        "bootstrap_ci_high": 0.07200000000000001,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.11373538113269116,
+         "dof": 249,
+         "p_value": 0.9095392134933367,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 39,
+         "correct_only_in_b": 38,
+         "discordant_pairs": 77,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.3234889800848443e-23
+        }
+       },
+       "composite_score": {
+        "system_a": 0.18805455988455988,
+        "system_b": 0.37550666666666666,
+        "mean_difference": -0.18745210678210678,
+        "bootstrap_ci_low": -0.20159779617604617,
+        "bootstrap_ci_high": 0.02403712193362191,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.23506819985569988,
+        "system_b": 0.21938333333333335,
+        "mean_difference": 0.01568486652236653,
+        "bootstrap_ci_low": -0.00412988050144299,
+        "bootstrap_ci_high": 0.03576228174603175,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.724,
+       "b_step_count_term": 0.6973333333333334,
+       "a_mae": 0.828,
+       "b_mae": 0.908
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.004,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": -0.012,
+        "bootstrap_ci_high": 0.012,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.0,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 1,
+         "correct_only_in_b": 1,
+         "discordant_pairs": 2,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.5
+        }
+       },
+       "step_f1": {
+        "system_a": 0.10786597846597848,
+        "system_b": 0.10957108447108448,
+        "mean_difference": -0.0017051060051059969,
+        "bootstrap_ci_low": -0.023099934232434234,
+        "bootstrap_ci_high": 0.019885744810744822,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.1574010705048318,
+         "dof": 249,
+         "p_value": 0.8750563297292842,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09175555555555555,
+        "system_b": 0.08707161727161727,
+        "mean_difference": 0.004683938283938274,
+        "bootstrap_ci_low": -0.014757844932844929,
+        "bootstrap_ci_high": 0.024763102453102454,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.4709927500425391,
+         "dof": 249,
+         "p_value": 0.6380582684757331,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.4709315107586074,
+        "system_b": 0.4651391350033641,
+        "mean_difference": 0.005792375755243273,
+        "bootstrap_ci_low": -0.009994805672408947,
+        "bootstrap_ci_high": 0.021430353214186553,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.7276764213641236,
+         "dof": 249,
+         "p_value": 0.4674953606284123,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.316,
+        "system_b": 0.284,
+        "mean_difference": 0.03200000000000003,
+        "bootstrap_ci_low": -0.03999999999999998,
+        "bootstrap_ci_high": 0.10399999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.8724545375763496,
+         "dof": 249,
+         "p_value": 0.3838009730348066,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 46,
+         "correct_only_in_b": 38,
+         "discordant_pairs": 84,
+         "p_value": 0.4452046690465762,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0339757656912846e-25
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3288063913863914,
+        "system_b": 0.12288325230325232,
+        "mean_difference": 0.20592313908313908,
+        "bootstrap_ci_low": -0.006492136530136586,
+        "bootstrap_ci_high": 0.22165959851259856,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16100798923298923,
+        "system_b": 0.15360406537906543,
+        "mean_difference": 0.0074039238539237995,
+        "bootstrap_ci_low": -0.013692708333333364,
+        "bootstrap_ci_high": 0.029350683830058826,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.5813333333333333,
+       "b_step_count_term": 0.5293333333333334,
+       "a_mae": 1.256,
+       "b_mae": 1.412
+      }
+     }
+    }
+   },
+   "size1000_balanced_trial0__uniform": {
+    "system_a": "size1000_balanced_trial0__biencoder_plus_ce__uniform",
+    "system_b": "size1000_balanced_trial0__biencoder_only__uniform",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.036,
+       "system_b": 0.044,
+       "mean_difference": -0.008,
+       "bootstrap_ci_low": -0.02266666666666666,
+       "bootstrap_ci_high": 0.005333333333333336,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -1.1341097489769987,
+        "dof": 749,
+        "p_value": 0.25711135713330774,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 11,
+        "correct_only_in_b": 17,
+        "discordant_pairs": 28,
+        "p_value": 0.34492845088243484,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 7.450580596923828e-09
+       },
+       "power": {
+        "sd_of_paired_differences": 0.19318150046738544,
+        "mde_at_this_n_80pct_power": 0.019762357007441885,
+        "n_needed_for_observed_difference_80pct_power": 4577
+       }
+      },
+      "step_f1": {
+       "system_a": 0.1681929107929108,
+       "system_b": 0.16026169386169387,
+       "mean_difference": 0.007931216931216928,
+       "bootstrap_ci_low": -0.007158234728234733,
+       "bootstrap_ci_high": 0.023094585137085108,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.0179428898720517,
+        "dof": 749,
+        "p_value": 0.3090337880813146,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.21337672598904028,
+        "mde_at_this_n_80pct_power": 0.021828317027625728,
+        "n_needed_for_observed_difference_80pct_power": 5681
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1484761090761091,
+       "system_b": 0.14410089540089538,
+       "mean_difference": 0.004375213675213707,
+       "bootstrap_ci_low": -0.010498002645502639,
+       "bootstrap_ci_high": 0.01910899674399675,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.571971890129737,
+        "dof": 749,
+        "p_value": 0.567512634305167,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.2094861010806011,
+        "mde_at_this_n_80pct_power": 0.021430308324739595,
+        "n_needed_for_observed_difference_80pct_power": 17994
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5259928206019984,
+       "system_b": 0.5131405987843701,
+       "mean_difference": 0.01285222181762824,
+       "bootstrap_ci_low": 0.0014254347075839033,
+       "bootstrap_ci_high": 0.024234935606906524,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.1655087543268396,
+        "dof": 749,
+        "p_value": 0.03066372043446786,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.16253575030601264,
+        "mde_at_this_n_80pct_power": 0.016627314293803954,
+        "n_needed_for_observed_difference_80pct_power": 1256
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4226666666666667,
+       "system_b": 0.43466666666666665,
+       "mean_difference": -0.011999999999999955,
+       "bootstrap_ci_low": -0.055999999999999994,
+       "bootstrap_ci_high": 0.030666666666666675,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.5444492256625664,
+        "dof": 749,
+        "p_value": 0.5862944265571732,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 132,
+        "correct_only_in_b": 141,
+        "discordant_pairs": 273,
+        "p_value": 0.6283375482150046,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.3177747429038154e-82
+       },
+       "power": {
+        "sd_of_paired_differences": 0.6036073136171143,
+        "mde_at_this_n_80pct_power": 0.06174868294916394,
+        "n_needed_for_observed_difference_80pct_power": 19859
+       }
+      },
+      "composite_score": {
+       "system_a": 0.20558398171432654,
+       "system_b": 0.1710682794982795,
+       "mean_difference": 0.03451570221604705,
+       "bootstrap_ci_low": -0.1929362423132423,
+       "bootstrap_ci_high": 0.08075016551041549,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.22249721852221854,
+       "system_b": 0.21383534937284937,
+       "mean_difference": 0.008661869149369172,
+       "bootstrap_ci_low": -0.006364499805749773,
+       "bootstrap_ci_high": 0.024122719953657373,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.13793103448275862,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.6617777777777778,
+      "b_step_count_term": 0.6373333333333333,
+      "a_mae": 1.0146666666666666,
+      "b_mae": 1.088
+     },
+     "composite_difference_decomposition": {
+      "total": 0.03451570221604705,
+      "contributions": {
+       "w_step_f1_x_delta": 0.003172486772486771,
+       "w_ordered_x_delta": 0.0013125641025641122,
+       "w_reference_micro_x_delta": 0.027586206896551724,
+       "w_step_count_x_delta": 0.002444444444444449
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.09191430475987296,
+       "w_ordered_x_delta": 0.03802802835498663,
+       "w_reference_micro_x_delta": 0.7992364380674931,
+       "w_step_count_x_delta": 0.07082122881764745
+      },
+      "sum_of_contributions_check": 0.03451570221604706
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.088,
+        "system_b": 0.112,
+        "mean_difference": -0.024000000000000007,
+        "bootstrap_ci_low": -0.064,
+        "bootstrap_ci_high": 0.016,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.2259763899243377,
+         "dof": 249,
+         "p_value": 0.2213657543610356,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 9,
+         "correct_only_in_b": 15,
+         "discordant_pairs": 24,
+         "p_value": 0.30745625495910645,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.1920928955078125e-07
+        }
+       },
+       "step_f1": {
+        "system_a": 0.2553857142857143,
+        "system_b": 0.25767619047619045,
+        "mean_difference": -0.0022904761904761206,
+        "bootstrap_ci_low": -0.038492499999999964,
+        "bootstrap_ci_high": 0.034152380952380934,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.12301659422037288,
+         "dof": 249,
+         "p_value": 0.9021931913407553,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2375267399267399,
+        "system_b": 0.24946666666666664,
+        "mean_difference": -0.011939926739926748,
+        "bootstrap_ci_low": -0.047832399267399274,
+        "bootstrap_ci_high": 0.02433547619047617,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.6425954508009398,
+         "dof": 249,
+         "p_value": 0.5210778710985292,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5810747688488774,
+        "system_b": 0.5836673787198069,
+        "mean_difference": -0.002592609870929463,
+        "bootstrap_ci_low": -0.02720332496562168,
+        "bootstrap_ci_high": 0.021335962990430377,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.21077256775570796,
+         "dof": 249,
+         "p_value": 0.8332371302579158,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.516,
+        "system_b": 0.584,
+        "mean_difference": -0.06799999999999995,
+        "bootstrap_ci_low": -0.136,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.9229412623646887,
+         "dof": 249,
+         "p_value": 0.055627965714236456,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 31,
+         "correct_only_in_b": 48,
+         "discordant_pairs": 79,
+         "p_value": 0.07116340869529117,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.308722450212111e-24
+        }
+       },
+       "composite_score": {
+        "system_a": 0.4462123076923077,
+        "system_b": 0.25857714285714284,
+        "mean_difference": 0.18763516483516485,
+        "bootstrap_ci_low": -0.033436551282051336,
+        "bootstrap_ci_high": 0.21272023809523807,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.30776538461538466,
+        "system_b": 0.32322142857142855,
+        "mean_difference": -0.015456043956043886,
+        "bootstrap_ci_low": -0.04987610347985351,
+        "bootstrap_ci_high": 0.019463690476190426,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.728,
+       "b_step_count_term": 0.8066666666666666,
+       "a_mae": 0.816,
+       "b_mae": 0.58
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.02,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": -0.016,
+        "bootstrap_ci_high": 0.016,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.0,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 2,
+         "discordant_pairs": 4,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.125
+        }
+       },
+       "step_f1": {
+        "system_a": 0.162415873015873,
+        "system_b": 0.13755642135642138,
+        "mean_difference": 0.024859451659451637,
+        "bootstrap_ci_low": 0.003961038961038957,
+        "bootstrap_ci_high": 0.04592816738816735,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.3098797282099457,
+         "dof": 249,
+         "p_value": 0.021713319503805208,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.138,
+        "system_b": 0.11288681318681318,
+        "mean_difference": 0.025113186813186833,
+        "bootstrap_ci_low": 0.005750595238095219,
+        "bootstrap_ci_high": 0.04476199633699633,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.518403394496033,
+         "dof": 249,
+         "p_value": 0.01241659376760713,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5241565821328713,
+        "system_b": 0.5035458587859397,
+        "mean_difference": 0.020610723346931592,
+        "bootstrap_ci_low": 0.0017978990731231715,
+        "bootstrap_ci_high": 0.0396442841004638,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.1196903844641635,
+         "dof": 249,
+         "p_value": 0.03502181655873185,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.452,
+        "system_b": 0.416,
+        "mean_difference": 0.03600000000000003,
+        "bootstrap_ci_low": -0.040000000000000036,
+        "bootstrap_ci_high": 0.11199999999999999,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.9231073908594604,
+         "dof": 249,
+         "p_value": 0.35684486697501744,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 52,
+         "correct_only_in_b": 43,
+         "discordant_pairs": 95,
+         "p_value": 0.41191007368097654,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 5.048709793414476e-29
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3787663492063492,
+        "system_b": 0.3491552791652792,
+        "mean_difference": 0.029611070041069998,
+        "bootstrap_ci_low": 0.012787806277056255,
+        "bootstrap_ci_high": 0.04658805086580077,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.22345793650793652,
+        "system_b": 0.186444098956599,
+        "mean_difference": 0.037013837551337525,
+        "bootstrap_ci_low": 0.015984757846320318,
+        "bootstrap_ci_high": 0.058235063582251084,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.724,
+       "b_step_count_term": 0.6026666666666667,
+       "a_mae": 0.828,
+       "b_mae": 1.192
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.0,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": null,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 0,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.08677714507714508,
+        "system_b": 0.08555246975246976,
+        "mean_difference": 0.0012246753246753228,
+        "bootstrap_ci_low": -0.016942854922854918,
+        "bootstrap_ci_high": 0.0190778255078255,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.1339700800865767,
+         "dof": 249,
+         "p_value": 0.8935344506018926,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.0699015873015873,
+        "system_b": 0.06994920634920634,
+        "mean_difference": -4.761904761904634e-05,
+        "bootstrap_ci_low": -0.01772396825396826,
+        "bootstrap_ci_high": 0.017530396825396807,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.005308576713404711,
+         "dof": 249,
+         "p_value": 0.9957686390507496,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.4727471108242462,
+        "system_b": 0.4522085588473638,
+        "mean_difference": 0.020538551976882424,
+        "bootstrap_ci_low": 0.003979514127350483,
+        "bootstrap_ci_high": 0.03686356252902512,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.444753752055888,
+         "dof": 249,
+         "p_value": 0.015189169840719866,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.3,
+        "system_b": 0.304,
+        "mean_difference": -0.0040000000000000036,
+        "bootstrap_ci_low": -0.08399999999999996,
+        "bootstrap_ci_high": 0.07200000000000001,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.1003045989282859,
+         "dof": 249,
+         "p_value": 0.9201832195486563,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 49,
+         "correct_only_in_b": 50,
+         "discordant_pairs": 99,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.1554436208840472e-30
+        }
+       },
+       "composite_score": {
+        "system_a": 0.1366008744512193,
+        "system_b": 0.10547241647241647,
+        "mean_difference": 0.03112845797880283,
+        "bootstrap_ci_low": -0.2054785662115662,
+        "bootstrap_ci_high": 0.07663210156510157,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.13626833444333447,
+        "system_b": 0.1318405205905206,
+        "mean_difference": 0.004427813852813878,
+        "bootstrap_ci_low": -0.0172678264790765,
+        "bootstrap_ci_high": 0.025711564546564526,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.13793103448275862,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.5333333333333334,
+       "b_step_count_term": 0.5026666666666666,
+       "a_mae": 1.4,
+       "b_mae": 1.492
+      }
+     }
+    }
+   },
+   "size1000_imbalanced_trial0__raw": {
+    "system_a": "size1000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "system_b": "size1000_imbalanced_trial0__biencoder_only__raw",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.034666666666666665,
+       "system_b": 0.030666666666666665,
+       "mean_difference": 0.004,
+       "bootstrap_ci_low": -0.009333333333333336,
+       "bootstrap_ci_high": 0.017333333333333333,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.5770934978764192,
+        "dof": 749,
+        "p_value": 0.5640497055730368,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 15,
+        "correct_only_in_b": 12,
+        "discordant_pairs": 27,
+        "p_value": 0.7011080384254456,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.4901161193847656e-08
+       },
+       "power": {
+        "sd_of_paired_differences": 0.1898210808198908,
+        "mde_at_this_n_80pct_power": 0.019418587999498898,
+        "n_needed_for_observed_difference_80pct_power": 17676
+       }
+      },
+      "step_f1": {
+       "system_a": 0.17549110149110148,
+       "system_b": 0.1599082251082251,
+       "mean_difference": 0.015582876382876365,
+       "bootstrap_ci_low": 0.0004490740740740855,
+       "bootstrap_ci_high": 0.030580307840307797,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 1.9985670517373664,
+        "dof": 749,
+        "p_value": 0.04601622584850322,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.213530311587402,
+        "mde_at_this_n_80pct_power": 0.02184402874649468,
+        "n_needed_for_observed_difference_80pct_power": 1474
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.16043398692810457,
+       "system_b": 0.14317142857142856,
+       "mean_difference": 0.017262558356676005,
+       "bootstrap_ci_low": 0.002453849206349215,
+       "bootstrap_ci_high": 0.03213259803921567,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.262716363391566,
+        "dof": 749,
+        "p_value": 0.023938775072672624,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.20893234267393115,
+        "mde_at_this_n_80pct_power": 0.021373659156459987,
+        "n_needed_for_observed_difference_80pct_power": 1150
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5302035628451818,
+       "system_b": 0.5253321480880906,
+       "mean_difference": 0.004871414757091186,
+       "bootstrap_ci_low": -0.0057258481871625185,
+       "bootstrap_ci_high": 0.015323234303164414,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.8991031660466737,
+        "dof": 749,
+        "p_value": 0.36888666409862675,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1483802888357256,
+        "mde_at_this_n_80pct_power": 0.015179218681625348,
+        "n_needed_for_observed_difference_80pct_power": 7282
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4786666666666667,
+       "system_b": 0.46266666666666667,
+       "mean_difference": 0.016000000000000014,
+       "bootstrap_ci_low": -0.02533333333333332,
+       "bootstrap_ci_high": 0.05600000000000005,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.768011189050925,
+        "dof": 749,
+        "p_value": 0.4427225952424852,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 128,
+        "correct_only_in_b": 116,
+        "discordant_pairs": 244,
+        "p_value": 0.48138284954551064,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 7.074749280333369e-74
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5705360185515193,
+        "mde_at_this_n_80pct_power": 0.05836550837911715,
+        "n_needed_for_observed_difference_80pct_power": 9981
+       }
+      },
+      "composite_score": {
+       "system_a": 0.21960917635741162,
+       "system_b": 0.1774036075036075,
+       "mean_difference": 0.04220556885380411,
+       "bootstrap_ci_low": -0.18012814514189512,
+       "bootstrap_ci_high": 0.2103692869663017,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.23879718473247882,
+       "system_b": 0.2217545093795094,
+       "mean_difference": 0.01704267535296941,
+       "bootstrap_ci_low": 0.0025348826942393245,
+       "bootstrap_ci_high": 0.03150743662995497,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.14285714285714285,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.727111111111111,
+      "b_step_count_term": 0.7048888888888889,
+      "a_mae": 0.8186666666666667,
+      "b_mae": 0.8853333333333333
+     },
+     "composite_difference_decomposition": {
+      "total": 0.04220556885380411,
+      "contributions": {
+       "w_step_f1_x_delta": 0.006233150553150546,
+       "w_ordered_x_delta": 0.005178767507002802,
+       "w_reference_micro_x_delta": 0.02857142857142857,
+       "w_step_count_x_delta": 0.0022222222222222144
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.14768550033626035,
+       "w_ordered_x_delta": 0.12270341681548085,
+       "w_reference_micro_x_delta": 0.6769587366633336,
+       "w_step_count_x_delta": 0.052652346184925765
+      },
+      "sum_of_contributions_check": 0.04220556885380413
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.096,
+        "system_b": 0.076,
+        "mean_difference": 0.020000000000000004,
+        "bootstrap_ci_low": -0.016,
+        "bootstrap_ci_high": 0.056,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0915070131742683,
+         "dof": 249,
+         "p_value": 0.27610486880840734,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 13,
+         "correct_only_in_b": 8,
+         "discordant_pairs": 21,
+         "p_value": 0.38331031799316406,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 9.5367431640625e-07
+        }
+       },
+       "step_f1": {
+        "system_a": 0.2812761904761905,
+        "system_b": 0.25001904761904764,
+        "mean_difference": 0.03125714285714287,
+        "bootstrap_ci_low": -0.004209523809523803,
+        "bootstrap_ci_high": 0.06744761904761906,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.722464649731647,
+         "dof": 249,
+         "p_value": 0.0862270489793141,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.26713333333333333,
+        "system_b": 0.2339333333333333,
+        "mean_difference": 0.033200000000000035,
+        "bootstrap_ci_low": -0.002333333333333327,
+        "bootstrap_ci_high": 0.06946833333333328,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.8129864812642982,
+         "dof": 249,
+         "p_value": 0.07103800867102099,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5957691572119477,
+        "system_b": 0.5881874136887768,
+        "mean_difference": 0.00758174352317087,
+        "bootstrap_ci_low": -0.014231501392419446,
+        "bootstrap_ci_high": 0.02963888791816378,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.6718164918439661,
+         "dof": 249,
+         "p_value": 0.5023233611369473,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.66,
+        "system_b": 0.624,
+        "mean_difference": 0.03600000000000003,
+        "bootstrap_ci_low": -0.03200000000000003,
+        "bootstrap_ci_high": 0.10399999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0684057031414511,
+         "dof": 249,
+         "p_value": 0.2863722289910878,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 40,
+         "correct_only_in_b": 31,
+         "discordant_pairs": 71,
+         "p_value": 0.3424709984198679,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 8.470329472543003e-22
+        }
+       },
+       "composite_score": {
+        "system_a": 0.4757171428571429,
+        "system_b": 0.4517876190476191,
+        "mean_difference": 0.02392952380952379,
+        "bootstrap_ci_low": -0.0021174523809524485,
+        "bootstrap_ci_high": 0.05062961904761908,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.34464642857142863,
+        "system_b": 0.3147345238095238,
+        "mean_difference": 0.029911904761904806,
+        "bootstrap_ci_low": -0.0026468154761905625,
+        "bootstrap_ci_high": 0.06328702380952389,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8306666666666667,
+       "b_step_count_term": 0.816,
+       "a_mae": 0.508,
+       "b_mae": 0.552
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.012,
+        "mean_difference": -0.004,
+        "bootstrap_ci_low": -0.023999999999999997,
+        "bootstrap_ci_high": 0.012,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.4464969065851096,
+         "dof": 249,
+         "p_value": 0.655626407259774,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 3,
+         "discordant_pairs": 5,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.0625
+        }
+       },
+       "step_f1": {
+        "system_a": 0.15237806637806636,
+        "system_b": 0.14063174603174602,
+        "mean_difference": 0.011746320346320338,
+        "bootstrap_ci_low": -0.011561919191919179,
+        "bootstrap_ci_high": 0.03514382395382391,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.9875399150238242,
+         "dof": 249,
+         "p_value": 0.3243366568134151,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13369999999999999,
+        "system_b": 0.11897142857142856,
+        "mean_difference": 0.014728571428571424,
+        "bootstrap_ci_low": -0.007072380952380943,
+        "bootstrap_ci_high": 0.03630071428571429,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.3307012930247772,
+         "dof": 249,
+         "p_value": 0.18450460693288087,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5271035505673597,
+        "system_b": 0.5224520146829778,
+        "mean_difference": 0.004651535884381941,
+        "bootstrap_ci_low": -0.012889396863055598,
+        "bootstrap_ci_high": 0.02209242281130715,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5279555660772065,
+         "dof": 249,
+         "p_value": 0.5980003460806274,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.488,
+        "system_b": 0.456,
+        "mean_difference": 0.03199999999999997,
+        "bootstrap_ci_low": -0.04799999999999999,
+        "bootstrap_ci_high": 0.10800000000000004,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.8075596335838452,
+         "dof": 249,
+         "p_value": 0.42011489714057015,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 53,
+         "correct_only_in_b": 45,
+         "discordant_pairs": 98,
+         "p_value": 0.479692499567487,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 6.310887241768095e-30
+        }
+       },
+       "composite_score": {
+        "system_a": 0.37386122655122656,
+        "system_b": 0.36221079365079367,
+        "mean_difference": 0.011650432900432883,
+        "bootstrap_ci_low": -0.006662038961038975,
+        "bootstrap_ci_high": 0.02973568253968255,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2173265331890332,
+        "system_b": 0.2027634920634921,
+        "mean_difference": 0.014563041125541104,
+        "bootstrap_ci_low": -0.008327548701298733,
+        "bootstrap_ci_high": 0.037169603174603175,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.728,
+       "b_step_count_term": 0.7026666666666667,
+       "a_mae": 0.816,
+       "b_mae": 0.892
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.004,
+        "mean_difference": -0.004,
+        "bootstrap_ci_low": -0.012,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.0,
+         "dof": 249,
+         "p_value": 0.3182813015158006,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 1,
+         "discordant_pairs": 1,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.09281904761904762,
+        "system_b": 0.08907388167388168,
+        "mean_difference": 0.0037451659451659403,
+        "bootstrap_ci_low": -0.013423246753246748,
+        "bootstrap_ci_high": 0.020905180375180375,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.4289958854999538,
+         "dof": 249,
+         "p_value": 0.6682971396489298,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08046862745098039,
+        "system_b": 0.07660952380952381,
+        "mean_difference": 0.003859103641456585,
+        "bootstrap_ci_low": -0.012162962184873952,
+        "bootstrap_ci_high": 0.019871015406162467,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.4763971683731872,
+         "dof": 249,
+         "p_value": 0.6342092152236537,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.467737980756238,
+        "system_b": 0.4653570158925172,
+        "mean_difference": 0.0023809648637208025,
+        "bootstrap_ci_low": -0.012459692819795977,
+        "bootstrap_ci_high": 0.017692036008492375,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.30772040993191246,
+         "dof": 249,
+         "p_value": 0.7585523236154185,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.288,
+        "system_b": 0.308,
+        "mean_difference": -0.020000000000000018,
+        "bootstrap_ci_low": -0.08400000000000002,
+        "bootstrap_ci_high": 0.04799999999999999,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.5765789258001914,
+         "dof": 249,
+         "p_value": 0.5647447828879817,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 35,
+         "correct_only_in_b": 40,
+         "discordant_pairs": 75,
+         "p_value": 0.644463913894226,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 5.293955920339377e-23
+        }
+       },
+       "composite_score": {
+        "system_a": 0.1521063025210084,
+        "system_b": 0.11821240981240982,
+        "mean_difference": 0.03389389270859858,
+        "bootstrap_ci_low": -0.18516105483405484,
+        "bootstrap_ci_high": 0.2034550211569477,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1544185924369748,
+        "system_b": 0.1477655122655123,
+        "mean_difference": 0.0066530801714625165,
+        "bootstrap_ci_low": -0.011415641843858775,
+        "bootstrap_ci_high": 0.024512548250360772,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.14285714285714285,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.6226666666666667,
+       "b_step_count_term": 0.5960000000000001,
+       "a_mae": 1.132,
+       "b_mae": 1.212
+      }
+     }
+    }
+   },
+   "size1000_imbalanced_trial0__typed": {
+    "system_a": "size1000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "system_b": "size1000_imbalanced_trial0__biencoder_only__typed",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.032,
+       "system_b": 0.02666666666666667,
+       "mean_difference": 0.005333333333333332,
+       "bootstrap_ci_low": -0.005333333333333332,
+       "bootstrap_ci_high": 0.016,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.9999999999999997,
+        "dof": 749,
+        "p_value": 0.31763345838622375,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 10,
+        "correct_only_in_b": 6,
+        "discordant_pairs": 16,
+        "p_value": 0.454498291015625,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 3.0517578125e-05
+       },
+       "power": {
+        "sd_of_paired_differences": 0.14605934866804432,
+        "mde_at_this_n_80pct_power": 0.014941787829935832,
+        "n_needed_for_observed_difference_80pct_power": 5887
+       }
+      },
+      "step_f1": {
+       "system_a": 0.1817014541014541,
+       "system_b": 0.16706542825366355,
+       "mean_difference": 0.014636025847790557,
+       "bootstrap_ci_low": 0.001580774171362395,
+       "bootstrap_ci_high": 0.02774735099323338,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.1757146236885854,
+        "dof": 749,
+        "p_value": 0.02988855635851132,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.18422640133458457,
+        "mde_at_this_n_80pct_power": 0.018846255488035153,
+        "n_needed_for_observed_difference_80pct_power": 1244
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.16300634920634918,
+       "system_b": 0.14791856661856662,
+       "mean_difference": 0.015087782587782567,
+       "bootstrap_ci_low": 0.00246486531986533,
+       "bootstrap_ci_high": 0.028071010101010117,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.3287821279295873,
+        "dof": 749,
+        "p_value": 0.0201357962444148,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.17743005597112818,
+        "mde_at_this_n_80pct_power": 0.018150993244530768,
+        "n_needed_for_observed_difference_80pct_power": 1086
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5375348919863999,
+       "system_b": 0.517633339818622,
+       "mean_difference": 0.01990155216777789,
+       "bootstrap_ci_low": 0.009349599688493962,
+       "bootstrap_ci_high": 0.030686991743384337,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 3.738518460861965,
+        "dof": 749,
+        "p_value": 0.00019921316002781249,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1457867490260367,
+        "mde_at_this_n_80pct_power": 0.014913901042472118,
+        "n_needed_for_observed_difference_80pct_power": 422
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5093333333333333,
+       "system_b": 0.47333333333333333,
+       "mean_difference": 0.035999999999999976,
+       "bootstrap_ci_low": -0.002666666666666706,
+       "bootstrap_ci_high": 0.07600000000000001,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.7637626058369016,
+        "dof": 749,
+        "p_value": 0.07817959836431426,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 131,
+        "correct_only_in_b": 104,
+        "discordant_pairs": 235,
+        "p_value": 0.08966190496308674,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 3.622271631530685e-71
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5589757942744745,
+        "mde_at_this_n_80pct_power": 0.05718290404745847,
+        "n_needed_for_observed_difference_80pct_power": 1893
+       }
+      },
+      "composite_score": {
+       "system_a": 0.1950935975135975,
+       "system_b": 0.18102396350925765,
+       "mean_difference": 0.01406963400433986,
+       "bootstrap_ci_low": -0.18994628221560578,
+       "bootstrap_ci_high": 0.21834900367823906,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2438669968919969,
+       "system_b": 0.22627995438657209,
+       "mean_difference": 0.01758704250542481,
+       "bootstrap_ci_low": 0.0047531535920506355,
+       "bootstrap_ci_high": 0.03065394123577947,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.0,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.735111111111111,
+      "b_step_count_term": 0.6982222222222223,
+      "a_mae": 0.7946666666666666,
+      "b_mae": 0.9053333333333333
+     },
+     "composite_difference_decomposition": {
+      "total": 0.01406963400433986,
+      "contributions": {
+       "w_step_f1_x_delta": 0.005854410339116223,
+       "w_ordered_x_delta": 0.00452633477633477,
+       "w_reference_micro_x_delta": 0.0,
+       "w_step_count_x_delta": 0.0036888888888888752
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.4161025323978148,
+       "w_ordered_x_delta": 0.32170948973787067,
+       "w_reference_micro_x_delta": 0.0,
+       "w_step_count_x_delta": 0.2621879778643152
+      },
+      "sum_of_contributions_check": 0.014069634004339868
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.096,
+        "system_b": 0.08,
+        "mean_difference": 0.016,
+        "bootstrap_ci_low": -0.016,
+        "bootstrap_ci_high": 0.048,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0,
+         "dof": 249,
+         "p_value": 0.3182813015158006,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 10,
+         "correct_only_in_b": 6,
+         "discordant_pairs": 16,
+         "p_value": 0.454498291015625,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.0517578125e-05
+        }
+       },
+       "step_f1": {
+        "system_a": 0.2948,
+        "system_b": 0.2664915750915751,
+        "mean_difference": 0.02830842490842489,
+        "bootstrap_ci_low": -0.002949340659340637,
+        "bootstrap_ci_high": 0.06037642857142845,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.7383005406408176,
+         "dof": 249,
+         "p_value": 0.08339402264707846,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2843333333333333,
+        "system_b": 0.25579999999999997,
+        "mean_difference": 0.028533333333333355,
+        "bootstrap_ci_low": -0.0026683333333333684,
+        "bootstrap_ci_high": 0.06020000000000003,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.7593964675625766,
+         "dof": 249,
+         "p_value": 0.07973828303105444,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6194803222315687,
+        "system_b": 0.5812850040425221,
+        "mean_difference": 0.038195318189046534,
+        "bootstrap_ci_low": 0.01518897387464351,
+        "bootstrap_ci_high": 0.06094721363896043,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 3.2787562306180345,
+         "dof": 249,
+         "p_value": 0.001191414912093312,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.724,
+        "system_b": 0.688,
+        "mean_difference": 0.03600000000000003,
+        "bootstrap_ci_low": -0.027999999999999914,
+        "bootstrap_ci_high": 0.09599999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.134544520671362,
+         "dof": 249,
+         "p_value": 0.2576572211193157,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 36,
+         "correct_only_in_b": 27,
+         "discordant_pairs": 63,
+         "p_value": 0.31350305329645284,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.168404344971009e-19
+        }
+       },
+       "composite_score": {
+        "system_a": 0.49108666666666667,
+        "system_b": 0.46666996336996336,
+        "mean_difference": 0.024416703296703313,
+        "bootstrap_ci_low": 0.0009851428571428424,
+        "bootstrap_ci_high": 0.04869576373626372,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.36385833333333345,
+        "system_b": 0.3333374542124543,
+        "mean_difference": 0.03052087912087914,
+        "bootstrap_ci_low": 0.0012314285714286595,
+        "bootstrap_ci_high": 0.06086970467032964,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8786666666666667,
+       "b_step_count_term": 0.8333333333333334,
+       "a_mae": 0.364,
+       "b_mae": 0.5
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.0,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": null,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 0,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.14674285714285712,
+        "system_b": 0.15024155844155845,
+        "mean_difference": -0.0034987012987013344,
+        "bootstrap_ci_low": -0.02194679653679657,
+        "bootstrap_ci_high": 0.014803643578643565,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.378221170690418,
+         "dof": 249,
+         "p_value": 0.7055885424715962,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11846666666666665,
+        "system_b": 0.12006666666666665,
+        "mean_difference": -0.0016000000000000042,
+        "bootstrap_ci_low": -0.018335000000000018,
+        "bootstrap_ci_high": 0.014799999999999954,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.18848883430245414,
+         "dof": 249,
+         "p_value": 0.8506469959613095,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5202871082354069,
+        "system_b": 0.527144581146914,
+        "mean_difference": -0.006857472911507068,
+        "bootstrap_ci_low": -0.02217617494101077,
+        "bootstrap_ci_high": 0.00826169872086737,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.8854709469713923,
+         "dof": 249,
+         "p_value": 0.37675697983122153,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.48,
+        "system_b": 0.5,
+        "mean_difference": -0.020000000000000018,
+        "bootstrap_ci_low": -0.09600000000000003,
+        "bootstrap_ci_high": 0.055999999999999994,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.5177162735856528,
+         "dof": 249,
+         "p_value": 0.6051158898097824,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 44,
+         "correct_only_in_b": 49,
+         "discordant_pairs": 93,
+         "p_value": 0.6785320136533252,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.0194839173657902e-28
+        }
+       },
+       "composite_score": {
+        "system_a": 0.36383714285714286,
+        "system_b": 0.37118329004329004,
+        "mean_difference": -0.007346147186147178,
+        "bootstrap_ci_low": -0.02132034559884561,
+        "bootstrap_ci_high": 0.006820208513708469,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20479642857142857,
+        "system_b": 0.2139791125541126,
+        "mean_difference": -0.009182683982684015,
+        "bootstrap_ci_low": -0.026650431998557,
+        "bootstrap_ci_high": 0.008525260642135655,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.696,
+       "b_step_count_term": 0.7506666666666667,
+       "a_mae": 0.912,
+       "b_mae": 0.748
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.0,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": null,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 0,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.10356150516150515,
+        "system_b": 0.08446315122785711,
+        "mean_difference": 0.019098353933648046,
+        "bootstrap_ci_low": 0.004463474172885944,
+        "bootstrap_ci_high": 0.03365736005824241,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.5650683241107477,
+         "dof": 249,
+         "p_value": 0.010902449713303886,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08621904761904761,
+        "system_b": 0.06788903318903318,
+        "mean_difference": 0.018330014430014432,
+        "bootstrap_ci_low": 0.005765595238095242,
+        "bootstrap_ci_high": 0.031204917027417015,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.8340257035284675,
+         "dof": 249,
+         "p_value": 0.004973438782960263,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.47283724549222417,
+        "system_b": 0.4444704342664301,
+        "mean_difference": 0.028366811225794042,
+        "bootstrap_ci_low": 0.01364069204922734,
+        "bootstrap_ci_high": 0.043317017416558,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 3.806427235047749,
+         "dof": 249,
+         "p_value": 0.00017755066591637337,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.324,
+        "system_b": 0.232,
+        "mean_difference": 0.092,
+        "bootstrap_ci_low": 0.023999999999999966,
+        "bootstrap_ci_high": 0.16,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.6178184257968895,
+         "dof": 249,
+         "p_value": 0.009391417176563294,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 51,
+         "correct_only_in_b": 28,
+         "discordant_pairs": 79,
+         "p_value": 0.012812402175831366,
+         "significant_at_alpha": true,
+         "min_attainable_p_value": 3.308722450212111e-24
+        }
+       },
+       "composite_score": {
+        "system_a": 0.130356983016983,
+        "system_b": 0.10521863711451947,
+        "mean_difference": 0.02513834590246354,
+        "bootstrap_ci_low": -0.17950824647574654,
+        "bootstrap_ci_high": 0.2296010197025197,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16294622877122877,
+        "system_b": 0.13152329639314936,
+        "mean_difference": 0.031422932378079416,
+        "bootstrap_ci_low": 0.014466832160894618,
+        "bootstrap_ci_high": 0.04841267975080477,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.6306666666666667,
+       "b_step_count_term": 0.5106666666666666,
+       "a_mae": 1.108,
+       "b_mae": 1.468
+      }
+     }
+    }
+   },
+   "size1000_imbalanced_trial0__uniform": {
+    "system_a": "size1000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "system_b": "size1000_imbalanced_trial0__biencoder_only__uniform",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.03333333333333333,
+       "system_b": 0.032,
+       "mean_difference": 0.0013333333333333322,
+       "bootstrap_ci_low": -0.010666666666666665,
+       "bootstrap_ci_high": 0.013333333333333336,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.21807928637912496,
+        "dof": 749,
+        "p_value": 0.8274267363770448,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 11,
+        "correct_only_in_b": 10,
+        "discordant_pairs": 21,
+        "p_value": 1.0,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 9.5367431640625e-07
+       },
+       "power": {
+        "sd_of_paired_differences": 0.16743835589928982,
+        "mde_at_this_n_80pct_power": 0.01712884804194555,
+        "n_needed_for_observed_difference_80pct_power": 123778
+       }
+      },
+      "step_f1": {
+       "system_a": 0.17149318089318089,
+       "system_b": 0.16287219914588333,
+       "mean_difference": 0.008620981747297557,
+       "bootstrap_ci_low": -0.005169358098042298,
+       "bootstrap_ci_high": 0.02219807150938729,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.2373224404960492,
+        "dof": 749,
+        "p_value": 0.21635516336813798,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1908114658028074,
+        "mde_at_this_n_80pct_power": 0.019519903816799484,
+        "n_needed_for_observed_difference_80pct_power": 3846
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.15812698412698412,
+       "system_b": 0.14818973544973546,
+       "mean_difference": 0.009937248677248656,
+       "bootstrap_ci_low": -0.003756846560846583,
+       "bootstrap_ci_high": 0.023454359788359806,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.4405021710296155,
+        "dof": 749,
+        "p_value": 0.1501432468440412,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.18892214706546157,
+        "mde_at_this_n_80pct_power": 0.019326627590566935,
+        "n_needed_for_observed_difference_80pct_power": 2837
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5309588431125554,
+       "system_b": 0.5193862670378518,
+       "mean_difference": 0.011572576074703522,
+       "bootstrap_ci_low": 0.0011236190829555823,
+       "bootstrap_ci_high": 0.022078257302976023,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.154510559894725,
+        "dof": 749,
+        "p_value": 0.03151836831140042,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1470997887536336,
+        "mde_at_this_n_80pct_power": 0.015048224255610766,
+        "n_needed_for_observed_difference_80pct_power": 1269
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5333333333333333,
+       "system_b": 0.444,
+       "mean_difference": 0.08933333333333332,
+       "bootstrap_ci_low": 0.04666666666666669,
+       "bootstrap_ci_high": 0.13066666666666665,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 4.226058756644875,
+        "dof": 749,
+        "p_value": 2.671654797561336e-05,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 162,
+        "correct_only_in_b": 95,
+        "discordant_pairs": 257,
+        "p_value": 3.4915311393937505e-05,
+        "significant_at_alpha": true,
+        "min_attainable_p_value": 8.636168555094445e-78
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5789067855109631,
+        "mde_at_this_n_80pct_power": 0.059221833051398894,
+        "n_needed_for_observed_difference_80pct_power": 330
+       }
+      },
+      "composite_score": {
+       "system_a": 0.2565242564842565,
+       "system_b": 0.25302802251549616,
+       "mean_difference": 0.0034962339687603095,
+       "bootstrap_ci_low": -0.05353745500581292,
+       "bootstrap_ci_high": 0.21120674228081857,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2373219872719873,
+       "system_b": 0.219062805922148,
+       "mean_difference": 0.01825918134983931,
+       "bootstrap_ci_low": 0.004473598172660635,
+       "bootstrap_ci_high": 0.03223131337582984,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.3333333333333333,
+      "b_ref_micro": 0.3888888888888889,
+      "a_step_count_term": 0.7382222222222222,
+      "b_step_count_term": 0.6564444444444444,
+      "a_mae": 0.7853333333333333,
+      "b_mae": 1.0306666666666666
+     },
+     "composite_difference_decomposition": {
+      "total": 0.0034962339687603095,
+      "contributions": {
+       "w_step_f1_x_delta": 0.003448392698919023,
+       "w_ordered_x_delta": 0.0029811746031745967,
+       "w_reference_micro_x_delta": -0.011111111111111117,
+       "w_step_count_x_delta": 0.008177777777777784
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.9863163420215124,
+       "w_ordered_x_delta": 0.8526816654183067,
+       "w_reference_micro_x_delta": -3.178022755453887,
+       "w_step_count_x_delta": 2.339024748014061
+      },
+      "sum_of_contributions_check": 0.003496233968760287
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.088,
+        "system_b": 0.088,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": -0.032,
+        "bootstrap_ci_high": 0.032,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.0,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 9,
+         "correct_only_in_b": 9,
+         "discordant_pairs": 18,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 7.62939453125e-06
+        }
+       },
+       "step_f1": {
+        "system_a": 0.28986666666666666,
+        "system_b": 0.27620346320346323,
+        "mean_difference": 0.013663203463203433,
+        "bootstrap_ci_low": -0.017738549783549794,
+        "bootstrap_ci_high": 0.04499324675324674,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.8396152162209627,
+         "dof": 249,
+         "p_value": 0.40192956668541396,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.286,
+        "system_b": 0.2627866666666666,
+        "mean_difference": 0.023213333333333364,
+        "bootstrap_ci_low": -0.008734000000000037,
+        "bootstrap_ci_high": 0.0550133333333333,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4065708333870053,
+         "dof": 249,
+         "p_value": 0.16080149942256647,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6176363641175623,
+        "system_b": 0.5917252890778902,
+        "mean_difference": 0.02591107503967205,
+        "bootstrap_ci_low": 0.005297600000346262,
+        "bootstrap_ci_high": 0.04606579516951809,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.460486066330049,
+         "dof": 249,
+         "p_value": 0.014554646486243975,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.724,
+        "system_b": 0.648,
+        "mean_difference": 0.07599999999999996,
+        "bootstrap_ci_low": 0.0119999999999999,
+        "bootstrap_ci_high": 0.14,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.2736100001038686,
+         "dof": 249,
+         "p_value": 0.023841447391038006,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 45,
+         "correct_only_in_b": 26,
+         "discordant_pairs": 71,
+         "p_value": 0.03192716208321237,
+         "significant_at_alpha": true,
+         "min_attainable_p_value": 8.470329472543003e-22
+        }
+       },
+       "composite_score": {
+        "system_a": 0.4872133333333334,
+        "system_b": 0.4674507186147186,
+        "mean_difference": 0.01976261471861479,
+        "bootstrap_ci_low": -0.00431714891774886,
+        "bootstrap_ci_high": 0.04418913593073597,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3590166666666667,
+        "system_b": 0.3343133982683983,
+        "mean_difference": 0.02470326839826842,
+        "bootstrap_ci_low": -0.005396436147186265,
+        "bootstrap_ci_high": 0.055236419913419925,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8546666666666667,
+       "b_step_count_term": 0.7813333333333333,
+       "a_mae": 0.436,
+       "b_mae": 0.656
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.008,
+        "mean_difference": 0.004,
+        "bootstrap_ci_low": -0.008,
+        "bootstrap_ci_high": 0.016,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5765789258001913,
+         "dof": 249,
+         "p_value": 0.5647447828879819,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 1,
+         "discordant_pairs": 3,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.25
+        }
+       },
+       "step_f1": {
+        "system_a": 0.13702886002886003,
+        "system_b": 0.13114314574314573,
+        "mean_difference": 0.0058857142857143,
+        "bootstrap_ci_low": -0.01610709956709957,
+        "bootstrap_ci_high": 0.02762005050505054,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5282098071747343,
+         "dof": 249,
+         "p_value": 0.5978241547793491,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.1158,
+        "system_b": 0.10979999999999998,
+        "mean_difference": 0.006000000000000019,
+        "bootstrap_ci_low": -0.015199999999999991,
+        "bootstrap_ci_high": 0.027200000000000016,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5585922018031984,
+         "dof": 249,
+         "p_value": 0.5769420314185905,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5160879867754459,
+        "system_b": 0.5112249003003103,
+        "mean_difference": 0.0048630864751355585,
+        "bootstrap_ci_low": -0.012557044198839304,
+        "bootstrap_ci_high": 0.02290415945746456,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5278058144344011,
+         "dof": 249,
+         "p_value": 0.5981041363779501,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.496,
+        "system_b": 0.42,
+        "mean_difference": 0.07600000000000001,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.15200000000000002,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.9817089232415201,
+         "dof": 249,
+         "p_value": 0.048611557378900494,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 56,
+         "correct_only_in_b": 37,
+         "discordant_pairs": 93,
+         "p_value": 0.06138589870445953,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.0194839173657902e-28
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3622182106782107,
+        "system_b": 0.3537972582972583,
+        "mean_difference": 0.008420952380952418,
+        "bootstrap_ci_low": -0.009598891774891828,
+        "bootstrap_ci_high": 0.026652393217893196,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20277276334776337,
+        "system_b": 0.19224657287157285,
+        "mean_difference": 0.010526190476190522,
+        "bootstrap_ci_low": -0.011998614718614704,
+        "bootstrap_ci_high": 0.0333154915223665,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.7266666666666667,
+       "b_step_count_term": 0.6839999999999999,
+       "a_mae": 0.82,
+       "b_mae": 0.948
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.0,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": null,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 0,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.087584015984016,
+        "system_b": 0.08126998849104111,
+        "mean_difference": 0.006314027492974883,
+        "bootstrap_ci_low": -0.007292429587955915,
+        "bootstrap_ci_high": 0.020001932920880285,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.9024901954367418,
+         "dof": 249,
+         "p_value": 0.36766871233089804,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.07258095238095237,
+        "system_b": 0.07198253968253968,
+        "mean_difference": 0.0005984126984126953,
+        "bootstrap_ci_low": -0.011750873015873017,
+        "bootstrap_ci_high": 0.012935198412698407,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.0939333188214102,
+         "dof": 249,
+         "p_value": 0.9252376666192778,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.45915217844465805,
+        "system_b": 0.45520861173535476,
+        "mean_difference": 0.003943566709303292,
+        "bootstrap_ci_low": -0.011716320539060101,
+        "bootstrap_ci_high": 0.019640906014326803,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.49557753516678066,
+         "dof": 249,
+         "p_value": 0.6206295943755238,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.38,
+        "system_b": 0.264,
+        "mean_difference": 0.11599999999999999,
+        "bootstrap_ci_low": 0.040000000000000036,
+        "bootstrap_ci_high": 0.18800000000000003,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 3.0569366103339726,
+         "dof": 249,
+         "p_value": 0.002479813125251934,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 61,
+         "correct_only_in_b": 32,
+         "discordant_pairs": 93,
+         "p_value": 0.003461853491442379,
+         "significant_at_alpha": true,
+         "min_attainable_p_value": 2.0194839173657902e-28
+        }
+       },
+       "composite_score": {
+        "system_a": 0.18680789210789212,
+        "system_b": 0.18228053507895614,
+        "mean_difference": 0.004527357028935974,
+        "bootstrap_ci_low": -0.05361148512400906,
+        "bootstrap_ci_high": 0.21159307314761264,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.15017653180153182,
+        "system_b": 0.13062844662647294,
+        "mean_difference": 0.019548085175058877,
+        "bootstrap_ci_low": 0.0029529707390562733,
+        "bootstrap_ci_high": 0.03603830128205128,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.3333333333333333,
+       "b_ref_micro": 0.3888888888888889,
+       "a_step_count_term": 0.6333333333333333,
+       "b_step_count_term": 0.504,
+       "a_mae": 1.1,
+       "b_mae": 1.488
+      }
+     }
+    }
+   },
+   "size2000_imbalanced_trial0__raw": {
+    "system_a": "size2000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "system_b": "size2000_imbalanced_trial0__biencoder_only__raw",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.037333333333333336,
+       "system_b": 0.04666666666666667,
+       "mean_difference": -0.009333333333333332,
+       "bootstrap_ci_low": -0.025333333333333333,
+       "bootstrap_ci_high": 0.006666666666666668,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -1.151042144372694,
+        "dof": 749,
+        "p_value": 0.25008221410042897,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 15,
+        "correct_only_in_b": 22,
+        "discordant_pairs": 37,
+        "p_value": 0.3240086000878364,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.4551915228366852e-11
+       },
+       "power": {
+        "sd_of_paired_differences": 0.22206298997712115,
+        "mde_at_this_n_80pct_power": 0.02271691686548816,
+        "n_needed_for_observed_difference_80pct_power": 4444
+       }
+      },
+      "step_f1": {
+       "system_a": 0.17911729751729755,
+       "system_b": 0.17804892884892884,
+       "mean_difference": 0.0010683686683687077,
+       "bootstrap_ci_low": -0.015070211270211272,
+       "bootstrap_ci_high": 0.017312378732378716,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.129727109376959,
+        "dof": 749,
+        "p_value": 0.8968171632727017,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.2255386796975871,
+        "mde_at_this_n_80pct_power": 0.023072477935967266,
+        "n_needed_for_observed_difference_80pct_power": 349791
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1601707045391256,
+       "system_b": 0.1595999185999186,
+       "mean_difference": 0.000570785939207008,
+       "bootstrap_ci_low": -0.014968280423280425,
+       "bootstrap_ci_high": 0.016577384433305496,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.07082504385400597,
+        "dof": 749,
+        "p_value": 0.9435559056019407,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.22070747676124325,
+        "mde_at_this_n_80pct_power": 0.022578248638791126,
+        "n_needed_for_observed_difference_80pct_power": 1173533
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5400628557221581,
+       "system_b": 0.5233271649996762,
+       "mean_difference": 0.016735690722481822,
+       "bootstrap_ci_low": 0.005974376919219721,
+       "bootstrap_ci_high": 0.027609911470645936,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 3.004447821875298,
+        "dof": 749,
+        "p_value": 0.0027493504253154398,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.15254908501642278,
+        "mde_at_this_n_80pct_power": 0.015605684146563109,
+        "n_needed_for_observed_difference_80pct_power": 653
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.47333333333333333,
+       "system_b": 0.47333333333333333,
+       "mean_difference": 0.0,
+       "bootstrap_ci_low": -0.03999999999999998,
+       "bootstrap_ci_high": 0.03999999999999998,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.0,
+        "dof": 749,
+        "p_value": 1.0,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 120,
+        "correct_only_in_b": 120,
+        "discordant_pairs": 240,
+        "p_value": 1.0,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.131959884853339e-72
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5660629261090032,
+        "mde_at_this_n_80pct_power": 0.05790791358063791,
+        "n_needed_for_observed_difference_80pct_power": null
+       }
+      },
+      "composite_score": {
+       "system_a": 0.19160924147976782,
+       "system_b": 0.38861065823065827,
+       "mean_difference": -0.19700141675089045,
+       "bootstrap_ci_low": -0.20898378577124635,
+       "bootstrap_ci_high": 0.008006871516397944,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2395115518497098,
+       "system_b": 0.23576332278832285,
+       "mean_difference": 0.003748229061386943,
+       "bootstrap_ci_low": -0.011601815129923658,
+       "bootstrap_ci_high": 0.019057348958911483,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.0,
+      "b_ref_micro": 1.0,
+      "a_step_count_term": 0.719111111111111,
+      "b_step_count_term": 0.6951111111111111,
+      "a_mae": 0.8426666666666667,
+      "b_mae": 0.9146666666666666
+     },
+     "composite_difference_decomposition": {
+      "total": -0.19700141675089045,
+      "contributions": {
+       "w_step_f1_x_delta": 0.0004273474673474831,
+       "w_ordered_x_delta": 0.0001712357817621024,
+       "w_reference_micro_x_delta": -0.2,
+       "w_step_count_x_delta": 0.002399999999999991
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": -0.0021692608834781462,
+       "w_ordered_x_delta": -0.0008692109152627625,
+       "w_reference_micro_x_delta": 1.0152211253023693,
+       "w_step_count_x_delta": -0.012182653503628385
+      },
+      "sum_of_contributions_check": -0.19700141675089045
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.092,
+        "system_b": 0.12,
+        "mean_difference": -0.027999999999999997,
+        "bootstrap_ci_low": -0.068,
+        "bootstrap_ci_high": 0.016,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.3016712362271894,
+         "dof": 249,
+         "p_value": 0.1942317650926608,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 11,
+         "correct_only_in_b": 18,
+         "discordant_pairs": 29,
+         "p_value": 0.26493089646101,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.725290298461914e-09
+        }
+       },
+       "step_f1": {
+        "system_a": 0.29572380952380956,
+        "system_b": 0.30019740259740263,
+        "mean_difference": -0.004473593073593074,
+        "bootstrap_ci_low": -0.04107136363636356,
+        "bootstrap_ci_high": 0.03113380952380953,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.2387622082775127,
+         "dof": 249,
+         "p_value": 0.8114863650390807,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2740105263157894,
+        "system_b": 0.28255555555555556,
+        "mean_difference": -0.008545029239766133,
+        "bootstrap_ci_low": -0.045901695906432775,
+        "bootstrap_ci_high": 0.028333567251461973,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.4434262103991069,
+         "dof": 249,
+         "p_value": 0.6578425211323654,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6083134087436441,
+        "system_b": 0.5905492351780087,
+        "mean_difference": 0.01776417356563542,
+        "bootstrap_ci_low": -0.006255512508073393,
+        "bootstrap_ci_high": 0.041809475964315494,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4477313093064017,
+         "dof": 249,
+         "p_value": 0.1489501033264401,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.64,
+        "system_b": 0.664,
+        "mean_difference": -0.02400000000000002,
+        "bootstrap_ci_low": -0.08799999999999997,
+        "bootstrap_ci_high": 0.039999999999999925,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.7378757628486091,
+         "dof": 249,
+         "p_value": 0.4612847613139066,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 30,
+         "correct_only_in_b": 36,
+         "discordant_pairs": 66,
+         "p_value": 0.5385827752459464,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.710505431213761e-20
+        }
+       },
+       "composite_score": {
+        "system_a": 0.4808926817042607,
+        "system_b": 0.48471229437229435,
+        "mean_difference": -0.003819612668033656,
+        "bootstrap_ci_low": -0.031835192868535,
+        "bootstrap_ci_high": 0.023575506379585286,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.35111585213032587,
+        "system_b": 0.35589036796536805,
+        "mean_difference": -0.004774515835042181,
+        "bootstrap_ci_low": -0.0397939910856687,
+        "bootstrap_ci_high": 0.029469382974481637,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.804,
+       "b_step_count_term": 0.7986666666666666,
+       "a_mae": 0.588,
+       "b_mae": 0.604
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.008,
+        "mean_difference": 0.008,
+        "bootstrap_ci_low": -0.012,
+        "bootstrap_ci_high": 0.028,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.8159506119058424,
+         "dof": 249,
+         "p_value": 0.41530824255993326,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 4,
+         "correct_only_in_b": 2,
+         "discordant_pairs": 6,
+         "p_value": 0.6875,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.03125
+        }
+       },
+       "step_f1": {
+        "system_a": 0.13943290043290044,
+        "system_b": 0.12465079365079365,
+        "mean_difference": 0.014782106782106785,
+        "bootstrap_ci_low": -0.009655519480519483,
+        "bootstrap_ci_high": 0.03858284271284272,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.198664859309649,
+         "dof": 249,
+         "p_value": 0.23179783256560327,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.12123333333333332,
+        "system_b": 0.10033333333333334,
+        "mean_difference": 0.020899999999999974,
+        "bootstrap_ci_low": -0.0004999999999999869,
+        "bootstrap_ci_high": 0.042667500000000004,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.8767159943400802,
+         "dof": 249,
+         "p_value": 0.061726478457492,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5304393935125665,
+        "system_b": 0.5059093683799802,
+        "mean_difference": 0.024530025132586286,
+        "bootstrap_ci_low": 0.007940798498891835,
+        "bootstrap_ci_high": 0.04094688481804765,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.916444074078393,
+         "dof": 249,
+         "p_value": 0.0038635269491624096,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.484,
+        "system_b": 0.44,
+        "mean_difference": 0.043999999999999984,
+        "bootstrap_ci_low": -0.03200000000000003,
+        "bootstrap_ci_high": 0.124,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.117436098415486,
+         "dof": 249,
+         "p_value": 0.26488492068952774,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 54,
+         "correct_only_in_b": 43,
+         "discordant_pairs": 97,
+         "p_value": 0.30993353423900705,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.262177448353619e-29
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3626764935064935,
+        "system_b": 0.3500936507936508,
+        "mean_difference": 0.012582842712842712,
+        "bootstrap_ci_low": -0.004727186507936521,
+        "bootstrap_ci_high": 0.030330492424242402,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2033456168831169,
+        "system_b": 0.18761706349206353,
+        "mean_difference": 0.015728553391053363,
+        "bootstrap_ci_low": -0.005908983134920596,
+        "bootstrap_ci_high": 0.03791311553030301,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.7053333333333334,
+       "b_step_count_term": 0.7013333333333334,
+       "a_mae": 0.884,
+       "b_mae": 0.896
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.012,
+        "mean_difference": -0.008,
+        "bootstrap_ci_low": -0.02,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.4170619309433983,
+         "dof": 249,
+         "p_value": 0.15771479274702116,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 2,
+         "discordant_pairs": 2,
+         "p_value": 0.5,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.5
+        }
+       },
+       "step_f1": {
+        "system_a": 0.1021951825951826,
+        "system_b": 0.10929859029859029,
+        "mean_difference": -0.007103407703407699,
+        "bootstrap_ci_low": -0.027455230880230868,
+        "bootstrap_ci_high": 0.012974608724608705,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.6842936733901236,
+         "dof": 249,
+         "p_value": 0.4944261244497726,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08526825396825397,
+        "system_b": 0.09591086691086691,
+        "mean_difference": -0.010642612942612942,
+        "bootstrap_ci_low": -0.029542493894993888,
+        "bootstrap_ci_high": 0.007125448717948718,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.1329869763537392,
+         "dof": 249,
+         "p_value": 0.25830947685175315,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.4814357649102635,
+        "system_b": 0.47352289144103965,
+        "mean_difference": 0.007912873469223869,
+        "bootstrap_ci_low": -0.00718134853376016,
+        "bootstrap_ci_high": 0.022783485495567714,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.037794280495122,
+         "dof": 249,
+         "p_value": 0.3003725723357838,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.296,
+        "system_b": 0.316,
+        "mean_difference": -0.020000000000000018,
+        "bootstrap_ci_low": -0.08800000000000002,
+        "bootstrap_ci_high": 0.04799999999999999,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.569031755828919,
+         "dof": 249,
+         "p_value": 0.569847495567949,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 36,
+         "correct_only_in_b": 41,
+         "discordant_pairs": 77,
+         "p_value": 0.6487911623106449,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.3234889800848443e-23
+        }
+       },
+       "composite_score": {
+        "system_a": 0.13125854922854924,
+        "system_b": 0.33102602952602955,
+        "mean_difference": -0.19976748029748032,
+        "bootstrap_ci_low": -0.21532709593184596,
+        "bootstrap_ci_high": 0.003718855755355758,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16407318653568656,
+        "system_b": 0.1637825369075369,
+        "mean_difference": 0.00029064962814964734,
+        "bootstrap_ci_low": -0.02025453168359417,
+        "bootstrap_ci_high": 0.021130230672105673,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.6479999999999999,
+       "b_step_count_term": 0.5853333333333333,
+       "a_mae": 1.056,
+       "b_mae": 1.244
+      }
+     }
+    }
+   },
+   "size2000_imbalanced_trial0__typed": {
+    "system_a": "size2000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "system_b": "size2000_imbalanced_trial0__biencoder_only__typed",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.04666666666666667,
+       "system_b": 0.050666666666666665,
+       "mean_difference": -0.003999999999999997,
+       "bootstrap_ci_low": -0.016,
+       "bootstrap_ci_high": 0.008,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.6544040886666121,
+        "dof": 749,
+        "p_value": 0.5130523870497855,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 9,
+        "correct_only_in_b": 12,
+        "discordant_pairs": 21,
+        "p_value": 0.6636238098144531,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 9.5367431640625e-07
+       },
+       "power": {
+        "sd_of_paired_differences": 0.16739582377035078,
+        "mde_at_this_n_80pct_power": 0.017124497029481385,
+        "n_needed_for_observed_difference_80pct_power": 13747
+       }
+      },
+      "step_f1": {
+       "system_a": 0.19266641007945357,
+       "system_b": 0.1912138454138454,
+       "mean_difference": 0.0014525646656081692,
+       "bootstrap_ci_low": -0.01219152905870296,
+       "bootstrap_ci_high": 0.01564703231551059,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.2045052893505163,
+        "dof": 749,
+        "p_value": 0.8380142161973148,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.19451879120468335,
+        "mde_at_this_n_80pct_power": 0.019899161085002552,
+        "n_needed_for_observed_difference_80pct_power": 140754
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1740328042328042,
+       "system_b": 0.17263756613756615,
+       "mean_difference": 0.0013952380952380605,
+       "bootstrap_ci_low": -0.01237105820105818,
+       "bootstrap_ci_high": 0.015586415343915298,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.19615531466890232,
+        "dof": 749,
+        "p_value": 0.8445418088583716,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1947954811069922,
+        "mde_at_this_n_80pct_power": 0.019927466303755657,
+        "n_needed_for_observed_difference_80pct_power": 152993
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5471138456044016,
+       "system_b": 0.5310403311127952,
+       "mean_difference": 0.016073514491606322,
+       "bootstrap_ci_low": 0.005787572952370518,
+       "bootstrap_ci_high": 0.02613553354855179,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 3.113087625141123,
+        "dof": 749,
+        "p_value": 0.0019218350195624092,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.14140023548228614,
+        "mde_at_this_n_80pct_power": 0.014465163215817681,
+        "n_needed_for_observed_difference_80pct_power": 608
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.52,
+       "system_b": 0.468,
+       "mean_difference": 0.05199999999999999,
+       "bootstrap_ci_low": 0.010666666666666658,
+       "bootstrap_ci_high": 0.09199999999999997,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.542534340833362,
+        "dof": 749,
+        "p_value": 0.011205383871207552,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 138,
+        "correct_only_in_b": 99,
+        "discordant_pairs": 237,
+        "p_value": 0.013405008382559848,
+        "significant_at_alpha": true,
+        "min_attainable_p_value": 9.055679078826712e-72
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5601020315212986,
+        "mde_at_this_n_80pct_power": 0.057298117473655936,
+        "n_needed_for_observed_difference_80pct_power": 911
+       }
+      },
+      "composite_score": {
+       "system_a": 0.20225418307940046,
+       "system_b": 0.22216569689569687,
+       "mean_difference": -0.01991151381629641,
+       "bootstrap_ci_low": -0.2035183426959514,
+       "bootstrap_ci_high": 0.17913435210940903,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2528177288492506,
+       "system_b": 0.24645712111962112,
+       "mean_difference": 0.006360607729629458,
+       "bootstrap_ci_low": -0.007773341913219645,
+       "bootstrap_ci_high": 0.02076330374888795,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.0,
+      "b_ref_micro": 0.125,
+      "a_step_count_term": 0.7297777777777779,
+      "b_step_count_term": 0.6888888888888889,
+      "a_mae": 0.8106666666666666,
+      "b_mae": 0.9333333333333333
+     },
+     "composite_difference_decomposition": {
+      "total": -0.01991151381629641,
+      "contributions": {
+       "w_step_f1_x_delta": 0.0005810258662432678,
+       "w_ordered_x_delta": 0.00041857142857141817,
+       "w_reference_micro_x_delta": -0.025,
+       "w_step_count_x_delta": 0.004088888888888898
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": -0.02918039640801856,
+       "w_ordered_x_delta": -0.021021577386488913,
+       "w_reference_micro_x_delta": 1.2555549633568774,
+       "w_step_count_x_delta": -0.20535298956236975
+      },
+      "sum_of_contributions_check": -0.019911513816296418
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.112,
+        "system_b": 0.116,
+        "mean_difference": -0.0040000000000000036,
+        "bootstrap_ci_low": -0.03599999999999999,
+        "bootstrap_ci_high": 0.027999999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.25771633900415375,
+         "dof": 249,
+         "p_value": 0.7968386968938346,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 7,
+         "correct_only_in_b": 8,
+         "discordant_pairs": 15,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 6.103515625e-05
+        }
+       },
+       "step_f1": {
+        "system_a": 0.31527619047619043,
+        "system_b": 0.29893333333333333,
+        "mean_difference": 0.016342857142857103,
+        "bootstrap_ci_low": -0.0129914285714286,
+        "bootstrap_ci_high": 0.046533333333333315,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0895222934468884,
+         "dof": 249,
+         "p_value": 0.2769769300582308,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.3,
+        "system_b": 0.2848333333333333,
+        "mean_difference": 0.015166666666666662,
+        "bootstrap_ci_low": -0.015500000000000014,
+        "bootstrap_ci_high": 0.04633333333333339,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.9644090023339614,
+         "dof": 249,
+         "p_value": 0.33577659052054754,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6318814281966165,
+        "system_b": 0.6067046545547155,
+        "mean_difference": 0.025176773641901073,
+        "bootstrap_ci_low": 0.004726180350494561,
+        "bootstrap_ci_high": 0.04561247063185411,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.441708267413403,
+         "dof": 249,
+         "p_value": 0.01531479499808512,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.748,
+        "system_b": 0.692,
+        "mean_difference": 0.05600000000000005,
+        "bootstrap_ci_low": -0.01200000000000001,
+        "bootstrap_ci_high": 0.12,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.655651459972346,
+         "dof": 249,
+         "p_value": 0.099052129147038,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 43,
+         "correct_only_in_b": 29,
+         "discordant_pairs": 72,
+         "p_value": 0.12491820036864003,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 4.235164736271502e-22
+        }
+       },
+       "composite_score": {
+        "system_a": 0.5037104761904763,
+        "system_b": 0.4835566666666667,
+        "mean_difference": 0.020153809523809574,
+        "bootstrap_ci_low": -0.003218250000000088,
+        "bootstrap_ci_high": 0.04420428571428564,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3796380952380953,
+        "system_b": 0.3544458333333334,
+        "mean_difference": 0.02519226190476187,
+        "bootstrap_ci_low": -0.00402281250000008,
+        "bootstrap_ci_high": 0.05525535714285712,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.876,
+       "b_step_count_term": 0.7853333333333333,
+       "a_mae": 0.372,
+       "b_mae": 0.644
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.016,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": -0.012,
+        "bootstrap_ci_high": 0.012,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.0,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 1,
+         "correct_only_in_b": 1,
+         "discordant_pairs": 2,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.5
+        }
+       },
+       "step_f1": {
+        "system_a": 0.15070020703933748,
+        "system_b": 0.15734236874236876,
+        "mean_difference": -0.00664216170303128,
+        "bootstrap_ci_low": -0.030456392206826974,
+        "bootstrap_ci_high": 0.016956193926846077,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.5518217620436767,
+         "dof": 249,
+         "p_value": 0.5815653774042593,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13027619047619046,
+        "system_b": 0.12926666666666664,
+        "mean_difference": 0.0010095238095238213,
+        "bootstrap_ci_low": -0.021792142857142857,
+        "bootstrap_ci_high": 0.02366690476190476,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.08759821623351681,
+         "dof": 249,
+         "p_value": 0.9302664258993563,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.534047389962992,
+        "system_b": 0.5162698827976191,
+        "mean_difference": 0.017777507165372852,
+        "bootstrap_ci_low": 0.0009730760957785219,
+        "bootstrap_ci_high": 0.03468052689769546,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.0447911327043875,
+         "dof": 249,
+         "p_value": 0.04192702145785674,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.464,
+        "system_b": 0.428,
+        "mean_difference": 0.03600000000000003,
+        "bootstrap_ci_low": -0.03200000000000003,
+        "bootstrap_ci_high": 0.10400000000000004,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0126305904903263,
+         "dof": 249,
+         "p_value": 0.31221961109160223,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 44,
+         "correct_only_in_b": 35,
+         "discordant_pairs": 79,
+         "p_value": 0.3681876338306308,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.308722450212111e-24
+        }
+       },
+       "composite_score": {
+        "system_a": 0.36549627329192547,
+        "system_b": 0.36878361416361416,
+        "mean_difference": -0.003287340871688693,
+        "bootstrap_ci_low": -0.023636706243032306,
+        "bootstrap_ci_high": 0.016866569013112453,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20687034161490683,
+        "system_b": 0.2109795177045177,
+        "mean_difference": -0.0041091760896108664,
+        "bootstrap_ci_low": -0.02954588280379038,
+        "bootstrap_ci_high": 0.02108321126639058,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.6613333333333333,
+       "b_step_count_term": 0.6706666666666667,
+       "a_mae": 1.016,
+       "b_mae": 0.988
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.02,
+        "mean_difference": -0.008,
+        "bootstrap_ci_low": -0.024,
+        "bootstrap_ci_high": 0.008,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.0,
+         "dof": 249,
+         "p_value": 0.3182813015158006,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 1,
+         "correct_only_in_b": 3,
+         "discordant_pairs": 4,
+         "p_value": 0.625,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.125
+        }
+       },
+       "step_f1": {
+        "system_a": 0.11202283272283273,
+        "system_b": 0.11736583416583417,
+        "mean_difference": -0.005343001443001441,
+        "bootstrap_ci_low": -0.02385837024087024,
+        "bootstrap_ci_high": 0.01187046814296813,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.582822066219682,
+         "dof": 249,
+         "p_value": 0.5605405178817476,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09182222222222222,
+        "system_b": 0.10381269841269841,
+        "mean_difference": -0.01199047619047619,
+        "bootstrap_ci_low": -0.02980031746031744,
+        "bootstrap_ci_high": 0.004368730158730149,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.385022497273367,
+         "dof": 249,
+         "p_value": 0.16728520203331054,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.4754127186535961,
+        "system_b": 0.47014645598605115,
+        "mean_difference": 0.00526626266754493,
+        "bootstrap_ci_low": -0.009516661074378343,
+        "bootstrap_ci_high": 0.02004025781934335,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.6923821986317602,
+         "dof": 249,
+         "p_value": 0.4893425244888688,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.348,
+        "system_b": 0.284,
+        "mean_difference": 0.064,
+        "bootstrap_ci_low": -0.008000000000000007,
+        "bootstrap_ci_high": 0.136,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.732213862481695,
+         "dof": 249,
+         "p_value": 0.08447381825187156,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 51,
+         "correct_only_in_b": 35,
+         "discordant_pairs": 86,
+         "p_value": 0.10522535125694397,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.5849394142282115e-26
+        }
+       },
+       "composite_score": {
+        "system_a": 0.13755579975579973,
+        "system_b": 0.13915680985680987,
+        "mean_difference": -0.0016010101010101307,
+        "bootstrap_ci_low": -0.21301714102564098,
+        "bootstrap_ci_high": 0.19370811799311802,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.17194474969474968,
+        "system_b": 0.17394601232101234,
+        "mean_difference": -0.0020012626262626565,
+        "bootstrap_ci_low": -0.021080542027417038,
+        "bootstrap_ci_high": 0.016004719932844896,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.6519999999999999,
+       "b_step_count_term": 0.6106666666666667,
+       "a_mae": 1.044,
+       "b_mae": 1.168
+      }
+     }
+    }
+   },
+   "size2000_imbalanced_trial0__uniform": {
+    "system_a": "size2000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "system_b": "size2000_imbalanced_trial0__biencoder_only__uniform",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.042666666666666665,
+       "system_b": 0.037333333333333336,
+       "mean_difference": 0.005333333333333329,
+       "bootstrap_ci_low": -0.004,
+       "bootstrap_ci_high": 0.014666666666666672,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.0691469319751377,
+        "dof": 749,
+        "p_value": 0.2853479012436823,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 9,
+        "correct_only_in_b": 5,
+        "discordant_pairs": 14,
+        "p_value": 0.4239501953125,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 0.0001220703125
+       },
+       "power": {
+        "sd_of_paired_differences": 0.1366129802179901,
+        "mde_at_this_n_80pct_power": 0.013975429740356109,
+        "n_needed_for_observed_difference_80pct_power": 5150
+       }
+      },
+      "step_f1": {
+       "system_a": 0.1763048877048877,
+       "system_b": 0.17253788433788433,
+       "mean_difference": 0.003767003367003363,
+       "bootstrap_ci_low": -0.0108768004218004,
+       "bootstrap_ci_high": 0.01791255004255007,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.5146585508527043,
+        "dof": 749,
+        "p_value": 0.6069434722847846,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.2004506400298949,
+        "mde_at_this_n_80pct_power": 0.020505985827094238,
+        "n_needed_for_observed_difference_80pct_power": 22225
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1599015873015873,
+       "system_b": 0.15658306878306877,
+       "mean_difference": 0.003318518518518526,
+       "bootstrap_ci_low": -0.011235727513227503,
+       "bootstrap_ci_high": 0.0170905687830688,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.45699945499737443,
+        "dof": 749,
+        "p_value": 0.6478039471691659,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.19886538487246785,
+        "mde_at_this_n_80pct_power": 0.020343815131177882,
+        "n_needed_for_observed_difference_80pct_power": 28187
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5330499591507277,
+       "system_b": 0.5235959820198607,
+       "mean_difference": 0.009453977130867042,
+       "bootstrap_ci_low": -0.0007476955714640315,
+       "bootstrap_ci_high": 0.019717070152026447,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.7630394280608366,
+        "dof": 749,
+        "p_value": 0.07830158182427407,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.14685311202623796,
+        "mde_at_this_n_80pct_power": 0.015022989367485216,
+        "n_needed_for_observed_difference_80pct_power": 1894
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5026666666666667,
+       "system_b": 0.472,
+       "mean_difference": 0.03066666666666673,
+       "bootstrap_ci_low": -0.011999999999999955,
+       "bootstrap_ci_high": 0.0733333333333333,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.4246411295859887,
+        "dof": 749,
+        "p_value": 0.15467748071668053,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 142,
+        "correct_only_in_b": 119,
+        "discordant_pairs": 261,
+        "p_value": 0.17315489006815712,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 5.397605346934028e-79
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5895107458292453,
+        "mde_at_this_n_80pct_power": 0.0603066121270124,
+        "n_needed_for_observed_difference_80pct_power": 2901
+       }
+      },
+      "composite_score": {
+       "system_a": 0.38978132016132017,
+       "system_b": 0.1835011854811855,
+       "mean_difference": 0.20628013468013467,
+       "bootstrap_ci_low": 0.006302288239538219,
+       "bootstrap_ci_high": 0.21736554244829245,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2372266502016502,
+       "system_b": 0.22937648185148188,
+       "mean_difference": 0.00785016835016833,
+       "bootstrap_ci_low": -0.00692743928525177,
+       "bootstrap_ci_high": 0.02182729129666628,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 1.0,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.7128888888888889,
+      "b_step_count_term": 0.6751111111111111,
+      "a_mae": 0.8613333333333333,
+      "b_mae": 0.9746666666666667
+     },
+     "composite_difference_decomposition": {
+      "total": 0.20628013468013467,
+      "contributions": {
+       "w_step_f1_x_delta": 0.0015068013468013453,
+       "w_ordered_x_delta": 0.000995555555555558,
+       "w_reference_micro_x_delta": 0.2,
+       "w_step_count_x_delta": 0.00377777777777778
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.00730463623721133,
+       "w_ordered_x_delta": 0.004826230878214724,
+       "w_reference_micro_x_delta": 0.9695553103556342,
+       "w_step_count_x_delta": 0.018313822528939767
+      },
+      "sum_of_contributions_check": 0.2062801346801347
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.104,
+        "mean_difference": 0.01200000000000001,
+        "bootstrap_ci_low": -0.01200000000000001,
+        "bootstrap_ci_high": 0.039999999999999994,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.904203972042414,
+         "dof": 249,
+         "p_value": 0.3667612313794705,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 7,
+         "correct_only_in_b": 4,
+         "discordant_pairs": 11,
+         "p_value": 0.548828125,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.0009765625
+        }
+       },
+       "step_f1": {
+        "system_a": 0.28607619047619043,
+        "system_b": 0.28566060606060606,
+        "mean_difference": 0.0004155844155843691,
+        "bootstrap_ci_low": -0.027925324675324666,
+        "bootstrap_ci_high": 0.028543484848484842,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.028555134861438076,
+         "dof": 249,
+         "p_value": 0.9772422676429894,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.27579999999999993,
+        "system_b": 0.2674444444444445,
+        "mean_difference": 0.00835555555555545,
+        "bootstrap_ci_low": -0.021266944444444436,
+        "bootstrap_ci_high": 0.037501388888888876,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5500952856431703,
+         "dof": 249,
+         "p_value": 0.5827471230807976,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.61461121200966,
+        "system_b": 0.5954771911864707,
+        "mean_difference": 0.01913402082318927,
+        "bootstrap_ci_low": -0.0017972069490548137,
+        "bootstrap_ci_high": 0.04070313945465758,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.760643080895373,
+         "dof": 249,
+         "p_value": 0.07952642235536402,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.712,
+        "system_b": 0.632,
+        "mean_difference": 0.07999999999999996,
+        "bootstrap_ci_low": 0.016000000000000014,
+        "bootstrap_ci_high": 0.14400000000000002,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.449489742783178,
+         "dof": 249,
+         "p_value": 0.014995625178120144,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 44,
+         "correct_only_in_b": 24,
+         "discordant_pairs": 68,
+         "p_value": 0.02052693371370707,
+         "significant_at_alpha": true,
+         "min_attainable_p_value": 6.776263578034403e-21
+        }
+       },
+       "composite_score": {
+        "system_a": 0.48103714285714283,
+        "system_b": 0.27049757575757577,
+        "mean_difference": 0.21053956709956706,
+        "bootstrap_ci_low": -0.001119778138528147,
+        "bootstrap_ci_high": 0.2326859015151515,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3512964285714286,
+        "system_b": 0.3381219696969697,
+        "mean_difference": 0.013174458874458894,
+        "bootstrap_ci_low": -0.015392387716450216,
+        "bootstrap_ci_high": 0.04139793560606061,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.8386666666666667,
+       "b_step_count_term": 0.76,
+       "a_mae": 0.484,
+       "b_mae": 0.72
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.0,
+        "mean_difference": 0.008,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.02,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4170619309433985,
+         "dof": 249,
+         "p_value": 0.15771479274702108,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 2,
+         "p_value": 0.5,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.5
+        }
+       },
+       "step_f1": {
+        "system_a": 0.14488888888888887,
+        "system_b": 0.12493313353313353,
+        "mean_difference": 0.019955755355755347,
+        "bootstrap_ci_low": -0.0041465101565101685,
+        "bootstrap_ci_high": 0.04406434398934397,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.6136616925223572,
+         "dof": 249,
+         "p_value": 0.10786737438614218,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11866666666666666,
+        "system_b": 0.10526666666666666,
+        "mean_difference": 0.013399999999999995,
+        "bootstrap_ci_low": -0.009401666666666671,
+        "bootstrap_ci_high": 0.03633333333333334,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.1543592292085294,
+         "dof": 249,
+         "p_value": 0.24945961222493113,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5165669665988813,
+        "system_b": 0.497639707522638,
+        "mean_difference": 0.018927259076243375,
+        "bootstrap_ci_low": 0.0013506772842333536,
+        "bootstrap_ci_high": 0.03707505397333114,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.0885601558865514,
+         "dof": 249,
+         "p_value": 0.037763262890628986,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.46,
+        "system_b": 0.432,
+        "mean_difference": 0.028000000000000025,
+        "bootstrap_ci_low": -0.04800000000000004,
+        "bootstrap_ci_high": 0.10799999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.7028140674865189,
+         "dof": 249,
+         "p_value": 0.4828281747114434,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 53,
+         "correct_only_in_b": 46,
+         "discordant_pairs": 99,
+         "p_value": 0.546713483598813,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.1554436208840472e-30
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3619555555555556,
+        "system_b": 0.1487532534132534,
+        "mean_difference": 0.21320230214230218,
+        "bootstrap_ci_low": -0.0012926666666666724,
+        "bootstrap_ci_high": 0.23048173054723053,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20244444444444445,
+        "system_b": 0.18594156676656678,
+        "mean_difference": 0.01650287767787767,
+        "bootstrap_ci_low": -0.00735649191086689,
+        "bootstrap_ci_high": 0.04073520111832608,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.6839999999999999,
+       "b_step_count_term": 0.6719999999999999,
+       "a_mae": 0.948,
+       "b_mae": 0.984
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.008,
+        "mean_difference": -0.004,
+        "bootstrap_ci_low": -0.012,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.0,
+         "dof": 249,
+         "p_value": 0.3182813015158006,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 1,
+         "discordant_pairs": 1,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.09794958374958375,
+        "system_b": 0.10701991341991342,
+        "mean_difference": -0.009070329670329669,
+        "bootstrap_ci_low": -0.03053426684426685,
+        "bootstrap_ci_high": 0.011663924963924955,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.8387363472427574,
+         "dof": 249,
+         "p_value": 0.40242173331623693,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08523809523809524,
+        "system_b": 0.09703809523809523,
+        "mean_difference": -0.011799999999999991,
+        "bootstrap_ci_low": -0.03254809523809524,
+        "bootstrap_ci_high": 0.008128690476190475,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.1305059280864942,
+         "dof": 249,
+         "p_value": 0.25935084668563607,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.46797169884364187,
+        "system_b": 0.4776710473504735,
+        "mean_difference": -0.009699348506831629,
+        "bootstrap_ci_low": -0.02441279957958383,
+        "bootstrap_ci_high": 0.00551410315561657,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.2842447282004408,
+         "dof": 249,
+         "p_value": 0.2002499355428279,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.336,
+        "system_b": 0.352,
+        "mean_difference": -0.01599999999999996,
+        "bootstrap_ci_low": -0.09199999999999997,
+        "bootstrap_ci_high": 0.06,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.41188277400210965,
+         "dof": 249,
+         "p_value": 0.6807796864728571,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 45,
+         "correct_only_in_b": 49,
+         "discordant_pairs": 94,
+         "p_value": 0.7571890741424051,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0097419586828951e-28
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3263512620712621,
+        "system_b": 0.3312527272727273,
+        "mean_difference": -0.004901465201465227,
+        "bootstrap_ci_low": -0.0223380878565878,
+        "bootstrap_ci_high": 0.01218823285048287,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.15793907758907763,
+        "system_b": 0.1640659090909091,
+        "mean_difference": -0.0061268315018314645,
+        "bootstrap_ci_low": -0.027922609820734832,
+        "bootstrap_ci_high": 0.01523529106310356,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.6160000000000001,
+       "b_step_count_term": 0.5933333333333333,
+       "a_mae": 1.152,
+       "b_mae": 1.22
+      }
+     }
+    }
+   },
+   "size4000_imbalanced_trial0__raw": {
+    "system_a": "size4000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "system_b": "size4000_imbalanced_trial0__biencoder_only__raw",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.04,
+       "system_b": 0.04533333333333334,
+       "mean_difference": -0.005333333333333336,
+       "bootstrap_ci_low": -0.01866666666666667,
+       "bootstrap_ci_high": 0.008000000000000004,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.755712770728008,
+        "dof": 749,
+        "p_value": 0.4500590163055616,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 12,
+        "correct_only_in_b": 16,
+        "discordant_pairs": 28,
+        "p_value": 0.5715881884098053,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 7.450580596923828e-09
+       },
+       "power": {
+        "sd_of_paired_differences": 0.19327362766059852,
+        "mde_at_this_n_80pct_power": 0.019771781566615333,
+        "n_needed_for_observed_difference_80pct_power": 10308
+       }
+      },
+      "step_f1": {
+       "system_a": 0.18857699816523343,
+       "system_b": 0.1762028463910817,
+       "mean_difference": 0.012374151774151743,
+       "bootstrap_ci_low": -0.0030894036029329775,
+       "bootstrap_ci_high": 0.027693605446840748,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.6059936540910678,
+        "dof": 749,
+        "p_value": 0.10869679298186159,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.21100961511991054,
+        "mde_at_this_n_80pct_power": 0.021586162939585422,
+        "n_needed_for_observed_difference_80pct_power": 2283
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.17118095238095235,
+       "system_b": 0.16001478151478152,
+       "mean_difference": 0.011166170866170833,
+       "bootstrap_ci_low": -0.0038568714618714686,
+       "bootstrap_ci_high": 0.026389011544011545,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.4734854019878578,
+        "dof": 749,
+        "p_value": 0.14104032147687,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.20753390756731702,
+        "mde_at_this_n_80pct_power": 0.02123060004488986,
+        "n_needed_for_observed_difference_80pct_power": 2712
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5461039107256193,
+       "system_b": 0.5284008790902841,
+       "mean_difference": 0.017703031635335154,
+       "bootstrap_ci_low": 0.007261920479561307,
+       "bootstrap_ci_high": 0.028108080847480024,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 3.3399323328564634,
+        "dof": 749,
+        "p_value": 0.0008794818278829563,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1451578774143586,
+        "mde_at_this_n_80pct_power": 0.014849567836281257,
+        "n_needed_for_observed_difference_80pct_power": 528
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.52,
+       "system_b": 0.46266666666666667,
+       "mean_difference": 0.05733333333333335,
+       "bootstrap_ci_low": 0.016000000000000014,
+       "bootstrap_ci_high": 0.09736666666666623,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.7367790359903323,
+        "dof": 749,
+        "p_value": 0.00635144453472968,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 146,
+        "correct_only_in_b": 103,
+        "discordant_pairs": 249,
+        "p_value": 0.007650533228319401,
+        "significant_at_alpha": true,
+        "min_attainable_p_value": 2.210859150104178e-75
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5737174896230909,
+        "mde_at_this_n_80pct_power": 0.058690971050093056,
+        "n_needed_for_observed_difference_80pct_power": 786
+       }
+      },
+      "composite_score": {
+       "system_a": 0.20087397386926797,
+       "system_b": 0.3907522396775338,
+       "mean_difference": -0.18987826580826583,
+       "bootstrap_ci_low": -0.2009664306651954,
+       "bootstrap_ci_high": 0.015027436616216023,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.25109246733658497,
+       "system_b": 0.23844029959691726,
+       "mean_difference": 0.012652167739667708,
+       "bootstrap_ci_low": -0.0015923963665691436,
+       "bootstrap_ci_high": 0.027022198584367715,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.0,
+      "b_ref_micro": 1.0,
+      "a_step_count_term": 0.7408888888888889,
+      "b_step_count_term": 0.7226666666666667,
+      "a_mae": 0.7773333333333333,
+      "b_mae": 0.832
+     },
+     "composite_difference_decomposition": {
+      "total": -0.18987826580826583,
+      "contributions": {
+       "w_step_f1_x_delta": 0.004949660709660697,
+       "w_ordered_x_delta": 0.0033498512598512495,
+       "w_reference_micro_x_delta": -0.2,
+       "w_step_count_x_delta": 0.001822222222222225
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": -0.026067547481493942,
+       "w_ordered_x_delta": -0.0176420995082915,
+       "w_reference_micro_x_delta": 1.0533064389894673,
+       "w_step_count_x_delta": -0.009596791999681827
+      },
+      "sum_of_contributions_check": -0.18987826580826583
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.108,
+        "system_b": 0.116,
+        "mean_difference": -0.008000000000000007,
+        "bootstrap_ci_low": -0.044,
+        "bootstrap_ci_high": 0.027999999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.4464969065851096,
+         "dof": 249,
+         "p_value": 0.655626407259774,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 9,
+         "correct_only_in_b": 11,
+         "discordant_pairs": 20,
+         "p_value": 0.8238029479980469,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.9073486328125e-06
+        }
+       },
+       "step_f1": {
+        "system_a": 0.310622969187675,
+        "system_b": 0.29987965367965363,
+        "mean_difference": 0.010743315508021378,
+        "bootstrap_ci_low": -0.021134500891265652,
+        "bootstrap_ci_high": 0.043999999999999935,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.6387263147954779,
+         "dof": 249,
+         "p_value": 0.5235880593692441,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2934,
+        "system_b": 0.28357777777777776,
+        "mean_difference": 0.009822222222222232,
+        "bootstrap_ci_low": -0.023177777777777797,
+        "bootstrap_ci_high": 0.04299999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5731269257994283,
+         "dof": 249,
+         "p_value": 0.567075967485543,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6235746052382365,
+        "system_b": 0.6094034287187494,
+        "mean_difference": 0.014171176519487072,
+        "bootstrap_ci_low": -0.007652593118838807,
+        "bootstrap_ci_high": 0.03671582764577788,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.2609823032286998,
+         "dof": 249,
+         "p_value": 0.20849542331161394,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.68,
+        "system_b": 0.668,
+        "mean_difference": 0.01200000000000001,
+        "bootstrap_ci_low": -0.04800000000000004,
+        "bootstrap_ci_high": 0.07199999999999995,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.3834548160582553,
+         "dof": 249,
+         "p_value": 0.7017097539375959,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 32,
+         "correct_only_in_b": 29,
+         "discordant_pairs": 61,
+         "p_value": 0.798152627305718,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 8.673617379884035e-19
+        }
+       },
+       "composite_score": {
+        "system_a": 0.49600252100840336,
+        "system_b": 0.48782519480519476,
+        "mean_difference": 0.008177326203208601,
+        "bootstrap_ci_low": -0.015763173796791468,
+        "bootstrap_ci_high": 0.03304743315508026,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3700031512605042,
+        "system_b": 0.35978149350649347,
+        "mean_difference": 0.010221657754010738,
+        "bootstrap_ci_low": -0.019703967245989298,
+        "bootstrap_ci_high": 0.04130929144385025,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8373333333333334,
+       "b_step_count_term": 0.828,
+       "a_mae": 0.488,
+       "b_mae": 0.516
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.012,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": -0.02,
+        "bootstrap_ci_high": 0.02,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.0,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 3,
+         "correct_only_in_b": 3,
+         "discordant_pairs": 6,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.03125
+        }
+       },
+       "step_f1": {
+        "system_a": 0.15714554334554334,
+        "system_b": 0.1275968253968254,
+        "mean_difference": 0.02954871794871794,
+        "bootstrap_ci_low": 0.006221111111111117,
+        "bootstrap_ci_high": 0.053151654456654436,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.492376257243378,
+         "dof": 249,
+         "p_value": 0.013340132054668418,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13119999999999998,
+        "system_b": 0.10594285714285713,
+        "mean_difference": 0.025257142857142853,
+        "bootstrap_ci_low": 0.00432309523809525,
+        "bootstrap_ci_high": 0.04736285714285712,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.323370382927037,
+         "dof": 249,
+         "p_value": 0.02096527675146916,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.533015929943775,
+        "system_b": 0.507201623981248,
+        "mean_difference": 0.025814305962526984,
+        "bootstrap_ci_low": 0.008870564156324375,
+        "bootstrap_ci_high": 0.0425352746110194,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.999468126916078,
+         "dof": 249,
+         "p_value": 0.0029787989928914717,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.508,
+        "system_b": 0.404,
+        "mean_difference": 0.10399999999999998,
+        "bootstrap_ci_low": 0.03199999999999997,
+        "bootstrap_ci_high": 0.17600000000000005,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.7459145264616702,
+         "dof": 249,
+         "p_value": 0.006474435940559326,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 59,
+         "correct_only_in_b": 33,
+         "discordant_pairs": 92,
+         "p_value": 0.008780930806975222,
+         "significant_at_alpha": true,
+         "min_attainable_p_value": 4.0389678347315804e-28
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3750182173382174,
+        "system_b": 0.35428825396825403,
+        "mean_difference": 0.020729963369963356,
+        "bootstrap_ci_low": 0.0035743443223443293,
+        "bootstrap_ci_high": 0.03857898534798528,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.21877277167277168,
+        "system_b": 0.19286031746031748,
+        "mean_difference": 0.025912454212454195,
+        "bootstrap_ci_low": 0.004467930402930344,
+        "bootstrap_ci_high": 0.0482237316849817,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.728,
+       "b_step_count_term": 0.7146666666666667,
+       "a_mae": 0.816,
+       "b_mae": 0.856
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.008,
+        "mean_difference": -0.008,
+        "bootstrap_ci_low": -0.02,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.4170619309433983,
+         "dof": 249,
+         "p_value": 0.15771479274702116,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 2,
+         "discordant_pairs": 2,
+         "p_value": 0.5,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.5
+        }
+       },
+       "step_f1": {
+        "system_a": 0.09796248196248197,
+        "system_b": 0.10113206009676598,
+        "mean_difference": -0.003169578134284007,
+        "bootstrap_ci_low": -0.02423491936168407,
+        "bootstrap_ci_high": 0.01671594941006701,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.3020698439963072,
+         "dof": 249,
+         "p_value": 0.7628509720306295,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08894285714285713,
+        "system_b": 0.09052370962370963,
+        "mean_difference": -0.0015808524808525043,
+        "bootstrap_ci_low": -0.021905192307692316,
+        "bootstrap_ci_high": 0.01790453463203462,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.15436040376104648,
+         "dof": 249,
+         "p_value": 0.8774506119143974,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.48172119699484617,
+        "system_b": 0.4685975845708547,
+        "mean_difference": 0.01312361242399146,
+        "bootstrap_ci_low": -0.0009055874511198473,
+        "bootstrap_ci_high": 0.027424030111032414,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.8067176382693713,
+         "dof": 249,
+         "p_value": 0.07201347678980152,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.372,
+        "system_b": 0.316,
+        "mean_difference": 0.055999999999999994,
+        "bootstrap_ci_low": -0.020000000000000018,
+        "bootstrap_ci_high": 0.132,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.431867192350015,
+         "dof": 249,
+         "p_value": 0.15343587329500694,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 55,
+         "correct_only_in_b": 41,
+         "discordant_pairs": 96,
+         "p_value": 0.18428587288036472,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.524354896707238e-29
+        }
+       },
+       "composite_score": {
+        "system_a": 0.13160118326118325,
+        "system_b": 0.33014327025915263,
+        "mean_difference": -0.19854208699796938,
+        "bootstrap_ci_low": -0.2145841005154976,
+        "bootstrap_ci_high": 0.009044520335873217,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16450147907647908,
+        "system_b": 0.16267908782394078,
+        "mean_difference": 0.0018223912525383024,
+        "bootstrap_ci_low": -0.018924458874458882,
+        "bootstrap_ci_high": 0.02191217046025871,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.6573333333333333,
+       "b_step_count_term": 0.6253333333333333,
+       "a_mae": 1.028,
+       "b_mae": 1.124
+      }
+     }
+    }
+   },
+   "size4000_imbalanced_trial0__typed": {
+    "system_a": "size4000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "system_b": "size4000_imbalanced_trial0__biencoder_only__typed",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.05333333333333334,
+       "system_b": 0.04666666666666667,
+       "mean_difference": 0.006666666666666668,
+       "bootstrap_ci_low": -0.006666666666666668,
+       "bootstrap_ci_high": 0.019999999999999997,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.9622028701950642,
+        "dof": 749,
+        "p_value": 0.3362582353113336,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 16,
+        "correct_only_in_b": 11,
+        "discordant_pairs": 27,
+        "p_value": 0.44206833839416504,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.4901161193847656e-08
+       },
+       "power": {
+        "sd_of_paired_differences": 0.1897460415993591,
+        "mde_at_this_n_80pct_power": 0.019410911530157265,
+        "n_needed_for_observed_difference_80pct_power": 6359
+       }
+      },
+      "step_f1": {
+       "system_a": 0.19801275761275763,
+       "system_b": 0.18659219766588186,
+       "mean_difference": 0.011420559946875769,
+       "bootstrap_ci_low": -0.0037987086987087346,
+       "bootstrap_ci_high": 0.026615446493078076,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.4556273698264555,
+        "dof": 749,
+        "p_value": 0.14591465632200987,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.21486605816534002,
+        "mde_at_this_n_80pct_power": 0.021980674857436017,
+        "n_needed_for_observed_difference_80pct_power": 2779
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.18347809042809043,
+       "system_b": 0.1657215784215784,
+       "mean_difference": 0.017756512006512043,
+       "bootstrap_ci_low": 0.0027802000777000873,
+       "bootstrap_ci_high": 0.03285130355755355,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.3328017326208026,
+        "dof": 749,
+        "p_value": 0.019922493792410064,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.20845410976379047,
+        "mde_at_this_n_80pct_power": 0.021324736203278436,
+        "n_needed_for_observed_difference_80pct_power": 1082
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5459401505709149,
+       "system_b": 0.5287493632947979,
+       "mean_difference": 0.017190787276117003,
+       "bootstrap_ci_low": 0.006429288258901009,
+       "bootstrap_ci_high": 0.028029105842876087,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 3.07854137839921,
+        "dof": 749,
+        "p_value": 0.002156077271065343,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.15292602591715182,
+        "mde_at_this_n_80pct_power": 0.015644244985115928,
+        "n_needed_for_observed_difference_80pct_power": 622
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.488,
+       "system_b": 0.4706666666666667,
+       "mean_difference": 0.01733333333333331,
+       "bootstrap_ci_low": -0.02266666666666667,
+       "bootstrap_ci_high": 0.05733333333333335,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.8442790494697918,
+        "dof": 749,
+        "p_value": 0.39878306638898914,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 125,
+        "correct_only_in_b": 112,
+        "discordant_pairs": 237,
+        "p_value": 0.43575910980737387,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 9.055679078826712e-72
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5622464319933695,
+        "mde_at_this_n_80pct_power": 0.05751748841545659,
+        "n_needed_for_observed_difference_80pct_power": 8259
+       }
+      },
+      "composite_score": {
+       "system_a": 0.3052707523957524,
+       "system_b": 0.39164224148171517,
+       "mean_difference": -0.08637148908596276,
+       "bootstrap_ci_low": -0.19452220601620598,
+       "bootstrap_ci_high": 0.019451169144695527,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.25658844049469054,
+       "system_b": 0.23955280185214398,
+       "mean_difference": 0.017035638642546563,
+       "bootstrap_ci_low": 0.002163447287057441,
+       "bootstrap_ci_high": 0.031506230111871564,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.5,
+      "b_ref_micro": 1.0,
+      "a_step_count_term": 0.7102222222222223,
+      "b_step_count_term": 0.6728888888888889,
+      "a_mae": 0.8693333333333333,
+      "b_mae": 0.9813333333333333
+     },
+     "composite_difference_decomposition": {
+      "total": -0.08637148908596276,
+      "contributions": {
+       "w_step_f1_x_delta": 0.004568223978750308,
+       "w_ordered_x_delta": 0.0053269536019536125,
+       "w_reference_micro_x_delta": -0.1,
+       "w_step_count_x_delta": 0.003733333333333344
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": -0.05289041588948063,
+       "w_ordered_x_delta": -0.06167490752245648,
+       "w_reference_micro_x_delta": 1.157789463378051,
+       "w_step_count_x_delta": -0.043224139966114024
+      },
+      "sum_of_contributions_check": -0.08637148908596275
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.128,
+        "system_b": 0.124,
+        "mean_difference": 0.0040000000000000036,
+        "bootstrap_ci_low": -0.032,
+        "bootstrap_ci_high": 0.04000000000000001,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.21780176115740937,
+         "dof": 249,
+         "p_value": 0.8277619508153277,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 11,
+         "correct_only_in_b": 10,
+         "discordant_pairs": 21,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 9.5367431640625e-07
+        }
+       },
+       "step_f1": {
+        "system_a": 0.3197206349206349,
+        "system_b": 0.2981333333333333,
+        "mean_difference": 0.0215873015873016,
+        "bootstrap_ci_low": -0.013347142857142773,
+        "bootstrap_ci_high": 0.05613333333333331,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.218338480090344,
+         "dof": 249,
+         "p_value": 0.2242484797233918,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.31188333333333335,
+        "system_b": 0.2775,
+        "mean_difference": 0.03438333333333332,
+        "bootstrap_ci_low": 0.00033249999999991,
+        "bootstrap_ci_high": 0.06825125000000007,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 1.9679769056171095,
+         "dof": 249,
+         "p_value": 0.05018033670125777,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6203444212654308,
+        "system_b": 0.603008418763871,
+        "mean_difference": 0.017336002501559755,
+        "bootstrap_ci_low": -0.005497001823407557,
+        "bootstrap_ci_high": 0.04052966051063076,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4653254262389335,
+         "dof": 249,
+         "p_value": 0.14409370271010633,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.716,
+        "system_b": 0.664,
+        "mean_difference": 0.051999999999999935,
+        "bootstrap_ci_low": -0.01200000000000001,
+        "bootstrap_ci_high": 0.11599999999999999,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.5695905652347983,
+         "dof": 249,
+         "p_value": 0.11778025513643843,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 41,
+         "correct_only_in_b": 28,
+         "discordant_pairs": 69,
+         "p_value": 0.14803218069275836,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 3.3881317890172014e-21
+        }
+       },
+       "composite_score": {
+        "system_a": 0.5051865873015873,
+        "system_b": 0.48263666666666666,
+        "mean_difference": 0.022549920634920617,
+        "bootstrap_ci_low": -0.0031007261904762396,
+        "bootstrap_ci_high": 0.04831073809523808,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3814832341269841,
+        "system_b": 0.35329583333333336,
+        "mean_difference": 0.02818740079365073,
+        "bootstrap_ci_low": -0.0038759077380953674,
+        "bootstrap_ci_high": 0.06038842261904757,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8373333333333334,
+       "b_step_count_term": 0.8013333333333333,
+       "a_mae": 0.488,
+       "b_mae": 0.596
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.012,
+        "mean_difference": 0.004,
+        "bootstrap_ci_low": -0.008,
+        "bootstrap_ci_high": 0.02,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5765789258001912,
+         "dof": 249,
+         "p_value": 0.5647447828879819,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 1,
+         "discordant_pairs": 3,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.25
+        }
+       },
+       "step_f1": {
+        "system_a": 0.1590989898989899,
+        "system_b": 0.15416507936507934,
+        "mean_difference": 0.004933910533910568,
+        "bootstrap_ci_low": -0.01795821789321794,
+        "bootstrap_ci_high": 0.028147727272727262,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.4207075007173971,
+         "dof": 249,
+         "p_value": 0.6743315509073379,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13773333333333335,
+        "system_b": 0.12729157509157507,
+        "mean_difference": 0.010441758241758275,
+        "bootstrap_ci_low": -0.011456190476190483,
+        "bootstrap_ci_high": 0.03264366300366297,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.9343545148930701,
+         "dof": 249,
+         "p_value": 0.35102625327067377,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5350538395536691,
+        "system_b": 0.5234628528795913,
+        "mean_difference": 0.011590986674077874,
+        "bootstrap_ci_low": -0.0048574061051021074,
+        "bootstrap_ci_high": 0.028202790365759168,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.3757113715648697,
+         "dof": 249,
+         "p_value": 0.170147218995189,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.444,
+        "system_b": 0.488,
+        "mean_difference": -0.043999999999999984,
+        "bootstrap_ci_low": -0.12,
+        "bootstrap_ci_high": 0.03200000000000003,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.1538774271113161,
+         "dof": 249,
+         "p_value": 0.24965673977218616,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 40,
+         "correct_only_in_b": 51,
+         "discordant_pairs": 91,
+         "p_value": 0.29446978456853307,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 8.077935669463161e-28
+        }
+       },
+       "composite_score": {
+        "system_a": 0.378159595959596,
+        "system_b": 0.37105350427350425,
+        "mean_difference": 0.00710609168609172,
+        "bootstrap_ci_low": -0.009801817460317525,
+        "bootstrap_ci_high": 0.024438597458097476,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.22269949494949498,
+        "system_b": 0.21381688034188032,
+        "mean_difference": 0.008882614607614664,
+        "bootstrap_ci_low": -0.012252271825396836,
+        "bootstrap_ci_high": 0.03054824682262186,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.732,
+       "b_step_count_term": 0.712,
+       "a_mae": 0.804,
+       "b_mae": 0.864
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.004,
+        "mean_difference": 0.012,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.028,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.7390490211537188,
+         "dof": 249,
+         "p_value": 0.0832620199015193,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 3,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 3,
+         "p_value": 0.25,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.25
+        }
+       },
+       "step_f1": {
+        "system_a": 0.11521864801864802,
+        "system_b": 0.10747818029923292,
+        "mean_difference": 0.007740467719415098,
+        "bootstrap_ci_low": -0.012408509969562597,
+        "bootstrap_ci_high": 0.028200200004673697,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.7613399403111669,
+         "dof": 249,
+         "p_value": 0.4471744886084921,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.10081760461760461,
+        "system_b": 0.09237316017316018,
+        "mean_difference": 0.008444444444444435,
+        "bootstrap_ci_low": -0.010535191197691208,
+        "bootstrap_ci_high": 0.027647117604617587,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.885116285397254,
+         "dof": 249,
+         "p_value": 0.3769478398704594,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.48242219089364474,
+        "system_b": 0.45977681824093164,
+        "mean_difference": 0.022645372652713103,
+        "bootstrap_ci_low": 0.0059148155595950234,
+        "bootstrap_ci_high": 0.03915277004177316,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.7030552404269046,
+         "dof": 249,
+         "p_value": 0.0073435719643135345,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.304,
+        "system_b": 0.26,
+        "mean_difference": 0.043999999999999984,
+        "bootstrap_ci_low": -0.02400000000000002,
+        "bootstrap_ci_high": 0.11200000000000002,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.255007222383448,
+         "dof": 249,
+         "p_value": 0.21065273723321173,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 44,
+         "correct_only_in_b": 33,
+         "discordant_pairs": 77,
+         "p_value": 0.25430466614770003,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.3234889800848443e-23
+        }
+       },
+       "composite_score": {
+        "system_a": 0.23246607392607394,
+        "system_b": 0.3212365535049746,
+        "mean_difference": -0.08877047957890066,
+        "bootstrap_ci_low": -0.2010806433595644,
+        "bootstrap_ci_high": 0.019470495666614105,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16558259240759238,
+        "system_b": 0.15154569188121822,
+        "mean_difference": 0.014036900526374158,
+        "bootstrap_ci_low": -0.007737065573315583,
+        "bootstrap_ci_high": 0.036447232559107534,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.5,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.5613333333333332,
+       "b_step_count_term": 0.5053333333333334,
+       "a_mae": 1.316,
+       "b_mae": 1.484
+      }
+     }
+    }
+   },
+   "size4000_imbalanced_trial0__uniform": {
+    "system_a": "size4000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "system_b": "size4000_imbalanced_trial0__biencoder_only__uniform",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.04133333333333333,
+       "system_b": 0.04666666666666667,
+       "mean_difference": -0.005333333333333336,
+       "bootstrap_ci_low": -0.016,
+       "bootstrap_ci_high": 0.005333333333333336,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.942739118413533,
+        "dof": 749,
+        "p_value": 0.3461183326436221,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 7,
+        "correct_only_in_b": 11,
+        "discordant_pairs": 18,
+        "p_value": 0.480682373046875,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 7.62939453125e-06
+       },
+       "power": {
+        "sd_of_paired_differences": 0.15493082424948795,
+        "mde_at_this_n_80pct_power": 0.015849334707867303,
+        "n_needed_for_observed_difference_80pct_power": 6624
+       }
+      },
+      "step_f1": {
+       "system_a": 0.18295842305842305,
+       "system_b": 0.17242183742183745,
+       "mean_difference": 0.010536585636585605,
+       "bootstrap_ci_low": -0.002986010563510564,
+       "bootstrap_ci_high": 0.024389464701964715,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.5234193229511477,
+        "dof": 749,
+        "p_value": 0.12807591257455983,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.18941356280892954,
+        "mde_at_this_n_80pct_power": 0.019376899140057934,
+        "n_needed_for_observed_difference_80pct_power": 2537
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.16658422873422873,
+       "system_b": 0.1576,
+       "mean_difference": 0.008984228734228744,
+       "bootstrap_ci_low": -0.004139571632071626,
+       "bootstrap_ci_high": 0.02236648453398452,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.3465820440921503,
+        "dof": 749,
+        "p_value": 0.17852221123547335,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.18271685565363202,
+        "mde_at_this_n_80pct_power": 0.01869182982826002,
+        "n_needed_for_observed_difference_80pct_power": 3247
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5327379194016908,
+       "system_b": 0.5226512379903042,
+       "mean_difference": 0.010086681411386578,
+       "bootstrap_ci_low": -0.0007542808166598136,
+       "bootstrap_ci_high": 0.020981850196538122,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.8359189398177884,
+        "dof": 749,
+        "p_value": 0.06676588895612838,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.15046151601695382,
+        "mde_at_this_n_80pct_power": 0.015392127031904818,
+        "n_needed_for_observed_difference_80pct_power": 1747
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.49733333333333335,
+       "system_b": 0.448,
+       "mean_difference": 0.04933333333333334,
+       "bootstrap_ci_low": 0.009333333333333305,
+       "bootstrap_ci_high": 0.09066666666666667,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.323816750169876,
+        "dof": 749,
+        "p_value": 0.02040204156025689,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 146,
+        "correct_only_in_b": 109,
+        "discordant_pairs": 255,
+        "p_value": 0.023980943288481892,
+        "significant_at_alpha": true,
+        "min_attainable_p_value": 3.454467422037778e-77
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5813922182464022,
+        "mde_at_this_n_80pct_power": 0.05947609139868833,
+        "n_needed_for_observed_difference_80pct_power": 1091
+       }
+      },
+      "composite_score": {
+       "system_a": 0.1928030822880823,
+       "system_b": 0.38167095719095717,
+       "mean_difference": -0.18886787490287488,
+       "bootstrap_ci_low": -0.19940191242553745,
+       "bootstrap_ci_high": 0.015630810532060557,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2410038528601029,
+       "system_b": 0.22708869648869653,
+       "mean_difference": 0.013915156371406362,
+       "bootstrap_ci_low": 1.3428822335015435e-05,
+       "bootstrap_ci_high": 0.027887054091741602,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.0,
+      "b_ref_micro": 1.0,
+      "a_step_count_term": 0.6964444444444444,
+      "b_step_count_term": 0.6542222222222223,
+      "a_mae": 0.9106666666666666,
+      "b_mae": 1.0373333333333334
+     },
+     "composite_difference_decomposition": {
+      "total": -0.18886787490287488,
+      "contributions": {
+       "w_step_f1_x_delta": 0.004214634254634242,
+       "w_ordered_x_delta": 0.002695268620268623,
+       "w_reference_micro_x_delta": -0.2,
+       "w_step_count_x_delta": 0.004222222222222217
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": -0.02231525216663561,
+       "w_ordered_x_delta": -0.014270656784033083,
+       "w_reference_micro_x_delta": 1.058941337180025,
+       "w_step_count_x_delta": -0.02235542822935605
+      },
+      "sum_of_contributions_check": -0.18886787490287493
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.136,
+        "mean_difference": -0.020000000000000004,
+        "bootstrap_ci_low": -0.052000000000000005,
+        "bootstrap_ci_high": 0.01200000000000001,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.213825679850731,
+         "dof": 249,
+         "p_value": 0.2259643517585717,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 6,
+         "correct_only_in_b": 11,
+         "discordant_pairs": 17,
+         "p_value": 0.332305908203125,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.52587890625e-05
+        }
+       },
+       "step_f1": {
+        "system_a": 0.2962095238095238,
+        "system_b": 0.29431746031746037,
+        "mean_difference": 0.001892063492063445,
+        "bootstrap_ci_low": -0.0281589682539682,
+        "bootstrap_ci_high": 0.0321207142857143,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.12336521560105305,
+         "dof": 249,
+         "p_value": 0.9019174197779775,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2841910256410256,
+        "system_b": 0.2779,
+        "mean_difference": 0.006291025641025627,
+        "bootstrap_ci_low": -0.023710416666666703,
+        "bootstrap_ci_high": 0.03694999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.4119970839098479,
+         "dof": 249,
+         "p_value": 0.6806960099126713,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6124433979577218,
+        "system_b": 0.5965575732642396,
+        "mean_difference": 0.01588582469348221,
+        "bootstrap_ci_low": -0.005891640004103784,
+        "bootstrap_ci_high": 0.037807790723928876,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4386719065067484,
+         "dof": 249,
+         "p_value": 0.15149925998241562,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.688,
+        "system_b": 0.628,
+        "mean_difference": 0.05999999999999994,
+        "bootstrap_ci_low": -0.0040000000000000036,
+        "bootstrap_ci_high": 0.128,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.7879769646861272,
+         "dof": 249,
+         "p_value": 0.07499563530410269,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 43,
+         "correct_only_in_b": 28,
+         "discordant_pairs": 71,
+         "p_value": 0.09592363141082376,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 8.470329472543003e-22
+        }
+       },
+       "composite_score": {
+        "system_a": 0.4832077838827839,
+        "system_b": 0.4796303174603175,
+        "mean_difference": 0.0035774664224664243,
+        "bootstrap_ci_low": -0.020652102869352807,
+        "bootstrap_ci_high": 0.027305928724053644,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3540097298534799,
+        "system_b": 0.3495378968253969,
+        "mean_difference": 0.0044718330280830165,
+        "bootstrap_ci_low": -0.025815128586691022,
+        "bootstrap_ci_high": 0.034132410905067107,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.7946666666666666,
+       "b_step_count_term": 0.7853333333333333,
+       "a_mae": 0.616,
+       "b_mae": 0.644
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "mean_difference": 0.004,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.012,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0,
+         "dof": 249,
+         "p_value": 0.3182813015158006,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 1,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 1,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.15976507936507936,
+        "system_b": 0.1286989898989899,
+        "mean_difference": 0.031066089466089464,
+        "bootstrap_ci_low": 0.008617489177489189,
+        "bootstrap_ci_high": 0.05322518037518035,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.7318226239642485,
+         "dof": 249,
+         "p_value": 0.006749349803305173,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13510476190476192,
+        "system_b": 0.10977619047619046,
+        "mean_difference": 0.025328571428571464,
+        "bootstrap_ci_low": 0.0056283333333333185,
+        "bootstrap_ci_high": 0.045000714285714234,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.4964336444054736,
+         "dof": 249,
+         "p_value": 0.013192256976637569,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.519360298788536,
+        "system_b": 0.5043402833514118,
+        "mean_difference": 0.015020015437124168,
+        "bootstrap_ci_low": -0.003374063294610746,
+        "bootstrap_ci_high": 0.03328836991049442,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.6133126607399588,
+         "dof": 249,
+         "p_value": 0.10794318621099963,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.464,
+        "system_b": 0.416,
+        "mean_difference": 0.04800000000000004,
+        "bootstrap_ci_low": -0.02400000000000002,
+        "bootstrap_ci_high": 0.124,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.2664378130407814,
+         "dof": 249,
+         "p_value": 0.20653981163077162,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 51,
+         "correct_only_in_b": 39,
+         "discordant_pairs": 90,
+         "p_value": 0.24610644971627793,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.6155871338926322e-27
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3773707936507937,
+        "system_b": 0.34974578643578647,
+        "mean_difference": 0.027625007215007213,
+        "bootstrap_ci_low": 0.010439813131313109,
+        "bootstrap_ci_high": 0.04489110678210675,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2217134920634921,
+        "system_b": 0.18718223304473308,
+        "mean_difference": 0.03453125901875903,
+        "bootstrap_ci_low": 0.013049766414141389,
+        "bootstrap_ci_high": 0.0561138834776335,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.7293333333333334,
+       "b_step_count_term": 0.6533333333333333,
+       "a_mae": 0.812,
+       "b_mae": 1.04
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.004,
+        "mean_difference": 0.0,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": null,
+         "dof": 249,
+         "p_value": 1.0,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 0,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0
+        }
+       },
+       "step_f1": {
+        "system_a": 0.092900666000666,
+        "system_b": 0.09424906204906204,
+        "mean_difference": -0.0013483960483960389,
+        "bootstrap_ci_low": -0.01717850788100789,
+        "bootstrap_ci_high": 0.014016012321012322,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.16779667314240787,
+         "dof": 249,
+         "p_value": 0.8668794424763903,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08045689865689866,
+        "system_b": 0.08512380952380952,
+        "mean_difference": -0.004666910866910859,
+        "bootstrap_ci_low": -0.020416434676434687,
+        "bootstrap_ci_high": 0.01103865079365081,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.5845157760118891,
+         "dof": 249,
+         "p_value": 0.5594025729716902,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.46641006145881464,
+        "system_b": 0.4670558573552613,
+        "mean_difference": -0.0006457958964466437,
+        "bootstrap_ci_low": -0.016157834679747886,
+        "bootstrap_ci_high": 0.01512560382481032,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.08130258854720208,
+         "dof": 249,
+         "p_value": 0.9352666271279502,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.34,
+        "system_b": 0.3,
+        "mean_difference": 0.040000000000000036,
+        "bootstrap_ci_low": -0.03600000000000003,
+        "bootstrap_ci_high": 0.11599999999999999,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0315534712764842,
+         "dof": 249,
+         "p_value": 0.30328224883180516,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 52,
+         "correct_only_in_b": 42,
+         "discordant_pairs": 94,
+         "p_value": 0.3533280324715825,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.0097419586828951e-28
+        }
+       },
+       "composite_score": {
+        "system_a": 0.11783066933066932,
+        "system_b": 0.3156367676767677,
+        "mean_difference": -0.19780609834609836,
+        "bootstrap_ci_low": -0.21182604384504383,
+        "bootstrap_ci_high": 0.007801755855255808,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14728833666333666,
+        "system_b": 0.1445459595959596,
+        "mean_difference": 0.0027423770673770664,
+        "bootstrap_ci_low": -0.01563716332278829,
+        "bootstrap_ci_high": 0.020909304653679607,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.5653333333333332,
+       "b_step_count_term": 0.524,
+       "a_mae": 1.304,
+       "b_mae": 1.428
+      }
+     }
+    }
+   },
+   "size8000_imbalanced_trial0__raw": {
+    "system_a": "size8000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "system_b": "size8000_imbalanced_trial0__biencoder_only__raw",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.048,
+       "system_b": 0.044,
+       "mean_difference": 0.0040000000000000036,
+       "bootstrap_ci_low": -0.010666666666666672,
+       "bootstrap_ci_high": 0.018666666666666668,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.5219796104390265,
+        "dof": 749,
+        "p_value": 0.601838853641809,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 18,
+        "correct_only_in_b": 15,
+        "discordant_pairs": 33,
+        "p_value": 0.7283324808813632,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 2.3283064365386963e-10
+       },
+       "power": {
+        "sd_of_paired_differences": 0.20986358338575245,
+        "mde_at_this_n_80pct_power": 0.021468924548655156,
+        "n_needed_for_observed_difference_80pct_power": 21606
+       }
+      },
+      "step_f1": {
+       "system_a": 0.1907283605283605,
+       "system_b": 0.18505331444154974,
+       "mean_difference": 0.00567504608681077,
+       "bootstrap_ci_low": -0.009528325661266837,
+       "bootstrap_ci_high": 0.02056438715968126,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.733687529893328,
+        "dof": 749,
+        "p_value": 0.463368786627179,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.21183069290271436,
+        "mde_at_this_n_80pct_power": 0.02167015872714991,
+        "n_needed_for_observed_difference_80pct_power": 10936
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.17273968253968253,
+       "system_b": 0.16524013024013023,
+       "mean_difference": 0.007499552299552292,
+       "bootstrap_ci_low": -0.007484072039072027,
+       "bootstrap_ci_high": 0.02237587301587302,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.9841224687358732,
+        "dof": 749,
+        "p_value": 0.3253730848004135,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.20869729612671742,
+        "mde_at_this_n_80pct_power": 0.021349614029115154,
+        "n_needed_for_observed_difference_80pct_power": 6079
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5421902806691635,
+       "system_b": 0.5351094175638953,
+       "mean_difference": 0.007080863105268231,
+       "bootstrap_ci_low": -0.0032123091269810416,
+       "bootstrap_ci_high": 0.017873315233246822,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.3194998910952478,
+        "dof": 749,
+        "p_value": 0.18740523478676444,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.14696281809247866,
+        "mde_at_this_n_80pct_power": 0.015034212235315135,
+        "n_needed_for_observed_difference_80pct_power": 3382
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5013333333333333,
+       "system_b": 0.48933333333333334,
+       "mean_difference": 0.011999999999999955,
+       "bootstrap_ci_low": -0.026666666666666672,
+       "bootstrap_ci_high": 0.05066666666666669,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.597094670660364,
+        "dof": 749,
+        "p_value": 0.550624623717357,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 118,
+        "correct_only_in_b": 109,
+        "discordant_pairs": 227,
+        "p_value": 0.5955314428768117,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 9.273015376718553e-69
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5503876531666971,
+        "mde_at_this_n_80pct_power": 0.056304342124129596,
+        "n_needed_for_observed_difference_80pct_power": 16512
+       }
+      },
+      "composite_score": {
+       "system_a": 0.20006880452880452,
+       "system_b": 0.19377114262643674,
+       "mean_difference": 0.006297661902367774,
+       "bootstrap_ci_low": -0.19742250641950643,
+       "bootstrap_ci_high": 0.21027206025564849,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2500860056610057,
+       "system_b": 0.24221392828304594,
+       "mean_difference": 0.007872077377959752,
+       "bootstrap_ci_low": -0.006843270871285564,
+       "bootstrap_ci_high": 0.022369286757632317,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.0,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.7195555555555555,
+      "b_step_count_term": 0.7017777777777778,
+      "a_mae": 0.8413333333333334,
+      "b_mae": 0.8946666666666667
+     },
+     "composite_difference_decomposition": {
+      "total": 0.006297661902367774,
+      "contributions": {
+       "w_step_f1_x_delta": 0.002270018434724308,
+       "w_ordered_x_delta": 0.0022498656898656878,
+       "w_reference_micro_x_delta": 0.0,
+       "w_step_count_x_delta": 0.001777777777777767
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.36045416059424124,
+       "w_ordered_x_delta": 0.3572541245854737,
+       "w_reference_micro_x_delta": 0.0,
+       "w_step_count_x_delta": 0.2822917148202834
+      },
+      "sum_of_contributions_check": 0.006297661902367763
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.108,
+        "mean_difference": 0.008000000000000007,
+        "bootstrap_ci_low": -0.027999999999999997,
+        "bootstrap_ci_high": 0.044,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.4464969065851096,
+         "dof": 249,
+         "p_value": 0.655626407259774,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 11,
+         "correct_only_in_b": 9,
+         "discordant_pairs": 20,
+         "p_value": 0.8238029479980469,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.9073486328125e-06
+        }
+       },
+       "step_f1": {
+        "system_a": 0.31439999999999996,
+        "system_b": 0.31041344537815124,
+        "mean_difference": 0.003986554621848715,
+        "bootstrap_ci_low": -0.027943333333333348,
+        "bootstrap_ci_high": 0.03591050420168064,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.24273062695943365,
+         "dof": 249,
+         "p_value": 0.8084139027271181,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.297,
+        "system_b": 0.2887076923076923,
+        "mean_difference": 0.00829230769230771,
+        "bootstrap_ci_low": -0.024267051282051328,
+        "bootstrap_ci_high": 0.04130358974358968,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.49137832910774537,
+         "dof": 249,
+         "p_value": 0.6235917286915499,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.620586646506496,
+        "system_b": 0.6220761386132809,
+        "mean_difference": -0.001489492106784951,
+        "bootstrap_ci_low": -0.022692170124415025,
+        "bootstrap_ci_high": 0.01991843469171965,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.1381823829326811,
+         "dof": 249,
+         "p_value": 0.890207958948222,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.676,
+        "system_b": 0.684,
+        "mean_difference": -0.008000000000000007,
+        "bootstrap_ci_low": -0.06799999999999995,
+        "bootstrap_ci_high": 0.051999999999999935,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.26212327113692746,
+         "dof": 249,
+         "p_value": 0.7934431241417027,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 28,
+         "correct_only_in_b": 30,
+         "discordant_pairs": 58,
+         "p_value": 0.8956832138895903,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 6.938893903907228e-18
+        }
+       },
+       "composite_score": {
+        "system_a": 0.5001933333333334,
+        "system_b": 0.4919776858435682,
+        "mean_difference": 0.008215647489765165,
+        "bootstrap_ci_low": -0.016570809523809578,
+        "bootstrap_ci_high": 0.03351389398836457,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3752416666666667,
+        "system_b": 0.3649721073044603,
+        "mean_difference": 0.010269559362206415,
+        "bootstrap_ci_low": -0.02071351190476184,
+        "bootstrap_ci_high": 0.04189236748545564,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8533333333333333,
+       "b_step_count_term": 0.812,
+       "a_mae": 0.44,
+       "b_mae": 0.564
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.008,
+        "mean_difference": 0.012,
+        "bootstrap_ci_low": -0.008,
+        "bootstrap_ci_high": 0.032,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.134544520671362,
+         "dof": 249,
+         "p_value": 0.2576572211193157,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 5,
+         "correct_only_in_b": 2,
+         "discordant_pairs": 7,
+         "p_value": 0.453125,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.015625
+        }
+       },
+       "step_f1": {
+        "system_a": 0.15921538461538462,
+        "system_b": 0.13543174603174604,
+        "mean_difference": 0.023783638583638578,
+        "bootstrap_ci_low": 0.002316984126984113,
+        "bootstrap_ci_high": 0.046645238095238045,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.1024488472302267,
+         "dof": 249,
+         "p_value": 0.0365182686362208,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13473333333333332,
+        "system_b": 0.11206666666666665,
+        "mean_difference": 0.02266666666666667,
+        "bootstrap_ci_low": 0.0024666666666666726,
+        "bootstrap_ci_high": 0.04419999999999999,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.1368494873738553,
+         "dof": 249,
+         "p_value": 0.033585117361217116,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5284846334084438,
+        "system_b": 0.5127014729135133,
+        "mean_difference": 0.015783160494930448,
+        "bootstrap_ci_low": -0.001785291191707554,
+        "bootstrap_ci_high": 0.033328209578255025,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.7598165968941113,
+         "dof": 249,
+         "p_value": 0.07966683097320426,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.496,
+        "system_b": 0.472,
+        "mean_difference": 0.02400000000000002,
+        "bootstrap_ci_low": -0.04400000000000004,
+        "bootstrap_ci_high": 0.09200000000000003,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.6786328462976007,
+         "dof": 249,
+         "p_value": 0.4980007572540332,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 42,
+         "correct_only_in_b": 36,
+         "discordant_pairs": 78,
+         "p_value": 0.5715867180030725,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 6.617444900424222e-24
+        }
+       },
+       "composite_score": {
+        "system_a": 0.37557282051282054,
+        "system_b": 0.3589926984126984,
+        "mean_difference": 0.016580122100122163,
+        "bootstrap_ci_low": 8.278083028086028e-05,
+        "bootstrap_ci_high": 0.03356763492063494,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.21946602564102569,
+        "system_b": 0.19874087301587304,
+        "mean_difference": 0.02072515262515265,
+        "bootstrap_ci_low": 0.00010347603785108714,
+        "bootstrap_ci_high": 0.04195954365079365,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.7146666666666667,
+       "b_step_count_term": 0.712,
+       "a_mae": 0.856,
+       "b_mae": 0.864
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.016,
+        "mean_difference": -0.008,
+        "bootstrap_ci_low": -0.028,
+        "bootstrap_ci_high": 0.012,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.8159506119058424,
+         "dof": 249,
+         "p_value": 0.41530824255993326,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 4,
+         "discordant_pairs": 6,
+         "p_value": 0.6875,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.03125
+        }
+       },
+       "step_f1": {
+        "system_a": 0.09856969696969696,
+        "system_b": 0.10931475191475193,
+        "mean_difference": -0.010745054945054969,
+        "bootstrap_ci_low": -0.03432355866355865,
+        "bootstrap_ci_high": 0.011946842601842625,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.9088128074689404,
+         "dof": 249,
+         "p_value": 0.3643277325505485,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08648571428571428,
+        "system_b": 0.09494603174603175,
+        "mean_difference": -0.008460317460317474,
+        "bootstrap_ci_low": -0.030936825396825404,
+        "bootstrap_ci_high": 0.012758809523809528,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.7573223152000993,
+         "dof": 249,
+         "p_value": 0.4495728367852023,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.47749956209255096,
+        "system_b": 0.4705506411648915,
+        "mean_difference": 0.006948920927659474,
+        "bootstrap_ci_low": -0.008593409217552167,
+        "bootstrap_ci_high": 0.022226213966182313,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.8779626887145775,
+         "dof": 249,
+         "p_value": 0.38081032401095954,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.332,
+        "system_b": 0.312,
+        "mean_difference": 0.020000000000000018,
+        "bootstrap_ci_low": -0.052000000000000046,
+        "bootstrap_ci_high": 0.09599999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.5233807340161405,
+         "dof": 249,
+         "p_value": 0.6011747901875336,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 48,
+         "correct_only_in_b": 43,
+         "discordant_pairs": 91,
+         "p_value": 0.6752224599160567,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 8.077935669463161e-28
+        }
+       },
+       "composite_score": {
+        "system_a": 0.12444025974025974,
+        "system_b": 0.1303430436230436,
+        "mean_difference": -0.0059027838827838686,
+        "bootstrap_ci_low": -0.21120823154623156,
+        "bootstrap_ci_high": 0.19936097113997114,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.15555032467532467,
+        "system_b": 0.1629288045288045,
+        "mean_difference": -0.007378479853479836,
+        "bootstrap_ci_low": -0.030769256784881825,
+        "bootstrap_ci_high": 0.015157100954600957,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.5906666666666667,
+       "b_step_count_term": 0.5813333333333333,
+       "a_mae": 1.228,
+       "b_mae": 1.256
+      }
+     }
+    }
+   },
+   "size8000_imbalanced_trial0__typed": {
+    "system_a": "size8000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "system_b": "size8000_imbalanced_trial0__biencoder_only__typed",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.050666666666666665,
+       "system_b": 0.048,
+       "mean_difference": 0.0026666666666666644,
+       "bootstrap_ci_low": -0.00933333333333334,
+       "bootstrap_ci_high": 0.015999999999999997,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 0.40802137238148584,
+        "dof": 749,
+        "p_value": 0.6833745911910442,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 13,
+        "correct_only_in_b": 11,
+        "discordant_pairs": 24,
+        "p_value": 0.8388197422027588,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.1920928955078125e-07
+       },
+       "power": {
+        "sd_of_paired_differences": 0.17898492401947494,
+        "mde_at_this_n_80pct_power": 0.018310055356568152,
+        "n_needed_for_observed_difference_80pct_power": 35360
+       }
+      },
+      "step_f1": {
+       "system_a": 0.21126165686165685,
+       "system_b": 0.1947480984100179,
+       "mean_difference": 0.01651355845163896,
+       "bootstrap_ci_low": 0.002736779108977209,
+       "bootstrap_ci_high": 0.03040407683017586,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.317669005000071,
+        "dof": 749,
+        "p_value": 0.020735945043851962,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.19512813195347667,
+        "mde_at_this_n_80pct_power": 0.019961496295090995,
+        "n_needed_for_observed_difference_80pct_power": 1096
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.19383973063973062,
+       "system_b": 0.1727852332852333,
+       "mean_difference": 0.021054497354497326,
+       "bootstrap_ci_low": 0.007501123136123132,
+       "bootstrap_ci_high": 0.03461151034151037,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 3.037575124053118,
+        "dof": 749,
+        "p_value": 0.0024677134218225602,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.18982284662977417,
+        "mde_at_this_n_80pct_power": 0.01941876864084001,
+        "n_needed_for_observed_difference_80pct_power": 638
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5439559318584793,
+       "system_b": 0.5303738748559566,
+       "mean_difference": 0.013582057002522796,
+       "bootstrap_ci_low": 0.0031892214713949985,
+       "bootstrap_ci_high": 0.024070884920005534,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": {
+        "t": 2.541612582581201,
+        "dof": 749,
+        "p_value": 0.011234715095863162,
+        "significant_at_alpha": true
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.14634801245057702,
+        "mde_at_this_n_80pct_power": 0.01497131796978736,
+        "n_needed_for_observed_difference_80pct_power": 912
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5133333333333333,
+       "system_b": 0.492,
+       "mean_difference": 0.021333333333333315,
+       "bootstrap_ci_low": -0.01866666666666661,
+       "bootstrap_ci_high": 0.06266666666666665,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.0371783235301606,
+        "dof": 749,
+        "p_value": 0.29998747876259796,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 127,
+        "correct_only_in_b": 111,
+        "discordant_pairs": 238,
+        "p_value": 0.3309087396642384,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 4.527839539413356e-72
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5632950298109347,
+        "mde_at_this_n_80pct_power": 0.057624759372446835,
+        "n_needed_for_observed_difference_80pct_power": 5473
+       }
+      },
+      "composite_score": {
+       "system_a": 0.3341232486032486,
+       "system_b": 0.19800147601624385,
+       "mean_difference": 0.13612177258700475,
+       "bootstrap_ci_low": -0.18753158984419432,
+       "bootstrap_ci_high": 0.21883801231803396,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2676540607540608,
+       "system_b": 0.24750184502030484,
+       "mean_difference": 0.020152215733755946,
+       "bootstrap_ci_low": 0.006432442276004634,
+       "bootstrap_ci_high": 0.03398531093641198,
+       "bootstrap_ci_excludes_zero": true,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.6,
+      "b_ref_micro": 0.0,
+      "a_step_count_term": 0.7146666666666667,
+      "b_step_count_term": 0.6826666666666668,
+      "a_mae": 0.856,
+      "b_mae": 0.952
+     },
+     "composite_difference_decomposition": {
+      "total": 0.13612177258700475,
+      "contributions": {
+       "w_step_f1_x_delta": 0.006605423380655584,
+       "w_ordered_x_delta": 0.006316349206349198,
+       "w_reference_micro_x_delta": 0.12,
+       "w_step_count_x_delta": 0.003199999999999992
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": 0.04852584017324345,
+       "w_ordered_x_delta": 0.04640219625638497,
+       "w_reference_micro_x_delta": 0.8815636008802322,
+       "w_step_count_x_delta": 0.023508362690139468
+      },
+      "sum_of_contributions_check": 0.13612177258700478
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.12,
+        "system_b": 0.132,
+        "mean_difference": -0.01200000000000001,
+        "bootstrap_ci_low": -0.04400000000000001,
+        "bootstrap_ci_high": 0.020000000000000004,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.7269202914457258,
+         "dof": 249,
+         "p_value": 0.46795763373894234,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 7,
+         "correct_only_in_b": 10,
+         "discordant_pairs": 17,
+         "p_value": 0.629058837890625,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.52587890625e-05
+        }
+       },
+       "step_f1": {
+        "system_a": 0.32807619047619047,
+        "system_b": 0.31763174603174604,
+        "mean_difference": 0.010444444444444423,
+        "bootstrap_ci_low": -0.016769365079364988,
+        "bootstrap_ci_high": 0.03800079365079362,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.7453021265310175,
+         "dof": 249,
+         "p_value": 0.4567920203837785,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.3184666666666667,
+        "system_b": 0.30357142857142855,
+        "mean_difference": 0.014895238095238128,
+        "bootstrap_ci_low": -0.012542857142857078,
+        "bootstrap_ci_high": 0.04356238095238104,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.0533455301478252,
+         "dof": 249,
+         "p_value": 0.29320372804565903,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6276116143355489,
+        "system_b": 0.6122916256366132,
+        "mean_difference": 0.015319988698935694,
+        "bootstrap_ci_low": -0.004628117337229972,
+        "bootstrap_ci_high": 0.0354582162433421,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4820961258934067,
+         "dof": 249,
+         "p_value": 0.13957914972592286,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.712,
+        "system_b": 0.716,
+        "mean_difference": -0.0040000000000000036,
+        "bootstrap_ci_low": -0.06399999999999995,
+        "bootstrap_ci_high": 0.05599999999999994,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.13457491604929533,
+         "dof": 249,
+         "p_value": 0.8930566891864592,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 27,
+         "correct_only_in_b": 28,
+         "discordant_pairs": 55,
+         "p_value": 1.0,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 5.551115123125783e-17
+        }
+       },
+       "composite_score": {
+        "system_a": 0.5123704761904762,
+        "system_b": 0.5011907936507937,
+        "mean_difference": 0.01117968253968249,
+        "bootstrap_ci_low": -0.008953809523809468,
+        "bootstrap_ci_high": 0.03155647619047615,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3904630952380953,
+        "system_b": 0.3764884920634921,
+        "mean_difference": 0.013974603174603195,
+        "bootstrap_ci_low": -0.011192261904761943,
+        "bootstrap_ci_high": 0.039445595238095175,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.856,
+       "b_step_count_term": 0.8306666666666667,
+       "a_mae": 0.432,
+       "b_mae": 0.508
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.008,
+        "mean_difference": 0.008,
+        "bootstrap_ci_low": 0.0,
+        "bootstrap_ci_high": 0.02,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.4170619309433985,
+         "dof": 249,
+         "p_value": 0.15771479274702108,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 2,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 2,
+         "p_value": 0.5,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.5
+        }
+       },
+       "step_f1": {
+        "system_a": 0.1682920634920635,
+        "system_b": 0.14523492063492063,
+        "mean_difference": 0.02305714285714286,
+        "bootstrap_ci_low": 0.002628492063492087,
+        "bootstrap_ci_high": 0.04430555555555554,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.172281581950011,
+         "dof": 249,
+         "p_value": 0.030778253720120708,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.1439111111111111,
+        "system_b": 0.1214,
+        "mean_difference": 0.022511111111111107,
+        "bootstrap_ci_low": 0.0037555555555555667,
+        "bootstrap_ci_high": 0.041889999999999976,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.318326463152043,
+         "dof": 249,
+         "p_value": 0.02124227034979194,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5297035936179757,
+        "system_b": 0.5077913385074214,
+        "mean_difference": 0.02191225511055428,
+        "bootstrap_ci_low": 0.004176252998714076,
+        "bootstrap_ci_high": 0.03934106670742461,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.4518384710204186,
+         "dof": 249,
+         "p_value": 0.014900453432214205,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.472,
+        "system_b": 0.436,
+        "mean_difference": 0.035999999999999976,
+        "bootstrap_ci_low": -0.035999999999999976,
+        "bootstrap_ci_high": 0.10400000000000004,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.9878305435823476,
+         "dof": 249,
+         "p_value": 0.3241945629963503,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 46,
+         "correct_only_in_b": 37,
+         "discordant_pairs": 83,
+         "p_value": 0.379999396411918,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.0679515313825692e-25
+        }
+       },
+       "composite_score": {
+        "system_a": 0.3792901587301587,
+        "system_b": 0.35971396825396823,
+        "mean_difference": 0.01957619047619047,
+        "bootstrap_ci_low": 0.003594460317460284,
+        "bootstrap_ci_high": 0.03623631746031746,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.22411269841269846,
+        "system_b": 0.19964246031746033,
+        "mean_difference": 0.024470238095238128,
+        "bootstrap_ci_low": 0.004493075396825382,
+        "bootstrap_ci_high": 0.045295396825396836,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.688,
+       "b_step_count_term": 0.6519999999999999,
+       "a_mae": 0.936,
+       "b_mae": 1.044
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.004,
+        "mean_difference": 0.012,
+        "bootstrap_ci_low": -0.004,
+        "bootstrap_ci_high": 0.032,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.3438012400514816,
+         "dof": 249,
+         "p_value": 0.18023588114803066,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 4,
+         "correct_only_in_b": 1,
+         "discordant_pairs": 5,
+         "p_value": 0.375,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.0625
+        }
+       },
+       "step_f1": {
+        "system_a": 0.13741671661671662,
+        "system_b": 0.12137762856338707,
+        "mean_difference": 0.016039088053329542,
+        "bootstrap_ci_low": -0.007726240491534625,
+        "bootstrap_ci_high": 0.04006354726285067,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.3150501285945673,
+         "dof": 249,
+         "p_value": 0.18970282716162135,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11914141414141415,
+        "system_b": 0.09338427128427128,
+        "mean_difference": 0.025757142857142867,
+        "bootstrap_ci_low": 0.002624585137085148,
+        "bootstrap_ci_high": 0.04881746392496392,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.1842958838132023,
+         "dof": 249,
+         "p_value": 0.029873654329918994,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.4745525876219137,
+        "system_b": 0.47103866042383513,
+        "mean_difference": 0.0035139271980785813,
+        "bootstrap_ci_low": -0.0127786588027761,
+        "bootstrap_ci_high": 0.019959160495785604,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.4191440052435039,
+         "dof": 249,
+         "p_value": 0.675472245048499,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.356,
+        "system_b": 0.324,
+        "mean_difference": 0.03199999999999997,
+        "bootstrap_ci_low": -0.04799999999999999,
+        "bootstrap_ci_high": 0.10799999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.7994223130790763,
+         "dof": 249,
+         "p_value": 0.4248075064988511,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 54,
+         "correct_only_in_b": 46,
+         "discordant_pairs": 100,
+         "p_value": 0.4841184136072915,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.5777218104420236e-30
+        }
+       },
+       "composite_score": {
+        "system_a": 0.27070911088911087,
+        "system_b": 0.13309966614396954,
+        "mean_difference": 0.13760944474514133,
+        "bootstrap_ci_low": -0.187449432101696,
+        "bootstrap_ci_high": 0.22196712755940315,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.18838638861138865,
+        "system_b": 0.16637458267996194,
+        "mean_difference": 0.02201180593142671,
+        "bootstrap_ci_low": -0.0033533027389277344,
+        "bootstrap_ci_high": 0.04746431001499787,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.6,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.6000000000000001,
+       "b_step_count_term": 0.5653333333333332,
+       "a_mae": 1.2,
+       "b_mae": 1.304
+      }
+     }
+    }
+   },
+   "size8000_imbalanced_trial0__uniform": {
+    "system_a": "size8000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "system_b": "size8000_imbalanced_trial0__biencoder_only__uniform",
+    "alignment": "positional (row i to row i)",
+    "positional_alignment_verified": true,
+    "overall": {
+     "n": 750,
+     "metrics": {
+      "exact_match": {
+       "system_a": 0.042666666666666665,
+       "system_b": 0.048,
+       "mean_difference": -0.005333333333333336,
+       "bootstrap_ci_low": -0.018666666666666665,
+       "bootstrap_ci_high": 0.006666666666666668,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.8163149556155184,
+        "dof": 749,
+        "p_value": 0.41457956201979995,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 10,
+        "correct_only_in_b": 14,
+        "discordant_pairs": 24,
+        "p_value": 0.5412561893463135,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 1.1920928955078125e-07
+       },
+       "power": {
+        "sd_of_paired_differences": 0.17892523916569986,
+        "mde_at_this_n_80pct_power": 0.01830394963016378,
+        "n_needed_for_observed_difference_80pct_power": 8834
+       }
+      },
+      "step_f1": {
+       "system_a": 0.17474454913278445,
+       "system_b": 0.1816171236171236,
+       "mean_difference": -0.0068725744843391445,
+       "bootstrap_ci_low": -0.020752305972894153,
+       "bootstrap_ci_high": 0.007102978666213948,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.960055632836451,
+        "dof": 749,
+        "p_value": 0.3373370258149421,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.1960440595554667,
+        "mde_at_this_n_80pct_power": 0.020055195164908775,
+        "n_needed_for_observed_difference_80pct_power": 6387
+       }
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.15753146591970124,
+       "system_b": 0.1649904761904762,
+       "mean_difference": -0.007459010270774946,
+       "bootstrap_ci_low": -0.021557434640522878,
+       "bootstrap_ci_high": 0.006898676470588187,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -1.0247611113849697,
+        "dof": 749,
+        "p_value": 0.3058067630917296,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.19933758885739916,
+        "mde_at_this_n_80pct_power": 0.020392121328758766,
+        "n_needed_for_observed_difference_80pct_power": 5606
+       }
+      },
+      "rouge_l_f1": {
+       "system_a": 0.5301727377283056,
+       "system_b": 0.5222343296012064,
+       "mean_difference": 0.007938408127099228,
+       "bootstrap_ci_low": -0.0030231124278091155,
+       "bootstrap_ci_high": 0.018892744784869336,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": 1.4381510322937459,
+        "dof": 749,
+        "p_value": 0.15080888649946766,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": null,
+       "power": {
+        "sd_of_paired_differences": 0.151167892114913,
+        "mde_at_this_n_80pct_power": 0.015464388902713455,
+        "n_needed_for_observed_difference_80pct_power": 2847
+       }
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4746666666666667,
+       "system_b": 0.48933333333333334,
+       "mean_difference": -0.014666666666666661,
+       "bootstrap_ci_low": -0.05733333333333335,
+       "bootstrap_ci_high": 0.028000000000000025,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": {
+        "t": -0.685918883060975,
+        "dof": 749,
+        "p_value": 0.4929765172548183,
+        "significant_at_alpha": false
+       },
+       "exact_mcnemar": {
+        "correct_only_in_a": 123,
+        "correct_only_in_b": 134,
+        "discordant_pairs": 257,
+        "p_value": 0.5328521132879824,
+        "significant_at_alpha": false,
+        "min_attainable_p_value": 8.636168555094445e-78
+       },
+       "power": {
+        "sd_of_paired_differences": 0.5855841248234244,
+        "mde_at_this_n_80pct_power": 0.05990492104395212,
+        "n_needed_for_observed_difference_80pct_power": 12512
+       }
+      },
+      "composite_score": {
+       "system_a": 0.24296678323854798,
+       "system_b": 0.20818843674843676,
+       "mean_difference": 0.03477834649011122,
+       "bootstrap_ci_low": -0.150339190759132,
+       "bootstrap_ci_high": 0.1939844415442944,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.23227990761961356,
+       "system_b": 0.23940221260221264,
+       "mean_difference": -0.007122304982599081,
+       "bootstrap_ci_low": -0.02132490623143202,
+       "bootstrap_ci_high": 0.007187491635543099,
+       "bootstrap_ci_excludes_zero": false,
+       "paired_t": null,
+       "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+       "exact_mcnemar": null
+      }
+     },
+     "composite_terms": {
+      "a_ref_micro": 0.2857142857142857,
+      "b_ref_micro": 0.08333333333333333,
+      "a_step_count_term": 0.6866666666666668,
+      "b_step_count_term": 0.6937777777777778,
+      "a_mae": 0.94,
+      "b_mae": 0.9186666666666666
+     },
+     "composite_difference_decomposition": {
+      "total": 0.03477834649011122,
+      "contributions": {
+       "w_step_f1_x_delta": -0.002749029793735658,
+       "w_ordered_x_delta": -0.0022377030812324836,
+       "w_reference_micro_x_delta": 0.04047619047619048,
+       "w_step_count_x_delta": -0.0007111111111111068
+      },
+      "contribution_share_of_total": {
+       "w_step_f1_x_delta": -0.07904429253177145,
+       "w_ordered_x_delta": -0.06434184793313122,
+       "w_reference_micro_x_delta": 1.1638330904460732,
+       "w_step_count_x_delta": -0.020446949981170102
+      },
+      "sum_of_contributions_check": 0.03477834649011123
+     }
+    },
+    "per_gold_hop": {
+     "2": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.108,
+        "system_b": 0.128,
+        "mean_difference": -0.020000000000000004,
+        "bootstrap_ci_low": -0.052000000000000005,
+        "bootstrap_ci_high": 0.011999999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.213825679850731,
+         "dof": 249,
+         "p_value": 0.2259643517585717,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 6,
+         "correct_only_in_b": 11,
+         "discordant_pairs": 17,
+         "p_value": 0.332305908203125,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 1.52587890625e-05
+        }
+       },
+       "step_f1": {
+        "system_a": 0.29887619047619046,
+        "system_b": 0.3146285714285714,
+        "mean_difference": -0.015752380952380962,
+        "bootstrap_ci_low": -0.047107619047619065,
+        "bootstrap_ci_high": 0.014629047619047618,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.0074503959682581,
+         "dof": 249,
+         "p_value": 0.3146963781574883,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.28713333333333335,
+        "system_b": 0.2969,
+        "mean_difference": -0.009766666666666646,
+        "bootstrap_ci_low": -0.04340166666666671,
+        "bootstrap_ci_high": 0.023033333333333295,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.5772503716820573,
+         "dof": 249,
+         "p_value": 0.5642918853025166,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.6153923223234047,
+        "system_b": 0.6104274306537968,
+        "mean_difference": 0.004964891669607896,
+        "bootstrap_ci_low": -0.017675259847703215,
+        "bootstrap_ci_high": 0.026605229257416613,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.4405454601794881,
+         "dof": 249,
+         "p_value": 0.6599243058157018,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.704,
+        "system_b": 0.664,
+        "mean_difference": 0.039999999999999925,
+        "bootstrap_ci_low": -0.028000000000000025,
+        "bootstrap_ci_high": 0.10799999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.1478067422089475,
+         "dof": 249,
+         "p_value": 0.2521499230528168,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 43,
+         "correct_only_in_b": 33,
+         "discordant_pairs": 76,
+         "p_value": 0.3018724904870077,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.6469779601696886e-23
+        }
+       },
+       "composite_score": {
+        "system_a": 0.28902380952380957,
+        "system_b": 0.4945214285714286,
+        "mean_difference": -0.20549761904761904,
+        "bootstrap_ci_low": -0.22724380952380951,
+        "bootstrap_ci_high": 0.012239130952381055,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.361279761904762,
+        "system_b": 0.3681517857142858,
+        "mean_difference": -0.006872023809523786,
+        "bootstrap_ci_low": -0.03764776785714289,
+        "bootstrap_ci_high": 0.021857113095238034,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.8333333333333334,
+       "b_step_count_term": 0.796,
+       "a_mae": 0.5,
+       "b_mae": 0.612
+      }
+     },
+     "3": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.004,
+        "mean_difference": 0.016,
+        "bootstrap_ci_low": 0.004,
+        "bootstrap_ci_high": 0.032,
+        "bootstrap_ci_excludes_zero": true,
+        "paired_t": {
+         "t": 2.012158166696862,
+         "dof": 249,
+         "p_value": 0.04528026312539455,
+         "significant_at_alpha": true
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 4,
+         "correct_only_in_b": 0,
+         "discordant_pairs": 4,
+         "p_value": 0.125,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.125
+        }
+       },
+       "step_f1": {
+        "system_a": 0.1402005772005772,
+        "system_b": 0.1422126984126984,
+        "mean_difference": -0.002012121212121215,
+        "bootstrap_ci_low": -0.024964033189033192,
+        "bootstrap_ci_high": 0.020962554112554092,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.17155179227249712,
+         "dof": 249,
+         "p_value": 0.8639292440695111,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11406666666666666,
+        "system_b": 0.11886666666666668,
+        "mean_difference": -0.004800000000000013,
+        "bootstrap_ci_low": -0.026533333333333325,
+        "bootstrap_ci_high": 0.01679999999999998,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.434007899654768,
+         "dof": 249,
+         "p_value": 0.6646585150687332,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.5148401039162502,
+        "system_b": 0.5070847103170837,
+        "mean_difference": 0.007755393599166549,
+        "bootstrap_ci_low": -0.010051593872708417,
+        "bootstrap_ci_high": 0.024962184433949215,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 0.8650129669460294,
+         "dof": 249,
+         "p_value": 0.3878642687114262,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.428,
+        "system_b": 0.476,
+        "mean_difference": -0.04799999999999999,
+        "bootstrap_ci_low": -0.12400000000000005,
+        "bootstrap_ci_high": 0.02799999999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.2133272092618281,
+         "dof": 249,
+         "p_value": 0.22615445853344918,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 43,
+         "correct_only_in_b": 55,
+         "discordant_pairs": 98,
+         "p_value": 0.26640559441119166,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 6.310887241768095e-30
+        }
+       },
+       "composite_score": {
+        "system_a": 0.15830023088023087,
+        "system_b": 0.362011746031746,
+        "mean_difference": -0.20371151515151514,
+        "bootstrap_ci_low": -0.21937166089466095,
+        "bootstrap_ci_high": 0.009500833333333299,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1978752886002886,
+        "system_b": 0.20251468253968252,
+        "mean_difference": -0.004639393939393915,
+        "bootstrap_ci_low": -0.027090965007214987,
+        "bootstrap_ci_high": 0.01700808351370849,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 0.0,
+       "b_ref_micro": 1.0,
+       "a_step_count_term": 0.6799999999999999,
+       "b_step_count_term": 0.6946666666666667,
+       "a_mae": 0.96,
+       "b_mae": 0.916
+      }
+     },
+     "4": {
+      "n": 250,
+      "metrics": {
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.012,
+        "mean_difference": -0.012,
+        "bootstrap_ci_low": -0.028,
+        "bootstrap_ci_high": 0.0,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -1.7390490211537188,
+         "dof": 249,
+         "p_value": 0.0832620199015193,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 0,
+         "correct_only_in_b": 3,
+         "discordant_pairs": 3,
+         "p_value": 0.25,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 0.25
+        }
+       },
+       "step_f1": {
+        "system_a": 0.0851568797215856,
+        "system_b": 0.08801010101010101,
+        "mean_difference": -0.002853221288515409,
+        "bootstrap_ci_low": -0.02029023979288685,
+        "bootstrap_ci_high": 0.014299700789406655,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.3191822711968899,
+         "dof": 249,
+         "p_value": 0.7498559043444343,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.07139439775910364,
+        "system_b": 0.0792047619047619,
+        "mean_difference": -0.007810364145658263,
+        "bootstrap_ci_low": -0.024203452380952378,
+        "bootstrap_ci_high": 0.008057499999999997,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.9370540229057022,
+         "dof": 249,
+         "p_value": 0.34963873641054066,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "rouge_l_f1": {
+        "system_a": 0.46028578694526245,
+        "system_b": 0.44919084783273877,
+        "mean_difference": 0.011094939112523683,
+        "bootstrap_ci_low": -0.004765675646539981,
+        "bootstrap_ci_high": 0.027269886953610118,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": 1.3505671819903398,
+         "dof": 249,
+         "p_value": 0.1780602582883898,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": null
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.292,
+        "system_b": 0.328,
+        "mean_difference": -0.03600000000000003,
+        "bootstrap_ci_low": -0.10799999999999998,
+        "bootstrap_ci_high": 0.035999999999999976,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": {
+         "t": -0.9878305435823476,
+         "dof": 249,
+         "p_value": 0.3241945629963503,
+         "significant_at_alpha": false
+        },
+        "exact_mcnemar": {
+         "correct_only_in_a": 37,
+         "correct_only_in_b": 46,
+         "discordant_pairs": 83,
+         "p_value": 0.379999396411918,
+         "significant_at_alpha": false,
+         "min_attainable_p_value": 2.0679515313825692e-25
+        }
+       },
+       "composite_score": {
+        "system_a": 0.31014773788303196,
+        "system_b": 0.11803213564213565,
+        "mean_difference": 0.1921156022408963,
+        "bootstrap_ci_low": -0.010436754159239425,
+        "bootstrap_ci_high": 0.2080088346065699,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.13768467235379,
+        "system_b": 0.14754016955266958,
+        "mean_difference": -0.00985549719887957,
+        "bootstrap_ci_low": -0.030596725102919956,
+        "bootstrap_ci_high": 0.010055575555979964,
+        "bootstrap_ci_excludes_zero": false,
+        "paired_t": null,
+        "paired_t_omitted_because": "no per-item value: the composite's reference term is a micro rate and its step-count term a MAE, so it is not an average of per-item scores",
+        "exact_mcnemar": null
+       }
+      },
+      "composite_terms": {
+       "a_ref_micro": 1.0,
+       "b_ref_micro": 0.0,
+       "a_step_count_term": 0.5466666666666666,
+       "b_step_count_term": 0.5906666666666667,
+       "a_mae": 1.36,
+       "b_mae": 1.228
+      }
+     }
+    }
+   }
+  },
+  "verdict_agreement": {
+   "what": "does the bootstrap CI verdict (excludes zero) agree with the paired t-test verdict (p < alpha)? counted where both apply, i.e. the five per-item metrics",
+   "overall_rows_only": {
+    "comparisons": 75,
+    "disagreements": 0,
+    "disagreeing_cells": []
+   },
+   "overall_plus_per_gold_hop": {
+    "comparisons": 300,
+    "disagreements": 2,
+    "disagreeing_cells": [
+     {
+      "pair": "size1000_imbalanced_trial0__uniform",
+      "stratum": "3",
+      "metric": "hop_count_exact_match",
+      "bootstrap_ci": [
+       0.0,
+       0.15200000000000002
+      ],
+      "paired_t_p_value": 0.048611557378900494
+     },
+     {
+      "pair": "size4000_imbalanced_trial0__typed",
+      "stratum": "2",
+      "metric": "ordered_step_accuracy",
+      "bootstrap_ci": [
+       0.00033249999999991,
+       0.06825125000000007
+      ],
+      "paired_t_p_value": 0.05018033670125777
+     }
+    ]
+   },
+   "mcnemar_vs_ci_on_binary_metrics_overall": {
+    "comparisons": 30,
+    "disagreements": 0,
+    "disagreeing_cells": []
+   }
+  },
+  "across_pair_summary": {
+   "exact_match": {
+    "pairs": 15,
+    "difference_positive": 7,
+    "difference_negative": 8,
+    "difference_zero": 0,
+    "bootstrap_ci_significant": 0,
+    "paired_t_significant": 0,
+    "exact_mcnemar_significant": 0,
+    "ci_width_min": 0.01866666666666667,
+    "ci_width_max": 0.032
+   },
+   "step_f1": {
+    "pairs": 15,
+    "difference_positive": 14,
+    "difference_negative": 1,
+    "difference_zero": 0,
+    "bootstrap_ci_significant": 3,
+    "paired_t_significant": 3,
+    "exact_mcnemar_significant": null,
+    "ci_width_min": 0.026166576821870985,
+    "ci_width_max": 0.03238259000258999
+   },
+   "ordered_step_accuracy": {
+    "pairs": 15,
+    "difference_positive": 14,
+    "difference_negative": 1,
+    "difference_zero": 0,
+    "bootstrap_ci_significant": 4,
+    "paired_t_significant": 4,
+    "exact_mcnemar_significant": null,
+    "ci_width_min": 0.02560614478114479,
+    "ci_width_max": 0.03154566485658592
+   },
+   "rouge_l_f1": {
+    "pairs": 15,
+    "difference_positive": 15,
+    "difference_negative": 0,
+    "difference_zero": 0,
+    "bootstrap_ci_significant": 8,
+    "paired_t_significant": 8,
+    "exact_mcnemar_significant": null,
+    "ci_width_min": 0.020283286539593864,
+    "ci_width_max": 0.023069211901298993
+   },
+   "hop_count_exact_match": {
+    "pairs": 15,
+    "difference_positive": 11,
+    "difference_negative": 3,
+    "difference_zero": 1,
+    "bootstrap_ci_significant": 4,
+    "paired_t_significant": 4,
+    "exact_mcnemar_significant": 4,
+    "ci_width_min": 0.07733333333333337,
+    "ci_width_max": 0.08666666666666667
+   },
+   "composite_score": {
+    "pairs": 15,
+    "difference_positive": 10,
+    "difference_negative": 5,
+    "difference_zero": 0,
+    "bootstrap_ci_significant": 1,
+    "paired_t_significant": null,
+    "exact_mcnemar_significant": null,
+    "ci_width_min": 0.21106325420875424,
+    "ci_width_max": 0.40829528589384484
+   }
+  },
+  "across_pair_dependence_warning": "the 15 pairs share the identical 750 eval items and use nested pools, so the sign counts are descriptive; no across-pair test was run and none is claimed",
+  "holm_bonferroni": {
+   "family_15_pairs_paired_t": {
+    "exact_match": {
+     "size2000_imbalanced_trial0__raw": 1.0,
+     "size1000_balanced_trial0__uniform": 1.0,
+     "size2000_imbalanced_trial0__uniform": 1.0,
+     "size1000_imbalanced_trial0__typed": 1.0,
+     "size4000_imbalanced_trial0__typed": 1.0,
+     "size4000_imbalanced_trial0__uniform": 1.0,
+     "size1000_balanced_trial0__raw": 1.0,
+     "size8000_imbalanced_trial0__uniform": 1.0,
+     "size4000_imbalanced_trial0__raw": 1.0,
+     "size2000_imbalanced_trial0__typed": 1.0,
+     "size1000_balanced_trial0__typed": 1.0,
+     "size1000_imbalanced_trial0__raw": 1.0,
+     "size8000_imbalanced_trial0__raw": 1.0,
+     "size8000_imbalanced_trial0__typed": 1.0,
+     "size1000_imbalanced_trial0__uniform": 1.0
+    },
+    "step_f1": {
+     "size8000_imbalanced_trial0__typed": 0.31103917565777944,
+     "size1000_imbalanced_trial0__typed": 0.4184397890191585,
+     "size1000_imbalanced_trial0__raw": 0.5982109360305419,
+     "size1000_balanced_trial0__typed": 0.9207424743387158,
+     "size1000_balanced_trial0__raw": 1.0,
+     "size4000_imbalanced_trial0__raw": 1.0,
+     "size4000_imbalanced_trial0__uniform": 1.0,
+     "size4000_imbalanced_trial0__typed": 1.0,
+     "size1000_imbalanced_trial0__uniform": 1.0,
+     "size1000_balanced_trial0__uniform": 1.0,
+     "size8000_imbalanced_trial0__uniform": 1.0,
+     "size8000_imbalanced_trial0__raw": 1.0,
+     "size2000_imbalanced_trial0__uniform": 1.0,
+     "size2000_imbalanced_trial0__typed": 1.0,
+     "size2000_imbalanced_trial0__raw": 1.0
+    },
+    "ordered_step_accuracy": {
+     "size8000_imbalanced_trial0__typed": 0.037015701327338404,
+     "size4000_imbalanced_trial0__typed": 0.2789149130937409,
+     "size1000_imbalanced_trial0__typed": 0.2789149130937409,
+     "size1000_imbalanced_trial0__raw": 0.28726530087207147,
+     "size1000_balanced_trial0__typed": 1.0,
+     "size4000_imbalanced_trial0__raw": 1.0,
+     "size1000_imbalanced_trial0__uniform": 1.0,
+     "size4000_imbalanced_trial0__uniform": 1.0,
+     "size8000_imbalanced_trial0__uniform": 1.0,
+     "size8000_imbalanced_trial0__raw": 1.0,
+     "size1000_balanced_trial0__raw": 1.0,
+     "size1000_balanced_trial0__uniform": 1.0,
+     "size2000_imbalanced_trial0__uniform": 1.0,
+     "size2000_imbalanced_trial0__typed": 1.0,
+     "size2000_imbalanced_trial0__raw": 1.0
+    },
+    "rouge_l_f1": {
+     "size1000_imbalanced_trial0__typed": 0.0029881974004171874,
+     "size4000_imbalanced_trial0__raw": 0.012312745590361388,
+     "size2000_imbalanced_trial0__typed": 0.02498385525431132,
+     "size4000_imbalanced_trial0__typed": 0.025872927252784117,
+     "size2000_imbalanced_trial0__raw": 0.03024285467846984,
+     "size8000_imbalanced_trial0__typed": 0.11234715095863163,
+     "size1000_balanced_trial0__uniform": 0.27597348391021076,
+     "size1000_imbalanced_trial0__uniform": 0.27597348391021076,
+     "size4000_imbalanced_trial0__uniform": 0.46736122269289865,
+     "size2000_imbalanced_trial0__uniform": 0.46980949094564445,
+     "size1000_balanced_trial0__raw": 0.6632094648161511,
+     "size8000_imbalanced_trial0__uniform": 0.6632094648161511,
+     "size8000_imbalanced_trial0__raw": 0.6632094648161511,
+     "size1000_balanced_trial0__typed": 0.6632094648161511,
+     "size1000_imbalanced_trial0__raw": 0.6632094648161511
+    },
+    "hop_count_exact_match": {
+     "size1000_imbalanced_trial0__uniform": 0.0004007482196342004,
+     "size4000_imbalanced_trial0__raw": 0.08892022348621552,
+     "size2000_imbalanced_trial0__typed": 0.14566999032569816,
+     "size4000_imbalanced_trial0__uniform": 0.24482449872308265,
+     "size1000_imbalanced_trial0__typed": 0.8599755820074568,
+     "size2000_imbalanced_trial0__uniform": 1.0,
+     "size8000_imbalanced_trial0__typed": 1.0,
+     "size1000_balanced_trial0__typed": 1.0,
+     "size4000_imbalanced_trial0__typed": 1.0,
+     "size1000_imbalanced_trial0__raw": 1.0,
+     "size8000_imbalanced_trial0__uniform": 1.0,
+     "size8000_imbalanced_trial0__raw": 1.0,
+     "size1000_balanced_trial0__uniform": 1.0,
+     "size1000_balanced_trial0__raw": 1.0,
+     "size2000_imbalanced_trial0__raw": 1.0
+    }
+   },
+   "family_15_pairs_exact_mcnemar": {
+    "hop_count_exact_match": {
+     "size1000_imbalanced_trial0__uniform": 0.0005237296709090626,
+     "size4000_imbalanced_trial0__raw": 0.10710746519647162,
+     "size2000_imbalanced_trial0__typed": 0.17426510897327802,
+     "size4000_imbalanced_trial0__uniform": 0.2877713194617827,
+     "size1000_imbalanced_trial0__typed": 0.9862809545939542,
+     "size2000_imbalanced_trial0__uniform": 1.0,
+     "size8000_imbalanced_trial0__typed": 1.0,
+     "size1000_balanced_trial0__typed": 1.0,
+     "size4000_imbalanced_trial0__typed": 1.0,
+     "size1000_imbalanced_trial0__raw": 1.0,
+     "size8000_imbalanced_trial0__uniform": 1.0,
+     "size8000_imbalanced_trial0__raw": 1.0,
+     "size1000_balanced_trial0__uniform": 1.0,
+     "size1000_balanced_trial0__raw": 1.0,
+     "size2000_imbalanced_trial0__raw": 1.0
+    },
+    "exact_match": {
+     "size2000_imbalanced_trial0__raw": 1.0,
+     "size1000_balanced_trial0__uniform": 1.0,
+     "size2000_imbalanced_trial0__uniform": 1.0,
+     "size4000_imbalanced_trial0__typed": 1.0,
+     "size1000_imbalanced_trial0__typed": 1.0,
+     "size4000_imbalanced_trial0__uniform": 1.0,
+     "size1000_balanced_trial0__raw": 1.0,
+     "size8000_imbalanced_trial0__uniform": 1.0,
+     "size4000_imbalanced_trial0__raw": 1.0,
+     "size2000_imbalanced_trial0__typed": 1.0,
+     "size1000_balanced_trial0__typed": 1.0,
+     "size1000_imbalanced_trial0__raw": 1.0,
+     "size8000_imbalanced_trial0__raw": 1.0,
+     "size8000_imbalanced_trial0__typed": 1.0,
+     "size1000_imbalanced_trial0__uniform": 1.0
+    }
+   }
+  }
+ },
+ "field_coverage": "per-hop strata carry the bootstrap CI, paired t and exact McNemar for every metric plus the composite terms; the power sub-block and the composite-difference decomposition are emitted for the overall rows only, because those are the only ones the note reports",
+ "unmeasured": [
+  "pool size (every Task-B pair holds size fixed)",
+  "balanced vs imbalanced pools",
+  "any guided (hop-count-forced) condition",
+  "MetaQA",
+  "any v2 run",
+  "the v1 predictions' own provenance (decoder, prompt revision, whether the 600 and the 750 were drawn with a seed)"
+ ]
+}

--- a/docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md
+++ b/docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md
@@ -22,6 +22,14 @@ no `experiments/log.md` entry.
 - What *is* new and reproducible here is the **statistics**: the significance battery was computed
   in this session from the v1 per-item scores, using v2's committed protocol code (§1). The
   significance verdicts are properties of v1's numbers; they inherit v1's provenance gap.
+- **The harness that produced these figures is not committed** (analyst output is analysis, not
+  code). The figures were **verified by independent recomputation in the PR #33 delta review**, so
+  they are not unchecked — but they are **not re-derivable from committed code** until the
+  `--compare` shim in recommendation 6(b) lands. Every statistic reported below is also emitted
+  machine-readably beside this note, in
+  [`2026-08-20-v1-masking-and-retrieval-significance.json`](2026-08-20-v1-masking-and-retrieval-significance.json)
+  (statistics only — no dataset content), which additionally carries the input sha256s, the
+  alignment order, the seed/resample/chunk parameters and the Holm-adjusted p-values.
 
 ---
 
@@ -64,7 +72,7 @@ are exactly what `--compare` would print.
 **Reproducibility gap, stated plainly:** the harness is not committed (analyst output is analysis,
 not code). The four house statistics are re-derivable today by re-stamping the v1 per-item files
 into v2's schema and running `--compare`; the EM / hop-EM bootstrap columns and the diagnostic in §4
-are not, until such a shim exists. See recommendation R5.
+are not, until such a shim exists. See recommendation 6(b).
 
 ## 2. Inputs — paths and content hashes
 
@@ -105,9 +113,12 @@ inventory; **no statistic in this note is computed from aggregates**).
 
 **Task A (ran; observed).** All three files hold **600 rows each, 600 distinct normalized questions
 each, 0 duplicates**. The three question sets are **identical** (`typed == uniform == raw`, True), so
-the comparison is on the full 600 — **no intersection fallback was needed**. Gold is identical
-across the three files for every item (`gold_steps` and `gold_hop_count`, 600/600 match). Gold hop
-distribution: **200 / 200 / 200** for hops 2 / 3 / 4 — the ADR 0007 pinned shape.
+the comparison is on the full 600 — **no intersection fallback was needed**. **Alignment is by
+normalized question text (strip, lowercase, collapse whitespace), and the aligned rows are processed
+in sorted order of that key** — matching v2's `--compare`, which sorts its aligned ids so the
+bootstrap is reproducible. (v1's per-item files have no `item_id`, hence the question text as key.)
+Gold is identical across the three files for every item (`gold_steps` and `gold_hop_count`, 600/600
+match). Gold hop distribution: **200 / 200 / 200** for hops 2 / 3 / 4 — the ADR 0007 pinned shape.
 
 **Aggregate cross-check.** Re-aggregating the per-item rows reproduced each variant's committed
 `_metrics.json` to a maximum absolute delta of **3.3e-16** (typed), **2.2e-16** (uniform),
@@ -124,6 +135,16 @@ these files. Alignment is therefore **positional**, and for every matched pair e
 question **and** `gold_steps` were asserted equal between the two cells (verified True for all 15
 pairs). This is a documented deviation from v2's id-based alignment, forced by v1's file format; it
 is safe here only because the sequences are literally identical.
+
+**Read the CI bounds to three significant figures, not to the last digit.** The bootstrap resamples
+*row indices*, so the CI endpoints depend on the order the aligned matrices were built in. Ran the
+Task-A typed-vs-raw battery in both orders and observed: **every point estimate agrees to ≤ 2.8e-17**
+(floating-point summation order) and **every significance verdict is identical**, while CI endpoints
+move in the third or fourth decimal — step F1 [+0.0053, +0.0412] in the reported sorted order vs
+[+0.0054, +0.0414] in v1 file order; exact match [+0.0033, +0.0400] vs [+0.0050, +0.0400]. The
+low-order digits of a CI in this note are therefore alignment- and harness-dependent; the intervals'
+signs, widths and verdicts are not. Both orders are recorded in the companion JSON under
+`task_a_masking.row_order_sensitivity`.
 
 ## 4. Task A — masking (typed / uniform / raw), n = 600, all three pairwise
 
@@ -209,7 +230,8 @@ Three consequences, all measured:
    ([−0.1841, +0.1868]). **No composite comparison among the three masking variants is significant
    at n = 600.**
 2. **The step-level gap does survive.** With the reference term removed and the remaining weights
-   renormalized (a diagnostic quantity constructed for this note, **not** a house metric), typed vs
+   renormalized to sum to 1 — **0.5 step F1 / 0.375 ordered accuracy / 0.125 step-count term**, a
+   diagnostic quantity constructed for this note and **not** a house metric — typed vs
    raw is **+0.0273, CI [+0.0107, +0.0440] — significant**, and it stays significant within hop 2
    (+0.0372) and hop 3 (+0.0289) separately. uniform vs raw on the same diagnostic is +0.0137,
    CI [−0.0015, +0.0289] — **not** significant.
@@ -224,15 +246,15 @@ Three consequences, all measured:
 Minimum detectable difference (paired, α = 0.05 two-sided, 80% power, from the observed
 per-item difference SDs), and the n the observed difference would need:
 
-| pair | metric | observed diff | sd(diff) | MDE at n=600 | n needed for observed diff |
+| pair | metric | observed diff | sd(diff) | MDE at n=600 | n needed for observed diff (ceil) |
 |---|---|---|---|---|---|
 | typed − raw | step F1 | +0.0232 | 0.2228 | 0.0255 | 727 |
 | typed − raw | ord acc | +0.0213 | 0.2184 | 0.0250 | 828 |
 | typed − raw | EM | +0.0217 | 0.2190 | 0.0250 | 802 |
-| typed − raw | hop EM | +0.0367 | 0.5650 | 0.0646 | 1,863 |
-| typed − uniform | step F1 | +0.0111 | 0.2212 | 0.0253 | 3,139 |
-| typed − uniform | ord acc | +0.0132 | 0.2129 | 0.0244 | 2,051 |
-| uniform − raw | step F1 | +0.0121 | 0.1996 | 0.0228 | 2,137 |
+| typed − raw | hop EM | +0.0367 | 0.5650 | 0.0646 | 1,864 |
+| typed − uniform | step F1 | +0.0111 | 0.2212 | 0.0253 | 3,140 |
+| typed − uniform | ord acc | +0.0132 | 0.2129 | 0.0244 | 2,052 |
+| uniform − raw | step F1 | +0.0121 | 0.1996 | 0.0228 | 2,138 |
 
 Read: n = 600 buys ~2.5 points of step F1 / ordered accuracy. The typed-vs-raw effects sit **right
 at** that threshold — they are significant, and they are marginal. **typed vs uniform would need
@@ -300,9 +322,9 @@ and `size4000_imbalanced__typed` hop 2 ordered accuracy (CI [+0.0003, +0.0683], 
 The 15 pairs are **not independent** (identical 750 eval items; nested pools), so the sign counts
 above are descriptive; no across-pair test was run and none is claimed. The strongest statement the
 data supports: **+CE raises ROUGE-L F1 in 15/15 pairs, significantly in 8 uncorrected and 5 after
-Holm, at a magnitude of +0.005 to +0.020**, and **never moves exact match** (0/15 by any test, with
-signs split 7/8). Composite is uninformative for the same reason as §4 — **14 of its 15 CIs straddle 0**,
-with widths from 0.2111 to 0.4083.
+Holm, at a magnitude of +0.005 to +0.020**, and **shows no significant effect on exact match**
+(0/15 by any test, with signs split 7/8). Composite is uninformative for the same reason as §4 — **14 of its 15 CIs straddle 0**,
+with widths from 0.2111 to 0.4083 (`across_pair_summary.composite_score` in the companion JSON).
 
 ## 6. What contradicts, and what confirms, `docs/prior-work.md`
 
@@ -325,10 +347,11 @@ with widths from 0.2111 to 0.4083.
 Ranked by how much each would change the decision. These are options and evidence, **not** a chosen
 direction — the call is Jahid's with his supervisor.
 
-1. **Do not default to typed on the strength of the composite.** The composite typed-vs-raw gap is
-   not significant (CI [−0.1842, +0.2259]) and is 87.3% one 0.2-weighted micro rate decided by four
-   predictions. Any masking default justified by "0.3606 vs 0.1888" is justified by an artifact.
-   This is the highest-impact item because it is the number most likely to be quoted.
+1. **A typed default justified by the composite would rest on an artifact.** The composite
+   typed-vs-raw gap is not significant (CI [−0.1842, +0.2259]) and is 87.3% one 0.2-weighted micro
+   rate decided by four predictions, so "0.3606 vs 0.1888" does not carry the weight it appears to.
+   This ranks first because it is the number most likely to be quoted, not because the ranking
+   settles what to do about it.
 2. **Typed over raw is defensible on the step-level metrics, and only just.** step F1 +0.0232
    (CI [+0.0053, +0.0412], t p=0.0112), ordered accuracy +0.0213, EM +0.0217 (McNemar p=0.0241),
    ROUGE-L +0.0126 (CI lower bound +0.0001 — the weakest of the four). All four sit at the n = 600
@@ -337,14 +360,16 @@ direction — the call is Jahid's with his supervisor.
    five-metric family alone the smallest is 0.0559. So: significant as ADR 0009 reports it
    (uncorrected), fragile under correction. Whether to correct is a supervisor question and is
    already flagged in ADR 0009.
-3. **typed vs uniform is undecidable at n = 600 — do not record a winner.** Nothing is significant
-   in either direction on any metric (largest effect: ordered accuracy +0.0132, t p=0.13). Resolving
-   it at the observed effect size needs ~2,000–3,000 items. If the choice between typed and uniform
-   matters to the thesis, the honest options are (a) enlarge the eval set, or (b) record the choice
-   as made on non-statistical grounds (e.g. masking-pipeline simplicity) and say so.
+3. **The data cannot name a winner between typed and uniform at n = 600.** Nothing is significant
+   in either direction on any metric (largest effect: ordered accuracy +0.0132, t p=0.13), so a
+   recorded winner would not be supported by these runs. Resolving it at the observed effect size
+   needs ~2,000–3,000 items. If the choice matters to the thesis, the options the evidence leaves
+   open are (a) enlarge the eval set, or (b) make the choice on non-statistical grounds
+   (e.g. masking-pipeline simplicity) and record that this is what happened.
 4. **Cross-encoder rerank: adopt-or-not turns on which metric is primary.** +CE is the most
    consistent effect anywhere in this note on **ROUGE-L F1** (15/15 pairs positive, 8 uncorrected /
-   5 Holm-surviving) and is **flat on exact match** (0/15, signs 7/8). That makes it a decision that
+   5 Holm-surviving) and shows **no significant effect on exact match** (0/15 by any test, signs
+   split 7/8). That makes it a decision that
    cannot be taken before #6 item 5 (thesis-primary metric) — worth surfacing as a dependency rather
    than deciding twice.
 5. **The reference-validity term needs a decision before the composite is used anywhere.** At v1's

--- a/docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md
+++ b/docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md
@@ -1,0 +1,365 @@
+# Are v1's masking and retrieval comparisons statistically significant?
+
+**Date:** 2026-08-20 · **Author:** analyst agent session · **Scope:** issue #6 item 4 (decomposer
+retrieval default) · **Runs:** none — this is a re-analysis of existing v1 artifacts, so there is
+no `experiments/log.md` entry.
+
+---
+
+## Prior-work caveat — read this before quoting any number below
+
+**Every input to this note is a v1 artifact** produced in the predecessor repo
+(`/cta/users/fyilmaz/Thesis---QA`, treated as read-only here) **before v2's rules existed**.
+
+- v1's `runs/` is gitignored and **untracked** — `git ls-files runs/` in v1 returns **0 files**
+  (ran; observed 0). The per-item files this note analyses therefore **carry no commit SHA**;
+  their only provenance is path + mtime + content hash (§2). This is the ADR 0005 situation: v1
+  runs are not tied to committed code.
+- Consequently **these are citable prior work, not v2 experimental claims.** Nothing here may be
+  reported as a v2 measurement, and none of it satisfies Gate 2 (committed code + committed config
+  + fixed seed). Any of these comparisons that the thesis wants to *assert* has to be re-run in v2
+  first (ADR 0001; which baselines and when is Jahid's call).
+- What *is* new and reproducible here is the **statistics**: the significance battery was computed
+  in this session from the v1 per-item scores, using v2's committed protocol code (§1). The
+  significance verdicts are properties of v1's numbers; they inherit v1's provenance gap.
+
+---
+
+## 1. Method — what was run
+
+The house protocol is ADR 0009 as amended 2026-08-20 (paired bootstrap + exact McNemar, with a
+paired t-test added alongside per issue #30), implemented in
+`scripts/musique_decompositions_evaluator.py` `--compare` and documented in `docs/METRICS.md` §5.
+
+v1's per-item files are **bare JSON lists** with **no `item_id`** and no stamped composite
+weights, so v2's `--compare` refuses them by design (`_load_per_item` / `_require_matching_weights`).
+The battery was therefore run from a session-local harness that **imports v2's own functions**
+(`_paired_bootstrap`, `_statistic_arrays`, `_mcnemar_exact_p`) and re-implements only the alignment
+step. Parameters are v2's (`configs/musique_eval.json`): 10,000 bootstrap resamples, chunk size
+1,000, α = 0.05, seed 42, `numpy.random.default_rng`, one index matrix applied to both systems,
+percentile CI of (A − B), composite recomputed on every resample with weights
+0.4 / 0.3 / 0.2 / 0.1 and step-count scale 3.0. **Those weights and that scale are identical in v1**
+(`Thesis---QA/scripts/musique_decompositions_evaluator.py:411-416`, read this session), so the
+composite compared here is the same quantity v1 reported.
+
+**Validation (ran; observed):** for the four statistics v2's protocol covers (`rouge_l_f1`,
+`step_f1`, `ordered_step_accuracy`, `composite_score`), the harness's difference, CI low and CI high
+were compared to v2's `_paired_bootstrap` called directly on the same rows, with **zero tolerance**
+(`abs_tol=0`). Result: **bit-identical on both a Task-A pair and a Task-B pair** (2/2 checks OK).
+Two statistics were added to the same bootstrap (`exact_match`, `hop_count_exact_match` means) plus
+one diagnostic (§4); adding statistics does not perturb the RNG stream, so the four house numbers
+are exactly what `--compare` would print.
+
+- **Exact McNemar** (two-sided, integer binomial on discordant pairs) for the two binary per-item
+  metrics: `exact_match`, `hop_count_exact_match`.
+- **Paired t-test**: `scipy.stats.ttest_rel` (**scipy 1.17.1 is present** in `.venv` — checked; no
+  hand-rolled fallback was needed) over per-item differences, for all five per-item metrics. The
+  **composite has no per-item value** (its reference term is a micro rate, its step-count term a
+  MAE), so no t-test and no McNemar is reported for it — only the bootstrap, which recomputes it.
+- **Per gold hop** (2/3/4): the whole battery re-run on each hop subset, seed 42 on that subset.
+  All strata have n ≥ 200, above `min_items_for_significance_claim` = 30.
+- **No multiple-comparison correction in the headline**, per ADR 0009. Holm-Bonferroni was computed
+  separately within stated families and is reported where it changes the reading (§5, §7).
+
+**Reproducibility gap, stated plainly:** the harness is not committed (analyst output is analysis,
+not code). The four house statistics are re-derivable today by re-stamping the v1 per-item files
+into v2's schema and running `--compare`; the EM / hop-EM bootstrap columns and the diagnostic in §4
+are not, until such a shim exists. See recommendation R5.
+
+## 2. Inputs — paths and content hashes
+
+All paths under `/cta/users/fyilmaz/Thesis---QA` (read-only; not modified). v1 HEAD is `a020fd6`
+with a clean tree, but as stated above the run files are untracked, so that SHA does **not** pin
+them.
+
+**Task A** — `runs/musique_decomposition_eval/` (mtime 2026-04-13; sha256, first 16 hex):
+
+| variant | per-item file | sha256[:16] | mtime |
+|---|---|---|---|
+| typed | `eval_typed_unguided_per_item.json` | `53ab0a08f380db9a` | 2026-04-13 13:07:57 |
+| uniform | `eval_uniform_unguided_per_item.json` | `a0348260dd4a7d73` | 2026-04-13 13:08:14 |
+| raw | `eval_raw_unguided_per_item.json` | `80e64a38b7934c52` | 2026-04-13 13:07:52 |
+
+Companion metrics files used for cross-checking: `eval_typed_unguided_metrics.json`
+`c4c9634b9287e354`, `eval_uniform_unguided_metrics.json` `4cff2acebaa9eac2`,
+`eval_raw_unguided_metrics.json` `c4a4093bdd479aab`. The three eval configs all record
+`seed: 42`, `limit: null`, gold `MusiQue/Data/dev_data/musique_ans_v1.0_dev_clean.jsonl`, and
+prediction paths `runs/decomposer_raw_unguided/{typed,masked,raw}/results.json` — note **"uniform"
+is the `masked` predictions path**, as `docs/prior-work.md` §3 says.
+
+**Task B** — `runs/pool_sweep/eval/<cell>/eval_per_item.json`, 33 cells, mtimes 2026-04-20 05:05 →
+2026-04-21 00:51. sha256[:12] per cell, in `ls` order:
+`ee64da7b422f`, `43231fdbb102`, `5792aa706a92`, `2e5530974c1e`, `f911796f96a4`, `4c3fc18b7138`,
+`7144c097bfe4`, `e353c76ae359`, `9547be04e6ea`, `648a213520d0`, `bd2f1d6fd499`, `c1e6f9759385`,
+`70e58b63076c`, `5fad3c5f009e`, `dc5abb6406e0`, `b2bfd5eda5d8`, `b054f418dd52`, `543f4cfc77c7`,
+`e06ffc80a9c1`, `fd64acc34395`, `21fd8dd22295`, `a53aabd9f3cc`, `3a0fb90b6f0c`, `6ac7af550531`,
+`1ab9623bce72`, `5444b2e2a60e`, `18451b8cfe7b`, `0c5bf23b087a`, `2a2dd118ee32`, `18fcac5e0213`,
+`fb5399e1ddc2`, `a0df3f17bbd7`, `c5ccdb504f23`
+(cell order: `size1000_balanced` {only,plus_ce} × {raw,typed,uniform}, `size1000_imbalanced` …,
+`size2000_balanced__biencoder_only` …, `size2000_imbalanced` …, `size4000_imbalanced` …,
+`size8000_imbalanced` …). Aggregate CSV `runs/pool_sweep/summary/all_runs.csv` sha256
+`89c5e923ddbb2a8737c12bda160e12b7df7d4f1ed7add3767604b6419ba51e6e` (used only to confirm the cell
+inventory; **no statistic in this note is computed from aggregates**).
+
+## 3. Item-set verification
+
+**Task A (ran; observed).** All three files hold **600 rows each, 600 distinct normalized questions
+each, 0 duplicates**. The three question sets are **identical** (`typed == uniform == raw`, True), so
+the comparison is on the full 600 — **no intersection fallback was needed**. Gold is identical
+across the three files for every item (`gold_steps` and `gold_hop_count`, 600/600 match). Gold hop
+distribution: **200 / 200 / 200** for hops 2 / 3 / 4 — the ADR 0007 pinned shape.
+
+**Aggregate cross-check.** Re-aggregating the per-item rows reproduced each variant's committed
+`_metrics.json` to a maximum absolute delta of **3.3e-16** (typed), **2.2e-16** (uniform),
+**3.3e-16** (raw) across EM, step F1, ordered accuracy, ROUGE-L F1, hop EM, composite,
+`reference_validity_micro` and `step_count_abs_error_mae`. The reference counts stated in
+`docs/prior-work.md` §3 are confirmed exactly: **typed 6/8, uniform 7/9, raw 0/4** valid/total
+`[#k]` references over 600 predictions.
+
+**Task B (ran; observed).** 33 eval cells, **750 rows each**, and the **normalized question
+sequence is identical across all 33 cells, order included** (True). Hop distribution 250 / 250 / 250.
+One question text appears twice (rows 370 and 376) with **identical gold** — a genuinely duplicated
+eval item, which is why keying by question is not usable and why v2's `--compare` would abort on
+these files. Alignment is therefore **positional**, and for every matched pair each row's normalized
+question **and** `gold_steps` were asserted equal between the two cells (verified True for all 15
+pairs). This is a documented deviation from v2's id-based alignment, forced by v1's file format; it
+is safe here only because the sequences are literally identical.
+
+## 4. Task A — masking (typed / uniform / raw), n = 600, all three pairwise
+
+`*` and **yes** mark a 95% bootstrap CI that excludes 0. "b/c" are McNemar's discordant counts
+(right only in A / right only in B).
+
+| pair | metric | A | B | diff | 95% CI | CI sig | McNemar b/c, p | t (dof=599), p |
+|---|---|---|---|---|---|---|---|---|
+| typed vs raw | EM | 0.0583 | 0.0367 | +0.0217 | [+0.0033, +0.0400] | **yes** | 21/8, p=0.0241 | t=2.424, p=0.0157 |
+| typed vs raw | step F1 | 0.2006 | 0.1775 | +0.0232 | [+0.0053, +0.0412] | **yes** | n/a (not binary) | t=2.545, p=0.0112 |
+| typed vs raw | ord acc | 0.1794 | 0.1581 | +0.0213 | [+0.0039, +0.0388] | **yes** | n/a (not binary) | t=2.385, p=0.0174 |
+| typed vs raw | ROUGE-L F1 | 0.5442 | 0.5315 | +0.0126 | [+0.0001, +0.0250] | **yes** | n/a (not binary) | t=1.997, p=0.0463 |
+| typed vs raw | hop EM | 0.5217 | 0.4850 | +0.0367 | [-0.0083, +0.0817] | no | 107/85, p=0.1294 | t=1.590, p=0.1124 |
+| typed vs raw | composite | 0.3606 | 0.1888 | +0.1718 | [-0.1842, +0.2259] | **no** | n/a | n/a (no per-item value) |
+| typed vs uniform | EM | 0.0583 | 0.0550 | +0.0033 | [-0.0133, +0.0200] | no | 15/13, p=0.8506 | t=0.378, p=0.7058 |
+| typed vs uniform | step F1 | 0.2006 | 0.1896 | +0.0111 | [-0.0064, +0.0290] | no | n/a | t=1.225, p=0.2211 |
+| typed vs uniform | ord acc | 0.1794 | 0.1662 | +0.0132 | [-0.0038, +0.0303] | no | n/a | t=1.515, p=0.1302 |
+| typed vs uniform | ROUGE-L F1 | 0.5442 | 0.5431 | +0.0011 | [-0.0107, +0.0127] | no | n/a | t=0.178, p=0.8589 |
+| typed vs uniform | hop EM | 0.5217 | 0.5050 | +0.0167 | [-0.0283, +0.0617] | no | 96/86, p=0.5048 | t=0.741, p=0.4590 |
+| typed vs uniform | composite | 0.3606 | 0.3554 | +0.0053 | [-0.1841, +0.1868] | no | n/a | n/a |
+| uniform vs raw | EM | 0.0550 | 0.0367 | +0.0183 | [+0.0033, +0.0333] | **yes** | 16/5, p=0.0266 | t=2.410, p=0.0163 |
+| uniform vs raw | step F1 | 0.1896 | 0.1775 | +0.0121 | [-0.0038, +0.0279] | no | n/a | t=1.484, p=0.1383 |
+| uniform vs raw | ord acc | 0.1662 | 0.1581 | +0.0081 | [-0.0075, +0.0236] | no | n/a | t=1.032, p=0.3025 |
+| uniform vs raw | ROUGE-L F1 | 0.5431 | 0.5315 | +0.0115 | [-0.0010, +0.0244] | no | n/a | t=1.785, p=0.0747 |
+| uniform vs raw | hop EM | 0.5050 | 0.4850 | +0.0200 | [-0.0283, +0.0683] | no | 112/100, p=0.4500 | t=0.824, p=0.4103 |
+| uniform vs raw | composite | 0.3554 | 0.1888 | +0.1665 | [-0.1875, +0.2143] | no | n/a | n/a |
+
+**The three tests agree everywhere they overlap.** Every metric flagged by the CI has t-test
+p < 0.05, and every metric the CI does not flag has t-test p > 0.05; both McNemar verdicts match
+their CI verdict. There is no case in the overall table where the bootstrap and the t-test disagree.
+
+### Per gold hop (n = 200 per stratum)
+
+| pair | hop | EM | step F1 | ord acc | ROUGE-L F1 | hop EM | composite | composite w/o ref term |
+|---|---|---|---|---|---|---|---|---|
+| typed vs raw | 2 | +0.0300 | +0.0397* | +0.0392 | +0.0183 | +0.0400 | +0.0298* | +0.0372* |
+| typed vs raw | 3 | +0.0150 | +0.0241 | +0.0254* | +0.0185 | +0.0350 | -0.1769 | +0.0289* |
+| typed vs raw | 4 | +0.0200* | +0.0057 | -0.0008 | +0.0010 | +0.0350 | +0.0126 | +0.0157 |
+| typed vs uniform | 2 | -0.0100 | +0.0019 | +0.0072 | -0.0054 | +0.0250 | +0.2029 | +0.0036 |
+| typed vs uniform | 3 | +0.0050 | +0.0145 | +0.0242* | +0.0056 | +0.0300 | +0.0137 | +0.0171 |
+| typed vs uniform | 4 | +0.0150 | +0.0168 | +0.0081 | +0.0030 | -0.0050 | -0.1842 | +0.0198 |
+| uniform vs raw | 2 | +0.0400 | +0.0378* | +0.0320 | +0.0237 | +0.0150 | -0.1731 | +0.0336* |
+| uniform vs raw | 3 | +0.0100 | +0.0096 | +0.0012 | +0.0129 | +0.0050 | -0.1906 | +0.0117 |
+| uniform vs raw | 4 | +0.0050 | -0.0111 | -0.0089 | -0.0020 | +0.0400 | +0.1967 | -0.0041 |
+
+Per-hop McNemar and t-tests were computed too. Across all 60 Task-A comparisons where both the
+bootstrap CI and the t-test apply (3 pairs × 5 metrics × {overall, hop 2, hop 3, hop 4}) the two
+verdicts disagree in **exactly one** cell, named below. Notable per-hop t-tests:
+typed vs raw step F1 at hop 2 t=2.013 p=0.0455 (dof=199); typed vs raw ordered accuracy at hop 3
+t=2.115 p=0.0357; typed vs raw EM at hop 4 t=2.015 p=0.0452 but **McNemar p=0.125 on 4/0 discordant
+pairs** — with only four discordant items the exact test cannot reach 0.05 (its minimum attainable
+p is 0.125), so that cell is a power artifact, not a finding. typed vs uniform ordered accuracy at
+hop 3 has CI [+0.0002, +0.0492] (nominally significant) while t p=0.0563 — a genuinely borderline
+cell that should not be leaned on.
+
+**Direction of the typed advantage:** typed > raw is concentrated in **hops 2 and 3**. At hop 4 the
+step-level gaps collapse (step F1 +0.0057, ordered accuracy −0.0008, ROUGE-L +0.0010, none
+significant). The masking benefit, such as it is, is a shallow-question benefit in these runs.
+
+### The typed-vs-raw composite gap is almost entirely one term (Task A.3)
+
+Exact decomposition of the composite difference into its four weighted terms (ran; the four
+contributions sum to the total to 1e-6):
+
+| pair | total Δcomposite | 0.4·Δstep F1 | 0.3·Δord acc | 0.2·Δref_micro | 0.1·Δstep-count term |
+|---|---|---|---|---|---|
+| typed vs raw | **+0.1718** | +0.0093 (5.4%) | +0.0064 (3.7%) | **+0.1500 (87.3%)** | +0.0062 (3.6%) |
+| uniform vs raw | +0.1665 | +0.0048 (2.9%) | +0.0024 (1.5%) | **+0.1556 (93.4%)** | +0.0037 (2.2%) |
+| typed vs uniform | +0.0053 | +0.0044 | +0.0040 | −0.0056 | +0.0024 |
+
+`reference_validity_micro` is **0.75 for typed, 0.7778 for uniform, 0.0000 for raw**, and those
+rates rest on **8 references from 3 items (typed), 9 from 4 items (uniform), 4 from 1 item (raw)**
+out of 600 predictions. So **87.3%** of the headline typed-vs-raw composite gap that
+`docs/prior-work.md` §3 reports is produced by a 0.2-weighted micro rate decided by **four
+predictions in total**. `docs/prior-work.md`'s caveat is confirmed and now quantified.
+
+Three consequences, all measured:
+
+1. **The composite gap is not significant.** typed vs raw composite CI is
+   **[−0.1842, +0.2259]** — width 0.41 on a 0-to-1 scale, straddling 0. The bootstrap resamples the
+   handful of reference-emitting items in or out, so the term flips between 0 and 0.75 across
+   resamples. The same happens for uniform vs raw ([−0.1875, +0.2143]) and typed vs uniform
+   ([−0.1841, +0.1868]). **No composite comparison among the three masking variants is significant
+   at n = 600.**
+2. **The step-level gap does survive.** With the reference term removed and the remaining weights
+   renormalized (a diagnostic quantity constructed for this note, **not** a house metric), typed vs
+   raw is **+0.0273, CI [+0.0107, +0.0440] — significant**, and it stays significant within hop 2
+   (+0.0372) and hop 3 (+0.0289) separately. uniform vs raw on the same diagnostic is +0.0137,
+   CI [−0.0015, +0.0289] — **not** significant.
+3. **Per hop the composite term outright reverses the ranking.** At hop 3 typed's ref_micro is 0.00
+   while raw's is 1.00 (raw emitted no references in that stratum, which scores 1.0 by the micro
+   convention when the denominator is empty), so the hop-3 composite reads **−0.1769 in raw's
+   favour** while every step-level metric in that stratum favours typed. The composite is not a
+   usable ranking signal at these reference volumes.
+
+### Power at n = 600
+
+Minimum detectable difference (paired, α = 0.05 two-sided, 80% power, from the observed
+per-item difference SDs), and the n the observed difference would need:
+
+| pair | metric | observed diff | sd(diff) | MDE at n=600 | n needed for observed diff |
+|---|---|---|---|---|---|
+| typed − raw | step F1 | +0.0232 | 0.2228 | 0.0255 | 727 |
+| typed − raw | ord acc | +0.0213 | 0.2184 | 0.0250 | 828 |
+| typed − raw | EM | +0.0217 | 0.2190 | 0.0250 | 802 |
+| typed − raw | hop EM | +0.0367 | 0.5650 | 0.0646 | 1,863 |
+| typed − uniform | step F1 | +0.0111 | 0.2212 | 0.0253 | 3,139 |
+| typed − uniform | ord acc | +0.0132 | 0.2129 | 0.0244 | 2,051 |
+| uniform − raw | step F1 | +0.0121 | 0.1996 | 0.0228 | 2,137 |
+
+Read: n = 600 buys ~2.5 points of step F1 / ordered accuracy. The typed-vs-raw effects sit **right
+at** that threshold — they are significant, and they are marginal. **typed vs uniform would need
+roughly 2,000–3,000 items** to resolve at the observed effect size; declaring it a tie at n = 600 is
+a statement about power, not about the two modes being equal.
+
+## 5. Task B — bi-encoder vs bi-encoder + cross-encoder rerank
+
+**Per-item data survives** — `runs/pool_sweep/eval/<cell>/eval_per_item.json` exists for all 33
+cells, so the "no per-item data ⇒ no test computable" fallback does **not** apply. **15 matched
+pairs** exist (same size, balance, trial and mask mode, differing only in retrieval variant):
+size1000 balanced and imbalanced, size2000 imbalanced, size4000 imbalanced, size8000 imbalanced,
+each × {raw, typed, uniform}. The three `size2000_balanced_trial0__biencoder_only__*` cells have
+**no `biencoder_plus_ce` counterpart** and are excluded — that is why 33 cells yield 15 pairs, not 16.
+Each pair is n = 750 on the identical, identically-ordered eval sequence.
+
+Differences are **(+CE) − (bi-encoder only)**; `*` = 95% CI excludes 0.
+
+| pool cell (size_balance__mask) | EM | step F1 | ord acc | ROUGE-L F1 | hop EM | composite |
+|---|---|---|---|---|---|---|
+| size1000_balanced__raw | -0.0053 | +0.0119 | +0.0045 | +0.0079 | -0.0027 | +0.1883 |
+| size1000_balanced__typed | -0.0040 | +0.0131 | +0.0111 | +0.0072 | +0.0187 | +0.0947 |
+| size1000_balanced__uniform | -0.0080 | +0.0079 | +0.0044 | +0.0129* | -0.0120 | +0.0345 |
+| size1000_imbalanced__raw | +0.0040 | +0.0156* | +0.0173* | +0.0049 | +0.0160 | +0.0422 |
+| size1000_imbalanced__typed | +0.0053 | +0.0146* | +0.0151* | +0.0199* | +0.0360 | +0.0141 |
+| size1000_imbalanced__uniform | +0.0013 | +0.0086 | +0.0099 | +0.0116* | +0.0893* | +0.0035 |
+| size2000_imbalanced__raw | -0.0093 | +0.0011 | +0.0006 | +0.0167* | +0.0000 | -0.1970 |
+| size2000_imbalanced__typed | -0.0040 | +0.0015 | +0.0014 | +0.0161* | +0.0520* | -0.0199 |
+| size2000_imbalanced__uniform | +0.0053 | +0.0038 | +0.0033 | +0.0095 | +0.0307 | +0.2063* |
+| size4000_imbalanced__raw | -0.0053 | +0.0124 | +0.0112 | +0.0177* | +0.0573* | -0.1899 |
+| size4000_imbalanced__typed | +0.0067 | +0.0114 | +0.0178* | +0.0172* | +0.0173 | -0.0864 |
+| size4000_imbalanced__uniform | -0.0053 | +0.0105 | +0.0090 | +0.0101 | +0.0493* | -0.1889 |
+| size8000_imbalanced__raw | +0.0040 | +0.0057 | +0.0075 | +0.0071 | +0.0120 | +0.0063 |
+| size8000_imbalanced__typed | +0.0027 | +0.0165* | +0.0211* | +0.0136* | +0.0213 | +0.1361 |
+| size8000_imbalanced__uniform | -0.0053 | -0.0069 | -0.0075 | +0.0079 | -0.0147 | +0.0348 |
+
+Counts across the 15 pairs (CI-significant / t-significant / McNemar-significant, all α = 0.05,
+uncorrected):
+
+| metric | Δ > 0 | Δ < 0 | Δ = 0 | CI sig | t sig | McNemar sig |
+|---|---|---|---|---|---|---|
+| exact match | 7 | 8 | 0 | **0** | **0** | **0** |
+| step F1 | 14 | 1 | 0 | 3 | 3 | n/a |
+| ordered step accuracy | 14 | 1 | 0 | 4 | 4 | n/a |
+| ROUGE-L F1 | **15** | **0** | 0 | **8** | **8** | n/a |
+| hop-count EM | 11 | 3 | 1 | 4 | 4 | 4 |
+| composite | 10 | 5 | 0 | 1 | n/a | n/a |
+
+The CI and t-test verdicts agree **75/75** on the overall rows where both apply (five metrics ×
+15 pairs; the composite has no t-test), and McNemar agrees with the CI on **both** binary metrics in
+all 15 pairs. Including the per-hop strata (300 comparisons), the CI and t-test disagree in 2 cells,
+both borderline: `size1000_imbalanced__uniform` hop 3 hop EM (CI [+0.0000, +0.1520], t p = 0.0486)
+and `size4000_imbalanced__typed` hop 2 ordered accuracy (CI [+0.0003, +0.0683], t p = 0.0502).
+
+**Multiplicity matters here** (15 pairs are a family). Holm-Bonferroni within each 15-test family:
+
+- **ROUGE-L F1: 5 of 15 survive** — `size1000_imbalanced__typed` (adj p = 0.0030),
+  `size4000_imbalanced__raw` (0.0123), `size2000_imbalanced__typed` (0.0250),
+  `size4000_imbalanced__typed` (0.0259), `size2000_imbalanced__raw` (0.0302).
+- **hop-count EM: 1 survives** — `size1000_imbalanced__uniform` (t adj p = 0.0004; McNemar adj
+  p = 0.0005, discordant 162/95).
+- **ordered accuracy: 1 survives** — `size8000_imbalanced__typed` (adj p = 0.0370).
+- **step F1: 0 survive. Exact match: 0 survive.**
+
+The 15 pairs are **not independent** (identical 750 eval items; nested pools), so the sign counts
+above are descriptive; no across-pair test was run and none is claimed. The strongest statement the
+data supports: **+CE raises ROUGE-L F1 in 15/15 pairs, significantly in 8 uncorrected and 5 after
+Holm, at a magnitude of +0.005 to +0.020**, and **never moves exact match** (0/15 by any test, with
+signs split 7/8). Composite is uninformative for the same reason as §4 — **14 of its 15 CIs straddle 0**,
+with widths from 0.2111 to 0.4083.
+
+## 6. What contradicts, and what confirms, `docs/prior-work.md`
+
+- **Confirmed:** typed's advantage over raw on step F1 / ordered accuracy / EM / ROUGE-L is real at
+  n = 600 (uncorrected) — FINDINGS' "prefer typed (or at least masked) over raw" is supported on the
+  step-level metrics.
+- **Confirmed and quantified:** the composite gap 0.3606 vs 0.1888 is 87.3% one micro term resting
+  on four predictions, and it is **not statistically significant**.
+- **Not supported as stated:** §4's aggregate reading that "cross-encoder rerank is not a free win
+  on mean composite" is true of the *mean composite* but understates ROUGE-L, where +CE wins
+  15/15 pairs. Conversely, §4's "helps … especially hop-count EM / step F1 at larger pools" is only
+  partly borne out: hop EM's single Holm-surviving win is at **size 1000** (imbalanced, uniform),
+  and step F1's three uncorrected wins are at sizes 1000 and 8000 — the size pattern is not clean.
+- **Unmeasured here:** pool size. Every pair in §5 holds size fixed, so **no claim in this note
+  bears on the "~2000–4000" half of issue #6 item 4.** Cross-size matched pairs exist on the same
+  750 items and the same battery would apply.
+
+## 7. Ranked takeaways for the masking-default decision (#6 item 4)
+
+Ranked by how much each would change the decision. These are options and evidence, **not** a chosen
+direction — the call is Jahid's with his supervisor.
+
+1. **Do not default to typed on the strength of the composite.** The composite typed-vs-raw gap is
+   not significant (CI [−0.1842, +0.2259]) and is 87.3% one 0.2-weighted micro rate decided by four
+   predictions. Any masking default justified by "0.3606 vs 0.1888" is justified by an artifact.
+   This is the highest-impact item because it is the number most likely to be quoted.
+2. **Typed over raw is defensible on the step-level metrics, and only just.** step F1 +0.0232
+   (CI [+0.0053, +0.0412], t p=0.0112), ordered accuracy +0.0213, EM +0.0217 (McNemar p=0.0241),
+   ROUGE-L +0.0126 (CI lower bound +0.0001 — the weakest of the four). All four sit at the n = 600
+   detection threshold (MDE ≈ 0.025). If any multiplicity correction is applied across the 15-test
+   Task-A family, **nothing survives** (smallest Holm-adjusted p = 0.1676); within the typed-vs-raw
+   five-metric family alone the smallest is 0.0559. So: significant as ADR 0009 reports it
+   (uncorrected), fragile under correction. Whether to correct is a supervisor question and is
+   already flagged in ADR 0009.
+3. **typed vs uniform is undecidable at n = 600 — do not record a winner.** Nothing is significant
+   in either direction on any metric (largest effect: ordered accuracy +0.0132, t p=0.13). Resolving
+   it at the observed effect size needs ~2,000–3,000 items. If the choice between typed and uniform
+   matters to the thesis, the honest options are (a) enlarge the eval set, or (b) record the choice
+   as made on non-statistical grounds (e.g. masking-pipeline simplicity) and say so.
+4. **Cross-encoder rerank: adopt-or-not turns on which metric is primary.** +CE is the most
+   consistent effect anywhere in this note on **ROUGE-L F1** (15/15 pairs positive, 8 uncorrected /
+   5 Holm-surviving) and is **flat on exact match** (0/15, signs 7/8). That makes it a decision that
+   cannot be taken before #6 item 5 (thesis-primary metric) — worth surfacing as a dependency rather
+   than deciding twice.
+5. **The reference-validity term needs a decision before the composite is used anywhere.** At v1's
+   reference volumes (4–9 references per 600 predictions) the term is noise with a 0.2 weight, and
+   its "no references ⇒ 1.0" convention makes a reference-free system beat a partly-correct one
+   (visible at hop 3 in §4, where the composite reverses the ranking). This is direct input to
+   issue #29 (composite bias check) and to #6 item 5.
+6. **Two cheap follow-ups the same battery answers, both unmeasured today:** (a) pool-size pairs
+   (2000 vs 4000 etc., matched on balance/mode/retrieval, same 750 items) — the other half of
+   #6 item 4; (b) a `--compare` shim that accepts v1-format per-item files, which would make every
+   number in §4–§5 reproducible from committed code instead of from a session-local harness.
+
+## 8. Unmeasured / out of scope
+
+Stated so it is not read into the note: pool size significance; balanced vs imbalanced pools; any
+guided (hop-forced) condition; MetaQA; any v2 run. No model was run and no v1 file was modified.
+The v1 predictions' own provenance (which decoder, which prompt revision, whether the 600 and the
+750 were drawn with a seed) is not established by this note — see the caveat up top and ADR 0005.

--- a/docs/prior-work.md
+++ b/docs/prior-work.md
@@ -58,6 +58,8 @@ Shared patterns per FINDINGS: exact match is low (gold plans are hard to reprodu
 
 FINDINGS' takeaways for next work: prefer typed (or at least masked) few-shot retrieval over raw; unguided decomposition needs stronger length/hop control; optimize for step F1 / ordered accuracy / hop EM, not only exact match.
 
+**Significance check (2026-08-20):** paired tests over these per-item files show the composite gap above is *not* significant and is 87% one fragile term; typed > raw holds on the step-level metrics (uncorrected), typed vs uniform decides nothing at n=600 — see `docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md` before citing this table.
+
 ## 4. Pool sweep — pool size × retrieval × mask mode (FINDINGS §5)
 
 Source: `Thesis---QA/handoff/results_analysis/pool_sweep_summary/all_runs.csv` + plots. 33 cells (sizes 1000/2000/4000/8000; balanced/imbalanced; biencoder_only vs biencoder_plus_ce; modes raw/typed/uniform); eval size typically 750 questions per cell. Same pool/eval provenance as §3: pool from MuSiQue train, eval from dev (`Thesis---QA/configs/pool_sweep.json:16,26`), which keeps the retrieval numbers leak-free.
@@ -74,6 +76,8 @@ Best cells by metric:
 Aggregate mean composite_score: mode typed 0.267, uniform 0.259, raw 0.243; biencoder_only 0.257, biencoder_plus_ce 0.256; size 4000 is highest among sizes at 0.311 (2000: 0.271, 1000: 0.232, 8000: 0.230).
 
 FINDINGS' conclusions: typed masking is the best average retrieval mode in this sweep; larger pool is not always better (8000 drops vs 4000); cross-encoder rerank is not a free win on mean composite (it helps some metrics, especially hop-count EM / step F1 at larger pools — consult the delta plots per metric); exact match stays ~3–5% across the board — pool size alone does not solve gold-plan matching.
+
+**Significance check (2026-08-20):** over the 15 matched cell pairs, +CE raises ROUGE-L F1 in 15/15 (5 survive Holm) and never moves exact match — see `docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md`.
 
 ## 5. MetaQA KG compile/execute charts (FINDINGS §6)
 

--- a/docs/prior-work.md
+++ b/docs/prior-work.md
@@ -77,7 +77,7 @@ Aggregate mean composite_score: mode typed 0.267, uniform 0.259, raw 0.243; bien
 
 FINDINGS' conclusions: typed masking is the best average retrieval mode in this sweep; larger pool is not always better (8000 drops vs 4000); cross-encoder rerank is not a free win on mean composite (it helps some metrics, especially hop-count EM / step F1 at larger pools — consult the delta plots per metric); exact match stays ~3–5% across the board — pool size alone does not solve gold-plan matching.
 
-**Significance check (2026-08-20):** over the 15 matched cell pairs, +CE raises ROUGE-L F1 in 15/15 (5 survive Holm) and never moves exact match — see `docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md`.
+**Significance check (2026-08-20):** over the 15 matched cell pairs, +CE raises ROUGE-L F1 in 15/15 (5 survive Holm) and shows no significant effect on exact match (0/15 by any test, signs split 7/8) — see `docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md`.
 
 ## 5. MetaQA KG compile/execute charts (FINDINGS §6)
 


### PR DESCRIPTION
Refs #6 (item 4 — decomposer retrieval default). Docs-only: one note at
`docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md`. **Do not merge yet** — for
Jahid's read before the supervisor conversation.

## Prior-work caveat (stated at the top of the note too)

Every input is a v1 artifact from `/cta/users/fyilmaz/Thesis---QA` (read-only, not modified). v1's
`runs/` is gitignored and untracked (`git ls-files runs/` returns 0), so these per-item files
**carry no commit SHA** — ADR 0005 territory. The results are **citable prior work, not v2
experimental claims**, and satisfy no part of Gate 2. Nothing was run on a GPU; there is no
`experiments/log.md` entry because no experiment was performed.

## Method

The house protocol (ADR 0009 as amended 2026-08-20: paired bootstrap + exact McNemar, with a paired
t-test alongside per #30), at v2's parameters — 10,000 resamples, chunk 1,000, alpha 0.05, seed 42,
one index matrix applied to both systems. v1's per-item files are bare lists without `item_id`, so
`--compare` refuses them; the battery was run from a session-local harness that **imports v2's own
`_paired_bootstrap` / `_statistic_arrays` / `_mcnemar_exact_p`** and was validated **bit-identical**
(`abs_tol=0`) against v2's implementation on the four house statistics, on one Task-A and one
Task-B pair. scipy 1.17.1 is present, so `ttest_rel` was used (no hand-rolled fallback).
Re-aggregating the v1 per-item rows reproduced each committed v1 `_metrics.json` to <= 3.3e-16.

## Headline findings

- **Masking, n = 600, item sets identical across all three variants (600/600, 200 per hop):**
  typed > raw is significant on exact match (+0.0217, McNemar p=0.0241), step F1 (+0.0232,
  CI [+0.0053, +0.0412]), ordered accuracy (+0.0213) and ROUGE-L F1 (+0.0126); hop-count EM is not.
  Bootstrap, t-test and McNemar agree 15/15 on the overall rows.
- **The composite gap that prior-work quotes (0.3606 vs 0.1888) is NOT significant**
  (CI [-0.1842, +0.2259]) and **87.3% of it is the single 0.2-weighted `reference_validity_micro`
  term**, which rests on 8 references from 3 items (typed) vs 4 from 1 item (raw) out of 600. With
  that term removed the typed-vs-raw advantage survives (+0.0273, CI [+0.0107, +0.0440]). At hop 3
  the term outright reverses the ranking.
- **typed vs uniform is undecidable at n = 600** — nothing significant on any metric; ~2,000-3,000
  items would be needed at the observed effect size. n = 600's MDE is ~0.025 on step F1.
- **Retrieval: per-item data survives** for all 33 pool-sweep cells, so the fallback ("aggregates
  only") does not apply. **15 matched pairs** (n = 750 each) differ only in retrieval. +CE raises
  ROUGE-L F1 in **15/15** pairs (8 significant uncorrected, 5 surviving Holm within the family) and
  **never moves exact match** (0/15 by any test, signs split 7/8).
- Multiplicity is reported honestly: under Holm, **no Task-A test survives** (smallest adjusted
  p = 0.1676), which is a caveat the masking-default decision should see.

## Ranked recommendation

Six ranked takeaways are in §7 of the note. The top three: (1) do not justify a masking default with
the composite; (2) typed > raw is defensible on step-level metrics but marginal and fragile under
correction; (3) typed vs uniform should be recorded as undecided at this n rather than given a
winner. Choosing among them is Jahid's call with his supervisor.

Unmeasured and flagged as such: pool size (all 15 pairs hold size fixed — the other half of #6
item 4), balanced vs imbalanced, any guided condition, MetaQA, any v2 run.