### PR TITLE
Clustering-based pool-construction strategy in the sweep (Refs #14)

### DIFF
--- a/MusiQue/scripts/check_question_similarity.py
+++ b/MusiQue/scripts/check_question_similarity.py
@@ -42,6 +42,7 @@ from _prep_common import (
 import numpy as np
 
 from model_size import assert_within_ceiling, load_limits
+from pool_embeddings import needs_e5_prefix
 from run_artifacts import now_iso, write_run_artifacts
 from seeding import set_global_seed
 
@@ -133,10 +134,6 @@ def _save_cached_pool_embeddings(
     )
 
 
-def _needs_e5_prefix(model_id: str) -> bool:
-    return "e5" in model_id.lower()
-
-
 def _load_jsonl(path: Path, limit: int | None = None) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     with path.open(encoding="utf-8") as f:
@@ -151,7 +148,7 @@ def _load_jsonl(path: Path, limit: int | None = None) -> list[dict[str, Any]]:
 
 
 def _embed(texts: list[str], model: Any, model_id: str, *, prefix: str) -> np.ndarray:
-    prepared = [f"{prefix}: {t}" for t in texts] if _needs_e5_prefix(model_id) else texts
+    prepared = [f"{prefix}: {t}" for t in texts] if needs_e5_prefix(model_id) else texts
     return model.encode(prepared, normalize_embeddings=True, show_progress_bar=True)
 
 

--- a/MusiQue/scripts/sample_pool.py
+++ b/MusiQue/scripts/sample_pool.py
@@ -1,38 +1,56 @@
 #!/usr/bin/env python3
 """Sample a pool JSONL from the merged MuSiQue masked pool file.
 
-Two balance strategies:
+Three pool-construction strategies (the ``--balance`` flag, which the sweep reads as
+"strategy" — see ADR 0021):
 
 - ``imbalanced``: uniform random draw without replacement over the whole pool, so the
   hop-bucket distribution mirrors the input (the natural imbalance of MuSiQue train).
 - ``balanced``: ``size // 3`` rows per coarse hop bucket (2-hop, 3-hop, 4-hop), failing
   fast if a bucket does not have enough rows (4-hop is the tight constraint).
+- ``clustered``: seeded k-means over bi-encoder embeddings of the input rows, keeping the
+  rows nearest to each centroid (issue #14). Every knob — text field, embedding model,
+  cluster count rule, representative rule, k-means parameters — comes from
+  ``sample_pool.clustering`` in ``configs/musique_prep.json``. The design is the
+  implementer's, not a research decision: ADR 0021 records which parts are arbitrary.
 
 The bucket comes from the row ``id`` prefix (``2hop__``, ``3hop1__``, ``4hop2__``, …),
 with fine buckets collapsed into coarse ones.
 
-Ported from v1. Adapted for v2: the bucket list and default input come from
-``configs/musique_prep.json`` / ``configs/paths.json``, the seed goes through
-``set_global_seed`` as well as the local RNG, and the run writes the standard trail
-alongside the pool.
+Clustering reads a **stored** text field off each row and never masks anything, so
+ADR 0003 (never re-mask the few-shot pool) holds by construction: the rows written out
+are the input rows unchanged.
+
+Ported from v1 (which had the two random strategies only). Adapted for v2: the bucket
+list and default input come from ``configs/musique_prep.json`` / ``configs/paths.json``,
+the seed goes through ``set_global_seed`` as well as the local RNG, and the run writes
+the standard trail alongside the pool.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import random
 import re
 import sys
+import time
 from collections import Counter
 from pathlib import Path
 from typing import Any
 
 from _prep_common import dataset_path, load_prep, require
 
+from model_size import assert_within_ceiling, load_limits
 from run_artifacts import now_iso, write_run_artifacts
+from run_config import load_config
 from seeding import set_global_seed
 
 _ID_HOP_RX = re.compile(r"^(?P<h>\d+)hop")
+
+#: The only representative rule implemented. A second rule is a deliberate change to
+#: ADR 0021, not a config value someone can set by accident.
+_REPRESENTATIVE_RULES = ("nearest_to_centroid",)
 
 
 def _coarse_bucket(row_id: str | None, buckets: tuple[str, ...]) -> str | None:
@@ -105,6 +123,273 @@ def _sample_balanced(
     return out
 
 
+# ------- clustered strategy (issue #14, ADR 0021) ------------------------
+
+
+def _clustering_texts(rows: list[dict[str, Any]], field: str) -> list[str]:
+    """The stored text of every row, or a loud failure.
+
+    A missing or blank field is refused rather than skipped: silently dropping rows would
+    change the candidate set the clustering ran over without saying so. The field is read
+    as-is — no masker runs here (ADR 0003).
+    """
+    texts: list[str] = []
+    missing: list[str] = []
+    for i, r in enumerate(rows):
+        value = r.get(field)
+        if not isinstance(value, str) or not value.strip():
+            missing.append(str(r.get("id") or f"index{i}"))
+            continue
+        texts.append(value)
+    if missing:
+        raise SystemExit(
+            f"[sample_pool] clustering text field {field!r} is missing or blank on "
+            f"{len(missing)} row(s), e.g. {missing[:5]}. Point "
+            f"sample_pool.clustering.text_field at a field the input pool actually "
+            f"carries, or fix the input pool."
+        )
+    return texts
+
+
+def _needs_e5_prefix(model_id: str) -> bool:
+    """E5 models expect ``query:`` / ``passage:`` prefixes (same rule as the retrieval stage)."""
+    return "e5" in model_id.lower()
+
+
+def _embed_texts(
+    texts: list[str],
+    *,
+    model_id: str,
+    device: str,
+    batch_size: int,
+    prefix: str,
+) -> tuple[Any, dict[str, Any]]:
+    """Embed ``texts`` with the bi-encoder, L2-normalised, asserting the size ceiling."""
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
+
+    limits = load_limits("model_limits.json")
+    model = SentenceTransformer(model_id, device=device)
+    size_record = assert_within_ceiling(
+        model, component="retrieval", model_id=model_id, limits=limits
+    )
+    prepared = [f"{prefix}: {t}" for t in texts] if _needs_e5_prefix(model_id) else list(texts)
+    t0 = time.time()
+    emb = model.encode(
+        prepared,
+        batch_size=batch_size,
+        normalize_embeddings=True,
+        show_progress_bar=True,
+    )
+    emb = np.asarray(emb, dtype=np.float32)
+    record = {
+        "model_id": model_id,
+        "device": device,
+        "batch_size": batch_size,
+        "prefix_applied": prefix if _needs_e5_prefix(model_id) else None,
+        "num_texts": len(texts),
+        "dim": int(emb.shape[1]) if emb.ndim == 2 else None,
+        "embed_seconds": round(time.time() - t0, 1),
+        "model_size": size_record,
+    }
+    return emb, record
+
+
+def _kmeans_select(
+    embeddings: Any,
+    row_ids: list[str],
+    size: int,
+    *,
+    seed: int,
+    examples_per_cluster: int,
+    representative_rule: str,
+    kmeans_params: dict[str, Any],
+    num_threads: int,
+) -> tuple[list[int], dict[str, Any]]:
+    """Pick exactly ``size`` row indices by seeded k-means over ``embeddings``.
+
+    ``k = ceil(size / examples_per_cluster)`` clusters; within each cluster the rows are
+    ranked by distance to their centroid (ties broken by row id, then row index, so the
+    order never depends on numpy's or sklearn's iteration order). Representatives are
+    taken **rank-major**: every cluster contributes its closest row before any cluster
+    contributes a second, so truncating at ``size`` cannot starve a cluster.
+
+    Empty clusters (sklearn relocates most, but not by contract) leave a shortfall; it is
+    topped up from the unselected rows in the same global ``(distance, id, index)`` order
+    and **counted** in the diagnostics rather than passing silently.
+
+    Returns (selected indices in selection order, diagnostics).
+    """
+    import numpy as np
+
+    n = int(embeddings.shape[0])
+    if size > n:
+        raise SystemExit(
+            f"[sample_pool] clustered size={size} exceeds pool row count {n}"
+        )
+    if representative_rule not in _REPRESENTATIVE_RULES:
+        raise SystemExit(
+            f"[sample_pool] unknown clustering.representative_rule "
+            f"{representative_rule!r}; implemented: {list(_REPRESENTATIVE_RULES)} "
+            f"(adding one is a change to ADR 0021, not a config value)"
+        )
+    if examples_per_cluster < 1:
+        raise SystemExit(
+            f"[sample_pool] clustering.examples_per_cluster must be >= 1, got "
+            f"{examples_per_cluster}"
+        )
+    if num_threads < 1:
+        raise SystemExit(
+            f"[sample_pool] clustering.kmeans.num_threads must be >= 1, got {num_threads}"
+        )
+
+    from sklearn.cluster import KMeans
+    from threadpoolctl import threadpool_limits
+
+    n_clusters = min(math.ceil(size / examples_per_cluster), n)
+    t0 = time.time()
+    # Single-threaded by default: sklearn's Lloyd loop reduces over OpenMP chunks, so the
+    # thread count is part of the floating-point result. num_threads=1 makes the fit
+    # bit-reproducible under the seed; raising it trades that for speed.
+    with threadpool_limits(limits=num_threads):
+        kmeans = KMeans(
+            n_clusters=n_clusters,
+            random_state=seed,
+            init=str(require(kmeans_params, "init")),
+            n_init=int(require(kmeans_params, "n_init")),
+            max_iter=int(require(kmeans_params, "max_iter")),
+            tol=float(require(kmeans_params, "tol")),
+            algorithm=str(require(kmeans_params, "algorithm")),
+        ).fit(np.asarray(embeddings, dtype=np.float32))
+    fit_seconds = round(time.time() - t0, 1)
+
+    labels = np.asarray(kmeans.labels_, dtype=int)
+    centroids = np.asarray(kmeans.cluster_centers_, dtype=np.float32)
+    distances = np.linalg.norm(
+        np.asarray(embeddings, dtype=np.float32) - centroids[labels], axis=1
+    )
+
+    def sort_key(idx: int) -> tuple[float, str, int]:
+        return (float(distances[idx]), row_ids[idx], idx)
+
+    members: list[list[int]] = [[] for _ in range(n_clusters)]
+    for idx in range(n):
+        members[int(labels[idx])].append(idx)
+    for cluster in members:
+        cluster.sort(key=sort_key)
+
+    selected: list[int] = []
+    for rank in range(examples_per_cluster):
+        for cluster in members:
+            if rank < len(cluster):
+                selected.append(cluster[rank])
+                if len(selected) == size:
+                    break
+        if len(selected) == size:
+            break
+
+    from_clusters = len(selected)
+    if len(selected) < size:
+        chosen = set(selected)
+        for idx in sorted((i for i in range(n) if i not in chosen), key=sort_key):
+            selected.append(idx)
+            if len(selected) == size:
+                break
+
+    if len(selected) != size or len(set(selected)) != size:
+        raise AssertionError(
+            f"[sample_pool] clustered selection produced {len(selected)} indices "
+            f"({len(set(selected))} distinct) for size={size}; this is a bug above."
+        )
+
+    cluster_sizes = [len(c) for c in members]
+    diagnostics = {
+        "strategy": "clustered",
+        "n_candidates": n,
+        "n_clusters": n_clusters,
+        "examples_per_cluster": examples_per_cluster,
+        "representative_rule": representative_rule,
+        "kmeans_params": {
+            "init": str(require(kmeans_params, "init")),
+            "n_init": int(require(kmeans_params, "n_init")),
+            "max_iter": int(require(kmeans_params, "max_iter")),
+            "tol": float(require(kmeans_params, "tol")),
+            "algorithm": str(require(kmeans_params, "algorithm")),
+            "num_threads": num_threads,
+            "random_state": seed,
+        },
+        "kmeans_n_iter": int(kmeans.n_iter_),
+        "kmeans_inertia": float(kmeans.inertia_),
+        "empty_clusters": int(sum(1 for c in cluster_sizes if c == 0)),
+        "cluster_size_min": int(min(cluster_sizes)),
+        "cluster_size_max": int(max(cluster_sizes)),
+        "selected_from_clusters": from_clusters,
+        "selected_from_topup": size - from_clusters,
+        "mean_distance_to_centroid_selected": float(
+            np.mean(distances[np.asarray(selected, dtype=int)])
+        ),
+        "kmeans_fit_seconds": fit_seconds,
+    }
+    return selected, diagnostics
+
+
+def _sample_clustered(
+    rows: list[dict[str, Any]],
+    size: int,
+    rng: random.Random,
+    *,
+    clustering: dict[str, Any],
+    embed_model_key: str | None,
+    device: str | None,
+    seed: int,
+    embeddings: Any | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Cluster the input rows and return ``size`` representatives plus diagnostics.
+
+    ``embeddings`` is a test seam: pass a precomputed array to exercise the selection
+    without loading an encoder. Production always passes ``None`` and embeds here.
+    """
+    field = str(require(clustering, "text_field"))
+    texts = _clustering_texts(rows, field)
+
+    similarity_cfg = load_config(str(require(clustering, "similarity_config")))
+    embed_key = embed_model_key or str(require(clustering, "embed_model"))
+    model_id = str(require(similarity_cfg, f"bi_encoder.embed_models.{embed_key}"))
+    embed_device = device or str(require(clustering, "device"))
+
+    if embeddings is None:
+        embeddings, embed_record = _embed_texts(
+            texts,
+            model_id=model_id,
+            device=embed_device,
+            batch_size=int(require(clustering, "embed_batch_size")),
+            prefix=str(require(clustering, "embed_prefix")),
+        )
+    else:
+        embed_record = {"model_id": model_id, "precomputed": True, "num_texts": len(texts)}
+
+    row_ids = [str(r.get("id") or f"index{i}") for i, r in enumerate(rows)]
+    selected, diagnostics = _kmeans_select(
+        embeddings,
+        row_ids,
+        size,
+        seed=seed,
+        examples_per_cluster=int(require(clustering, "examples_per_cluster")),
+        representative_rule=str(require(clustering, "representative_rule")),
+        kmeans_params=require(clustering, "kmeans"),
+        num_threads=int(require(clustering, "kmeans.num_threads")),
+    )
+    diagnostics["text_field"] = field
+    diagnostics["embedding"] = embed_record
+    diagnostics["embed_model_key"] = embed_key
+
+    out = [rows[i] for i in selected]
+    # Shuffle for the same reason the balanced draw does: pool order should not encode the
+    # strategy (here, distance-to-centroid rank) for anything reading the file in order.
+    rng.shuffle(out)
+    return out, diagnostics
+
+
 def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
     with path.open("w", encoding="utf-8") as f:
         for r in rows:
@@ -116,10 +401,25 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--config", default="musique_prep.json")
     p.add_argument("--input", type=Path, default=None, help="Input pool JSONL (default: the enriched pool).")
     p.add_argument("--size", type=int, required=True, help="Target pool size.")
-    p.add_argument("--balance", choices=["imbalanced", "balanced"], required=True)
+    p.add_argument(
+        "--balance",
+        choices=["imbalanced", "balanced", "clustered"],
+        required=True,
+        help="Pool-construction strategy (the sweep's 'balance' axis).",
+    )
     p.add_argument("--seed", type=int, default=None, help="RNG seed for this trial (default: config seed).")
     p.add_argument("--out-dir", type=Path, required=True, help="Output directory for pool.jsonl + artifacts.")
     p.add_argument("--overwrite", action="store_true", help="Overwrite pool.jsonl if it exists.")
+    p.add_argument(
+        "--embed-model",
+        default=None,
+        help="Bi-encoder key from configs/similarity.json (clustered only; default: config).",
+    )
+    p.add_argument(
+        "--device",
+        default=None,
+        help="Device for the bi-encoder (clustered only; default: config).",
+    )
     return p.parse_args()
 
 
@@ -148,10 +448,21 @@ def main() -> None:
     print(f"[sample_pool] input bucket counts: {input_counts}")
 
     rng = random.Random(seed)
+    clustering_diagnostics: dict[str, Any] | None = None
     if args.balance == "imbalanced":
         sampled = _sample_imbalanced(rows, args.size, rng)
-    else:
+    elif args.balance == "balanced":
         sampled = _sample_balanced(grouped, args.size, rng, buckets)
+    else:
+        sampled, clustering_diagnostics = _sample_clustered(
+            rows,
+            args.size,
+            rng,
+            clustering=require(section, "clustering"),
+            embed_model_key=args.embed_model,
+            device=args.device,
+            seed=seed,
+        )
 
     sampled_counts = Counter(_coarse_bucket(r.get("id"), buckets) or "unknown" for r in sampled)
     sampled_counts_dict = {b: sampled_counts.get(b, 0) for b in buckets}
@@ -174,6 +485,8 @@ def main() -> None:
         "input_bucket_counts": input_counts,
         "sampled_bucket_counts": sampled_counts_dict,
     }
+    if clustering_diagnostics is not None:
+        metrics["clustering"] = clustering_diagnostics
     # v1 wrote stats.json next to the pool; keep that filename for compatibility with
     # anything reading a pool directory, and add the standard trail alongside it.
     (args.out_dir / "stats.json").write_text(
@@ -190,6 +503,11 @@ def main() -> None:
             "seed": seed,
             "out_dir": str(args.out_dir),
             "overwrite": args.overwrite,
+            "clustering": (
+                require(section, "clustering") if args.balance == "clustered" else None
+            ),
+            "embed_model_override": args.embed_model,
+            "device_override": args.device,
         },
         metrics=metrics,
         note_title=f"Pool sample ({args.balance}, size {args.size}, seed {seed})",
@@ -198,11 +516,25 @@ def main() -> None:
             f"- Output: `{pool_path}` ({len(sampled)} rows)",
             f"- Input bucket counts: {input_counts}",
             f"- Sampled bucket counts: {sampled_counts_dict}",
+            *(
+                [
+                    f"- Clustering (ADR 0021): k={clustering_diagnostics['n_clusters']} "
+                    f"x {clustering_diagnostics['examples_per_cluster']} per cluster over "
+                    f"`{clustering_diagnostics['text_field']}` embedded with "
+                    f"`{clustering_diagnostics['embedding']['model_id']}`; "
+                    f"{clustering_diagnostics['selected_from_topup']} row(s) came from the "
+                    f"top-up rule, {clustering_diagnostics['empty_clusters']} cluster(s) empty",
+                ]
+                if clustering_diagnostics is not None
+                else []
+            ),
         ],
     )
 
     print(f"[sample_pool] wrote {len(sampled)} rows -> {pool_path}")
     print(f"[sample_pool] bucket counts: {sampled_counts_dict}")
+    if clustering_diagnostics is not None:
+        print(f"[sample_pool] clustering: {json.dumps(clustering_diagnostics, default=str)}")
 
 
 if __name__ == "__main__":

--- a/MusiQue/scripts/sample_pool.py
+++ b/MusiQue/scripts/sample_pool.py
@@ -42,8 +42,9 @@ from typing import Any
 from _prep_common import dataset_path, load_prep, require
 
 from model_size import assert_within_ceiling, load_limits
+from pool_embeddings import needs_e5_prefix
 from run_artifacts import now_iso, write_run_artifacts
-from run_config import load_config
+from run_config import load_config, resolve_config_path
 from seeding import set_global_seed
 
 _ID_HOP_RX = re.compile(r"^(?P<h>\d+)hop")
@@ -151,11 +152,6 @@ def _clustering_texts(rows: list[dict[str, Any]], field: str) -> list[str]:
     return texts
 
 
-def _needs_e5_prefix(model_id: str) -> bool:
-    """E5 models expect ``query:`` / ``passage:`` prefixes (same rule as the retrieval stage)."""
-    return "e5" in model_id.lower()
-
-
 def _embed_texts(
     texts: list[str],
     *,
@@ -173,7 +169,7 @@ def _embed_texts(
     size_record = assert_within_ceiling(
         model, component="retrieval", model_id=model_id, limits=limits
     )
-    prepared = [f"{prefix}: {t}" for t in texts] if _needs_e5_prefix(model_id) else list(texts)
+    prepared = [f"{prefix}: {t}" for t in texts] if needs_e5_prefix(model_id) else list(texts)
     t0 = time.time()
     emb = model.encode(
         prepared,
@@ -186,7 +182,7 @@ def _embed_texts(
         "model_id": model_id,
         "device": device,
         "batch_size": batch_size,
-        "prefix_applied": prefix if _needs_e5_prefix(model_id) else None,
+        "prefix_applied": prefix if needs_e5_prefix(model_id) else None,
         "num_texts": len(texts),
         "dim": int(emb.shape[1]) if emb.ndim == 2 else None,
         "embed_seconds": round(time.time() - t0, 1),
@@ -325,6 +321,11 @@ def _kmeans_select(
         "cluster_size_max": int(max(cluster_sizes)),
         "selected_from_clusters": from_clusters,
         "selected_from_topup": size - from_clusters,
+        # How many distinct clusters the selection actually covers. This is the rank-major
+        # property made observable: while size >= n_clusters it must equal n_clusters, so a
+        # regression that starves clusters shows up in every run's metrics, not only in a
+        # test (PR #34 review, N-4a).
+        "clusters_represented": len({int(labels[i]) for i in selected}),
         "mean_distance_to_centroid_selected": float(
             np.mean(distances[np.asarray(selected, dtype=int)])
         ),
@@ -341,10 +342,18 @@ def _sample_clustered(
     clustering: dict[str, Any],
     embed_model_key: str | None,
     device: str | None,
+    similarity_config: str | None,
     seed: int,
     embeddings: Any | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Cluster the input rows and return ``size`` representatives plus diagnostics.
+
+    ``similarity_config`` is the bi-encoder **alias registry** this run resolves through.
+    The sweep passes its own ``configs.similarity`` (``--similarity-config``) so that one
+    sweep genuinely uses one embedding model: without it, the pool stage read the registry
+    named in ``musique_prep.json`` while every retrieval stage read the one named in
+    ``pool_sweep.json``, and the two agreeing was a coincidence rather than a guarantee
+    (PR #34 review, I-2).
 
     ``embeddings`` is a test seam: pass a precomputed array to exercise the selection
     without loading an encoder. Production always passes ``None`` and embeds here.
@@ -352,7 +361,8 @@ def _sample_clustered(
     field = str(require(clustering, "text_field"))
     texts = _clustering_texts(rows, field)
 
-    similarity_cfg = load_config(str(require(clustering, "similarity_config")))
+    similarity_ref = similarity_config or str(require(clustering, "similarity_config"))
+    similarity_cfg = load_config(similarity_ref)
     embed_key = embed_model_key or str(require(clustering, "embed_model"))
     model_id = str(require(similarity_cfg, f"bi_encoder.embed_models.{embed_key}"))
     embed_device = device or str(require(clustering, "device"))
@@ -382,6 +392,12 @@ def _sample_clustered(
     diagnostics["text_field"] = field
     diagnostics["embedding"] = embed_record
     diagnostics["embed_model_key"] = embed_key
+    # The registry this run resolved the alias through, recorded as a resolved path: "one
+    # sweep, one embedding model" has to be checkable after the fact, not just intended.
+    diagnostics["similarity_config"] = str(resolve_config_path(similarity_ref))
+    diagnostics["similarity_config_source"] = (
+        "cli" if similarity_config else "clustering.similarity_config"
+    )
 
     out = [rows[i] for i in selected]
     # Shuffle for the same reason the balanced draw does: pool order should not encode the
@@ -413,14 +429,41 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument(
         "--embed-model",
         default=None,
-        help="Bi-encoder key from configs/similarity.json (clustered only; default: config).",
+        help="Bi-encoder key from the similarity config's registry (clustered only).",
     )
     p.add_argument(
         "--device",
         default=None,
         help="Device for the bi-encoder (clustered only; default: config).",
     )
-    return p.parse_args()
+    p.add_argument(
+        "--similarity-config",
+        default=None,
+        help="Committed config holding bi_encoder.embed_models, the alias registry to "
+             "resolve --embed-model through (clustered only). The sweep passes its own "
+             "configs.similarity so one sweep uses one embedding model.",
+    )
+    args = p.parse_args()
+    # Clustered-only flags are refused, not ignored, on the random strategies: they were
+    # being recorded in the config snapshot as if they had applied, which would read later
+    # as "this pool was built with that encoder" (PR #34 review, N-4b).
+    if args.balance != "clustered":
+        passed = [
+            name
+            for name, value in (
+                ("--embed-model", args.embed_model),
+                ("--device", args.device),
+                ("--similarity-config", args.similarity_config),
+            )
+            if value is not None
+        ]
+        if passed:
+            p.error(
+                f"{', '.join(passed)} applies to --balance clustered only; "
+                f"--balance {args.balance} embeds nothing. Drop the flag, or the run "
+                f"record would name an encoder that never ran."
+            )
+    return args
 
 
 def main() -> None:
@@ -461,6 +504,7 @@ def main() -> None:
             clustering=require(section, "clustering"),
             embed_model_key=args.embed_model,
             device=args.device,
+            similarity_config=args.similarity_config,
             seed=seed,
         )
 
@@ -506,8 +550,11 @@ def main() -> None:
             "clustering": (
                 require(section, "clustering") if args.balance == "clustered" else None
             ),
+            # Only recorded for the strategy they can affect; _parse_args refuses them
+            # elsewhere, so a null here means "not passed", never "passed and ignored".
             "embed_model_override": args.embed_model,
             "device_override": args.device,
+            "similarity_config_override": args.similarity_config,
         },
         metrics=metrics,
         note_title=f"Pool sample ({args.balance}, size {args.size}, seed {seed})",

--- a/configs/musique_prep.json
+++ b/configs/musique_prep.json
@@ -54,7 +54,26 @@
 
   "sample_pool": {
     "coarse_buckets": ["2hop", "3hop", "4hop"],
-    "run_subdir": "musique_sample_pool"
+    "run_subdir": "musique_sample_pool",
+    "_clustering_note": "Knobs for the clustered pool-construction strategy (--balance clustered, issue #14). The design is the implementer's, not a research decision: ADR 0021 records which parts are arbitrary and how to change them. text_field is read off the row as stored - no masker runs here (ADR 0003). embed_model is a key into bi_encoder.embed_models in similarity_config, so the alias registry stays single-sourced (ADR 0018). kmeans.num_threads=1 keeps the fit bit-reproducible under the seed; raising it is faster and no longer exactly reproducible.",
+    "clustering": {
+      "text_field": "question",
+      "similarity_config": "similarity.json",
+      "embed_model": "e5-small",
+      "embed_prefix": "passage",
+      "embed_batch_size": 64,
+      "device": "cpu",
+      "examples_per_cluster": 1,
+      "representative_rule": "nearest_to_centroid",
+      "kmeans": {
+        "init": "k-means++",
+        "n_init": 1,
+        "max_iter": 300,
+        "tol": 0.0001,
+        "algorithm": "lloyd",
+        "num_threads": 1
+      }
+    }
   },
 
   "sample_dev": {

--- a/configs/plot_pool_sweep.json
+++ b/configs/plot_pool_sweep.json
@@ -15,7 +15,7 @@
     "hop_count_exact_match_rate"
   ],
 
-  "balances": ["imbalanced", "balanced"],
+  "balances": ["imbalanced", "balanced", "clustered"],
   "variants": ["biencoder_only", "biencoder_plus_ce"],
   "modes": ["raw", "typed", "uniform"],
 

--- a/configs/pool_sweep.json
+++ b/configs/pool_sweep.json
@@ -3,6 +3,8 @@
 
   "imbalanced_sizes": [1000, 2000, 4000, 8000],
   "balanced_sizes": [1000, 2000, 3000],
+  "_clustered_sizes_note": "The clustering strategy (issue #14) is swept at 2000 only: ADR 0006 fixes the pool size at 2000, so the question this strategy is in the sweep to answer is construction-vs-construction at that size. Its knobs live in sample_pool.clustering (configs/musique_prep.json); the design is recorded as implementer defaults in ADR 0021.",
+  "clustered_sizes": [2000],
 
   "retrieval_modes": ["raw", "typed", "uniform"],
   "retriever_variants": ["biencoder_only", "biencoder_plus_ce"],

--- a/docs/adr/0021-clustering-pool-construction-strategy.md
+++ b/docs/adr/0021-clustering-pool-construction-strategy.md
@@ -98,21 +98,39 @@ rather than inventing a rationale.
    pointing it at a masked field is a one-line config change and needs no code.
 
 6. **The bi-encoder is the one the sweep already uses**, `intfloat/e5-small-v2` via the
-   `e5-small` alias, resolved through `bi_encoder.embed_models` in `configs/similarity.json`
-   so the alias registry stays single-sourced (ADR 0018). The orchestrator passes its own
-   `embed_model` and `device` to the pool stage for a clustered cell, so one sweep uses one
-   embedding model everywhere. Texts get the `passage:` prefix, the same prefix the retrieval
-   stage gives pool text, and the vectors are L2-normalised. The parameter count is printed
-   and asserted at load like every other model in this repo (`src/model_size.py`, component
-   `retrieval`; measured 33,360,000 parameters).
+   `e5-small` alias (ADR 0018). "One sweep, one embedding model" is **threaded, not assumed**:
+   for a clustered cell the orchestrator passes its own `embed_model`, `device` *and*
+   `configs.similarity` (as `--similarity-config`) to the pool stage, and the run's metrics
+   record the registry it resolved through as an absolute path. Before that, the pool stage
+   resolved the alias through the registry named in `configs/musique_prep.json` while every
+   retrieval stage used the one named in `configs/pool_sweep.json`; both pointed at
+   `similarity.json`, so the claim was true by coincidence (PR #34 review, I-2). Texts get the
+   `passage:` prefix — from `needs_e5_prefix` in `src/pool_embeddings.py`, now the single
+   definition the retrieval stage shares, so "the same prefix as retrieval" is enforced by one
+   function rather than by two identical copies — and the vectors are L2-normalised. The
+   parameter count is printed and asserted at load like every other model in this repo
+   (`src/model_size.py`, component `retrieval`; measured 33,360,000 parameters), and that the
+   assertion brackets the encoder construction is itself guarded at source level
+   (`tests/test_pool_clustering_guards.py`, ADR 0016), because no run without weights reaches it.
 
-7. **Determinism is bought explicitly.** `kmeans.num_threads` defaults to **1** and the fit
-   runs inside `threadpool_limits`, because sklearn's Lloyd loop reduces over OpenMP chunks
-   and the thread count is therefore part of the floating-point result. At one thread the fit
-   is bit-reproducible under the seed; raising the knob is faster and no longer exactly
-   reproducible, and that trade is stated in the config rather than discovered later.
-   `n_init = 1` with seeded `k-means++` init is the default because `k = 2000` makes repeated
-   restarts expensive; it is a cost choice, not a quality claim.
+7. **Determinism is bought explicitly, and it covers the clustering — not the embedding.**
+   `kmeans.num_threads` defaults to **1** and the fit runs inside `threadpool_limits`, because
+   sklearn's Lloyd loop reduces over OpenMP chunks and the thread count is therefore part of
+   the floating-point result. At one thread the fit is bit-reproducible under the seed; raising
+   the knob is faster and no longer exactly reproducible, and that trade is stated in the config
+   rather than discovered later. `n_init = 1` with seeded `k-means++` init is the default
+   because `k = 2000` makes repeated restarts expensive; it is a cost choice, not a quality
+   claim.
+
+   **The reproducibility that has been *verified* is CPU-only.** The byte-identical-pool check
+   runs the encoder on CPU over six fixture rows; the sweep drives the same code with
+   `--device cuda`, and this repo sets no torch determinism flags anywhere, so GPU embedding is
+   **not** verified to be bit-reproducible. A pool rebuilt later on different hardware — or on
+   the same GPU after a driver, torch or sentence-transformers change — may therefore differ at
+   the embedding step and select different representatives, even at the same seed. The
+   defensible statement is: the *selection rule* is deterministic given the embeddings, and the
+   embeddings are only guaranteed reproducible on the machine and stack that produced them.
+   That is why the pool file itself is the artifact to keep, not the recipe alone.
 
 8. **The pool file is shuffled with the trial's seeded RNG before it is written**, exactly as
    the balanced strategy already does, so file order does not encode distance-to-centroid rank
@@ -152,6 +170,25 @@ rather than inventing a rationale.
   six-row fixture has been run.
 - The clustered arm's *quality* is unmeasured. Nothing in this record supports a claim that
   clustering helps, and no such claim may be made until the run is in `experiments/log.md`.
+- **Confound 1 — one trial per arm makes the arms asymmetric in variance.** The sweep config
+  carries `num_trials: 1` (`pool_trial_seeds: [42]`). At one trial the clustered arm is
+  effectively deterministic — reseeding moves only the k-means init, over the same candidate
+  set — while `balanced` and `imbalanced` are each a *single random draw* from a distribution
+  of possible pools. A one-trial clustered-minus-random delta therefore mixes the effect of
+  the construction strategy with the draw noise of the random arms, and the two cannot be
+  separated from the numbers the sweep produces. Whether to raise `num_trials` (which
+  multiplies the sweep's decomposer cost by the trial count) is **Jahid's decision**; this
+  record states the confound and changes no config. Until it is raised, the honest reading of
+  a clustered-versus-random difference is "consistent with", not "caused by", the strategy.
+- **Confound 2 — the clustered pool is built in the retriever's own embedding space.** Pool
+  construction and retrieval share one encoder (item 6), which is what makes the arms
+  comparable on retrieval settings, but it also means the clustered pool is a coverage-optimal
+  cover of exactly the space the bi-encoder ranks in. The random arms have no such alignment.
+  Any retrieval-mediated metric (top-k neighbour quality, and therefore the decomposition
+  metrics downstream of it) is measured under that coupling, so a clustered advantage cannot be
+  attributed to "better examples" as distinct from "examples spread out in the retriever's
+  metric". Decoupling would need a different encoder for construction than for retrieval, which
+  is a design change nobody has asked for; no mitigation is claimed here.
 - If the supervisor settles the masking default (ADR 0018), item 5 should be revisited: a
   settled typed-masking default is a reason to consider clustering on the masked field, and
   that would be a config change plus a new sweep, not a code change.

--- a/docs/adr/0021-clustering-pool-construction-strategy.md
+++ b/docs/adr/0021-clustering-pool-construction-strategy.md
@@ -130,7 +130,8 @@ rather than inventing a rationale.
    the embedding step and select different representatives, even at the same seed. The
    defensible statement is: the *selection rule* is deterministic given the embeddings, and the
    embeddings are only guaranteed reproducible on the machine and stack that produced them.
-   That is why the pool file itself is the artifact to keep, not the recipe alone.
+   That is why the pool file itself is the artifact to keep, not the recipe alone (kept on the
+   compute box / under the ignored `runs/`, never committed — data never enters git).
 
 8. **The pool file is shuffled with the trial's seeded RNG before it is written**, exactly as
    the balanced strategy already does, so file order does not encode distance-to-centroid rank

--- a/docs/adr/0021-clustering-pool-construction-strategy.md
+++ b/docs/adr/0021-clustering-pool-construction-strategy.md
@@ -1,0 +1,179 @@
+# 0021. Clustering-Based Pool Construction: The Implementer's Design
+
+- **Status**: Accepted (design agent-authored, pending Jahid)
+- **Date**: 2026-08-20
+
+## Context
+
+ADR [0006](./0006-drop-the-jury-fix-dataset-roles-and-the-few-shot-method.md) fixes the
+few-shot pool size at **2000** and frames the contribution as the strategy for
+*constructing* the pool and retrieving from it — so construction is the thing under study,
+and the sweep is free to vary it instead of size. Until now the sweep had two construction
+strategies, both random: `imbalanced` (uniform draw over the whole pool) and `balanced`
+(equal quota per coarse hop bucket), selected by `--balance` in
+`MusiQue/scripts/sample_pool.py`.
+
+Issue #14 asks for a **third, clustering-based strategy** in the same sweep, evaluated
+against the others at pool size 2000. That is the part Jahid decided: *that* a clustering
+strategy exists and gets measured. He did **not** decide how it clusters — what is embedded,
+how many clusters, or which member of a cluster ends up in the pool. This record states the
+design the implementation adopted so the November write-up does not later mistake it for a
+research decision, and so changing it is a cheap, visible edit rather than an archaeology
+exercise.
+
+**Nothing in this record is a methodological finding, and nothing in it has been measured
+yet.** The clustered arm has produced no decomposition metrics; the evaluation at pool size
+2000 runs later on the GPU and lands in `experiments/log.md` as its own entry (which is why
+the PR for this work references #14 rather than closing it).
+
+## Decision
+
+**The clustering strategy is a third value of the sweep's existing construction axis, not a
+new stage.** `--balance clustered` in `MusiQue/scripts/sample_pool.py`, `clustered_sizes` in
+`configs/pool_sweep.json`, and everything downstream — pool directory names, run keys,
+`summary/all_runs.csv` columns, the plots — is unchanged. A clustered cell is therefore
+directly comparable with a balanced or imbalanced cell of the same size, trial seed, dev
+sample, retriever variant and retrieval mode, which is the only way issue #14's "sits next
+to the other strategies" is true.
+
+**It is swept at size 2000 only** (`clustered_sizes: [2000]`), because ADR 0006 fixes the
+pool size and the question this arm exists to answer is construction-versus-construction at
+that size.
+
+**Everything about how it clusters is config, not code**: `sample_pool.clustering` in
+`configs/musique_prep.json` holds the text field, the bi-encoder reference, the cluster-count
+rule, the representative rule and the k-means parameters. No clustering constant lives in the
+source.
+
+## Implementation conventions (agent-authored)
+
+The design below is the implementer's. It was not reviewed as methodology by anyone, it is
+not derived from the README or from any decision of Jahid's or his supervisor's, and it is
+changeable without touching issue #14's outcome. Where a choice is arbitrary this says so
+rather than inventing a rationale.
+
+1. **Seeded k-means over bi-encoder embeddings, keeping the row nearest each centroid.**
+   Concretely: embed every candidate row, fit `sklearn.cluster.KMeans` with
+   `random_state = <the trial's pool seed>`, and take the row closest to each centroid.
+   k-means was chosen because it is the obvious, standard, cheap choice with one
+   interpretable knob, and because "one representative per cluster" reaches an exact target
+   size without a second selection rule. It is **not** claimed to be the best clustering for
+   this data — no alternative was measured.
+
+2. **The cluster count follows the target size**: `k = ceil(size / examples_per_cluster)`,
+   with `examples_per_cluster = 1` by default, so `k = 2000` at the fixed pool size and each
+   cluster contributes exactly one row. The knob exists so a coarser clustering with several
+   representatives per cluster (`examples_per_cluster = 5` → `k = 400`) is a config change
+   rather than a rewrite. **The default of 1 is arbitrary** in the sense that no evidence says
+   one representative per cluster beats five; it is the setting that makes "the pool is a
+   diverse cover of the candidate set" most literal.
+
+3. **The representative rule is `nearest_to_centroid`, and it is the only one implemented.**
+   Any other value is refused at run time rather than silently ignored, in the shape ADR
+   [0019](./0019-musique-answering-backend-conventions.md) used for `context.policy`: a second
+   selection regime should require changing this record. Within a cluster, rows are ranked by
+   Euclidean distance to their centroid, ties broken by row id then row index, so the result
+   never depends on library iteration order.
+
+4. **Representatives are taken rank-major.** Every cluster contributes its closest row before
+   any cluster contributes a second, so truncating at the target size cannot starve a cluster.
+   When clusters cannot supply the target at all (empty clusters, or duplicate points
+   collapsing distinct centroids), the shortfall is **topped up** from the unselected rows in
+   the same global `(distance, id, index)` order and **counted** in the run's metrics
+   (`selected_from_topup`) rather than passing silently. Ascending distance for the top-up is
+   an arbitrary choice: "closest to some centroid first" is as defensible as its opposite, and
+   neither was measured.
+
+5. **The embedded text is the row's stored `question` field** — the raw question — read as-is.
+   Two things about this. First, **no masker runs**: the strategy reads a field the pool file
+   already carries, so ADR [0003](./0003-mask-queries-only-never-re-mask-the-few-shot-pool.md)
+   (never re-mask the few-shot pool) holds by construction, and the rows written out are the
+   input rows value-for-value. Second, the choice of *which* stored field is genuinely
+   arguable: clustering on `question_masked_typed` would cluster on question *structure*,
+   which is closer to what the retrieval stage matches on. The raw field is the default
+   because one pool is consumed by all three retrieval modes (`raw` / `typed` / `uniform`) in
+   the same sweep, and ADR [0018](./0018-resolve-the-carried-v1-research-decisions.md) records
+   the masking default as **reopened and unsettled** — so tying pool construction to typed
+   masking would bake an unsettled variable into the pool itself. `text_field` is the knob;
+   pointing it at a masked field is a one-line config change and needs no code.
+
+6. **The bi-encoder is the one the sweep already uses**, `intfloat/e5-small-v2` via the
+   `e5-small` alias, resolved through `bi_encoder.embed_models` in `configs/similarity.json`
+   so the alias registry stays single-sourced (ADR 0018). The orchestrator passes its own
+   `embed_model` and `device` to the pool stage for a clustered cell, so one sweep uses one
+   embedding model everywhere. Texts get the `passage:` prefix, the same prefix the retrieval
+   stage gives pool text, and the vectors are L2-normalised. The parameter count is printed
+   and asserted at load like every other model in this repo (`src/model_size.py`, component
+   `retrieval`; measured 33,360,000 parameters).
+
+7. **Determinism is bought explicitly.** `kmeans.num_threads` defaults to **1** and the fit
+   runs inside `threadpool_limits`, because sklearn's Lloyd loop reduces over OpenMP chunks
+   and the thread count is therefore part of the floating-point result. At one thread the fit
+   is bit-reproducible under the seed; raising the knob is faster and no longer exactly
+   reproducible, and that trade is stated in the config rather than discovered later.
+   `n_init = 1` with seeded `k-means++` init is the default because `k = 2000` makes repeated
+   restarts expensive; it is a cost choice, not a quality claim.
+
+8. **The pool file is shuffled with the trial's seeded RNG before it is written**, exactly as
+   the balanced strategy already does, so file order does not encode distance-to-centroid rank
+   for anything that reads the pool in order.
+
+9. **No embedding cache was added.** The retrieval stage has one, but it is private to
+   `MusiQue/scripts/check_question_similarity.py`, and extracting it into a shared module is a
+   refactor of code this work has no other reason to touch. With one clustered size and one
+   trial seed in the current grid, the input pool is embedded once. If the grid grows to
+   several clustered trials, this is the first thing to revisit.
+
+10. **Clustering is flat, not hop-stratified.** The clustered arm ignores hop buckets entirely
+    and reports whatever hop distribution falls out (`sampled_bucket_counts` in the run's
+    `stats.json`), which makes it the diversity-driven counterpart of `imbalanced`. A
+    hop-stratified clustering (cluster within each hop bucket, quota per bucket) is a plausible
+    fourth strategy and is **not** implemented — it would confound two construction ideas in
+    one arm, and nobody asked for it.
+
+## Consequences
+
+- The sweep has a third construction arm that is selectable from committed config and
+  comparable with the existing two at the fixed pool size. `--only clustered` restricts a run
+  to it.
+- `configs/pool_sweep.json` now requires `clustered_sizes`; a sweep config without that key is
+  refused loudly by `require()`, in this repo's no-silent-default style. `configs/plot_pool_sweep.json`
+  gains `clustered` in `balances`, so the per-strategy plots render it. The
+  `balanced_vs_imbalanced_delta` plot still pairs exactly those two strategies — a
+  clustered-versus-X delta plot was not added, because which comparison the thesis wants is
+  Jahid's call.
+- The `balance` axis name now means "construction strategy" and one of its values is not about
+  hop balance at all. Renaming the axis was declined: it is a column of `summary/all_runs.csv`,
+  a component of every pool directory name and run key, and of the v1 run keys the
+  significance tooling reads — a rename would break comparability with rows already produced,
+  to buy a better word.
+- A clustered cell costs one embedding pass over the input pool plus a k-means fit at
+  `k = 2000`, single-threaded by default. **This cost is unmeasured at real scale**; only the
+  six-row fixture has been run.
+- The clustered arm's *quality* is unmeasured. Nothing in this record supports a claim that
+  clustering helps, and no such claim may be made until the run is in `experiments/log.md`.
+- If the supervisor settles the masking default (ADR 0018), item 5 should be revisited: a
+  settled typed-masking default is a reason to consider clustering on the masked field, and
+  that would be a config change plus a new sweep, not a code change.
+
+## Alternatives considered
+
+- **A separate `cluster_pool.py` stage.** Rejected: it would need its own output conventions,
+  its own skip-existing logic and its own orchestrator stage, and the sweep would then have
+  two ways to produce a `pool.jsonl`. Extending the existing strategy flag keeps one producer
+  of pool files.
+- **A new `strategy` axis alongside `balance`.** Rejected for the comparability reason above —
+  it would change every run key and the summary table's column set, which the appender in
+  `scripts/pool_sweep_orchestrator.py` deliberately refuses to mix.
+- **Agglomerative or HDBSCAN clustering.** Both are defensible and neither reaches an exact
+  target size without an extra selection rule; HDBSCAN also leaves noise points that would
+  need a policy. Not chosen, not measured, and not ruled out on evidence.
+- **Maximal-marginal-relevance / farthest-point selection** (greedy diversity without
+  clustering). Simpler than k-means and arguably the same intent; it was not chosen because
+  issue #14 names clustering. Worth noting as the nearest neighbour of this design.
+- **Clustering the *masked* text by default.** See item 5: the argument for it is real, and the
+  reason against it is that ADR 0018 leaves the masking default unsettled. The knob is there.
+- **Hop-stratified clustering.** See item 10.
+- **Choosing k by a criterion (elbow, silhouette) instead of the target size.** Rejected as
+  scope: it needs a sweep of its own to be meaningful, and a criterion picked without measuring
+  it would be a fabricated rationale.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,8 @@ When to write a new one:
 - A decision that constrains future work — a rule a later session has to keep obeying.
 - Decisions of this shape earn a record: when the dataset changes, when the evaluation method changes, when the way few-shot examples are selected changes, when one model family or embedding model is chosen over another, when the evaluation set is split differently. These are examples of the *shape* of a decision, not a list of things to go decide.
 
+**Separate the human's decision from the implementer's defaults, and label arbitrary choices as arbitrary.** When a record has to carry both — Jahid decided *that* something exists, an agent decided *how* it works — keep them in different sections, say plainly which is which, and where a default had no evidence behind it, write "this is arbitrary" instead of retrofitting a rationale. A plausible-sounding reason invented after the fact is the worst outcome, because it survives review and gets cited in November as if it had been reasoned. ADR [0019](./0019-musique-answering-backend-conventions.md) put the implementer's part under its own heading; ADR [0021](./0021-clustering-pool-construction-strategy.md) additionally names which of its defaults are arbitrary. *(Convention captured from the PR #34 review, 2026-08-20; first instance ADR 0021.)*
+
 When **not** to write one:
 
 - Conventions that are obvious from the code (naming, folder layout) — a short note beside the code is enough.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,7 @@ When **not** to write one:
 | [0018](./0018-resolve-the-carried-v1-research-decisions.md) | Resolve the Carried v1 Research Decisions | Accepted (Jahid, 2026-08-20; embedding model pending supervisor confirmation) |
 | [0019](./0019-musique-answering-backend-conventions.md) | MuSiQue Answering-Backend Conventions: Reader, Context and Scoring | Accepted (Jahid, 2026-08-20, in session; pending supervisor confirmation) |
 | [0020](./0020-prior-work-re-analysis-convention.md) | Prior-Work Re-Analysis Convention | Accepted |
+| [0021](./0021-clustering-pool-construction-strategy.md) | Clustering-Based Pool Construction: The Implementer's Design | Accepted (design agent-authored, pending Jahid) |
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,12 @@ numpy==2.4.1
 scipy==1.17.1
 pandas==3.0.0
 scikit-learn==1.8.0
+# Imported directly by MusiQue/scripts/sample_pool.py (clustered pool construction,
+# issue #14): threadpool_limits is what makes the k-means fit single-threaded and
+# therefore bit-reproducible under the seed (ADR 0021 item 7). It arrives as a
+# scikit-learn dependency anyway, but a determinism guarantee should not rest on a
+# transitive pin. Version read from the installed .venv on 2026-08-20, not guessed.
+threadpoolctl==3.6.0
 
 # Plotting (scripts/analyze_runs.py, plot_pool_sweep.py, plot_musique_chunk_stats.py,
 # compare_answer_accuracy.py --report)

--- a/scripts/pool_sweep_orchestrator.py
+++ b/scripts/pool_sweep_orchestrator.py
@@ -253,11 +253,15 @@ def stage_sample_pool(
     ]
     if balance == "clustered":
         # The clustered strategy embeds the input pool, so it takes the sweep's own
-        # bi-encoder and device rather than the prep config's defaults — one sweep, one
-        # embedding model (ADR 0021).
+        # bi-encoder, device AND alias registry rather than the prep config's defaults —
+        # one sweep, one embedding model (ADR 0021). The registry is threaded explicitly
+        # because every retrieval stage below resolves --embed-model through
+        # configs.similarity: without this the pool stage resolved the same alias through
+        # a config named somewhere else, and the two agreeing was luck (PR #34 review).
         cmd += [
             "--embed-model", require(cfg, "embed_model"),
             "--device", require(cfg, "device"),
+            "--similarity-config", require(cfg, "configs.similarity"),
         ]
     if overwrite:
         cmd.append("--overwrite")

--- a/scripts/pool_sweep_orchestrator.py
+++ b/scripts/pool_sweep_orchestrator.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Orchestrator for the MuSiQue pool-size sweep.
+"""Orchestrator for the MuSiQue pool sweep.
 
 Reads ``configs/pool_sweep.json`` and drives the full pipeline:
 
   1. Sample a dev set once (reused for every cell).
-  2. For each ``(size, balance, trial)``:
+  2. For each ``(size, balance, trial)`` — where ``balance`` is the pool-**construction
+     strategy** (``imbalanced`` / ``balanced`` / ``clustered``, the last from issue #14
+     and ADR 0021, configured under ``clustered_sizes``):
        a. ``sample_pool.py``
        b. ``check_question_similarity.py`` (bi-encoder top-k, mode=all)
        c. ``truncate_top20.py``            -> top5_biencoder.jsonl
@@ -108,12 +110,20 @@ def _run_cmd(
 
 
 def _grid(cfg: dict[str, Any]) -> list[tuple[int, str]]:
-    """The (size, balance) combinations that actually exist in the config."""
+    """The (size, balance) combinations that actually exist in the config.
+
+    ``balance`` is the pool-**construction strategy** axis, not only a hop-balance flag:
+    ``clustered`` (issue #14, ADR 0021) is a third value of it. The name stays as it is so
+    every path, run key and ``all_runs.csv`` column keeps its meaning and rows produced
+    before the strategy existed stay comparable with rows produced after.
+    """
     combos: list[tuple[int, str]] = []
     for s in require(cfg, "imbalanced_sizes"):
         combos.append((int(s), "imbalanced"))
     for s in require(cfg, "balanced_sizes"):
         combos.append((int(s), "balanced"))
+    for s in require(cfg, "clustered_sizes"):
+        combos.append((int(s), "clustered"))
     return combos
 
 
@@ -241,6 +251,14 @@ def stage_sample_pool(
         "--seed", pool_seed,
         "--out-dir", out_dir,
     ]
+    if balance == "clustered":
+        # The clustered strategy embeds the input pool, so it takes the sweep's own
+        # bi-encoder and device rather than the prep config's defaults — one sweep, one
+        # embedding model (ADR 0021).
+        cmd += [
+            "--embed-model", require(cfg, "embed_model"),
+            "--device", require(cfg, "device"),
+        ]
     if overwrite:
         cmd.append("--overwrite")
     rc = _run_cmd(cmd, log_path=log_path, dry_run=dry_run)
@@ -818,6 +836,7 @@ def main() -> None:
         "grid": {
             "imbalanced_sizes": require(cfg, "imbalanced_sizes"),
             "balanced_sizes": require(cfg, "balanced_sizes"),
+            "clustered_sizes": require(cfg, "clustered_sizes"),
             "combos_run": [[size, balance] for size, balance in combos],
             "retriever_variants": variants,
             "retrieval_modes": modes,

--- a/src/pool_embeddings.py
+++ b/src/pool_embeddings.py
@@ -30,8 +30,15 @@ def _model_slug(model_id: str) -> str:
     return model_id.split("/")[-1].replace(".", "_")[:20]
 
 
-def _needs_e5_prefix(model_id: str) -> bool:
-    """E5 models expect 'query:' and 'passage:' prefixes."""
+def needs_e5_prefix(model_id: str) -> bool:
+    """E5 models expect 'query:' and 'passage:' prefixes.
+
+    The single definition of that rule for the whole repo. It used to be copied
+    character-for-character into ``MusiQue/scripts/check_question_similarity.py`` and
+    (with issue #14) ``MusiQue/scripts/sample_pool.py``; both now import this, so
+    "the clustered pool is embedded with the same prefix the retrieval stage uses"
+    is enforced by one function instead of asserted in prose (PR #34 review, N-2).
+    """
     return "e5" in model_id.lower()
 
 
@@ -100,7 +107,7 @@ def get_router_pool_embeddings(
     cache_file = cache_dir / f"embeddings_router_{model_slug}_{content_hash}.npz"
 
     model = SentenceTransformer(model_id)
-    use_prefix = _needs_e5_prefix(model_id)
+    use_prefix = needs_e5_prefix(model_id)
 
     if cache_file.exists():
         loaded = np.load(cache_file, allow_pickle=True)
@@ -127,7 +134,7 @@ def top_k_similar_router(
     k: int,
 ) -> list[tuple[dict, float]]:
     """Top-k similar from the combined router pool (hop unknown)."""
-    use_prefix = _needs_e5_prefix(model_id)
+    use_prefix = needs_e5_prefix(model_id)
     to_encode = [f"query: {query}"] if use_prefix else [query]
     q_emb = model.encode(to_encode, normalize_embeddings=True)[0]
     scores = np.dot(embeddings, q_emb)
@@ -161,7 +168,7 @@ def get_decomposer_pool_embeddings(
     cache_file = cache_dir / f"embeddings_decomposer_{model_slug}_masked_{content_hash}.npz"
 
     model = SentenceTransformer(model_id)
-    use_prefix = _needs_e5_prefix(model_id)
+    use_prefix = needs_e5_prefix(model_id)
 
     if cache_file.exists():
         loaded = np.load(cache_file, allow_pickle=True)
@@ -204,7 +211,7 @@ def top_k_similar_decomposer(
     not: a query retrieving its own gold decomposition as a few-shot example is leakage that
     would read as a quality gain. Asserted below rather than assumed.
     """
-    use_prefix = _needs_e5_prefix(model_id)
+    use_prefix = needs_e5_prefix(model_id)
     to_encode = [f"query: {query}"] if use_prefix else [query]
     q_emb = model.encode(to_encode, normalize_embeddings=True)[0]
     scores = np.dot(embeddings, q_emb)
@@ -261,7 +268,7 @@ def get_pool_embeddings(
     model = SentenceTransformer(model_id)
 
     model_slug = _model_slug(model_id)
-    use_prefix = _needs_e5_prefix(model_id)
+    use_prefix = needs_e5_prefix(model_id)
 
     for hop_key, items in pool.items():
         questions = [it["question"] for it in items]
@@ -310,7 +317,7 @@ def top_k_similar(
     items, emb = pool_embeddings[hop_key]
     if not items:
         return []
-    use_prefix = _needs_e5_prefix(model_id)
+    use_prefix = needs_e5_prefix(model_id)
     to_encode = [f"query: {query}"] if use_prefix else [query]
     q_emb = model.encode(to_encode, normalize_embeddings=True)[0]
     scores = np.dot(emb, q_emb)  # cosine sim (embeddings normalized)

--- a/tests/test_pool_clustering.py
+++ b/tests/test_pool_clustering.py
@@ -21,6 +21,15 @@ What it covers:
    changes the cluster count, an unknown ``representative_rule`` and a target larger than
    the candidate set are refused with a non-zero exit, and a missing ``text_field`` on any
    row is refused rather than silently dropping the row.
+5. **The bi-encoder registry is the one the caller passes** — ``--similarity-config`` (the
+   sweep's own ``configs.similarity``) wins over the prep config's reference and is recorded
+   as a resolved path, and the clustered-only flags are **refused** on a random strategy
+   rather than silently ignored while still appearing in that run's record.
+
+The ceiling-assertion order and the diagnostics-key contract are guarded separately, with no
+model loaded at all, in ``tests/test_pool_clustering_guards.py``: the checks here that
+exercise the real encoder self-skip without a local model cache, which is exactly the blind
+spot ADR 0016 asks for a source-level guard against.
 
 Run::
 
@@ -166,15 +175,27 @@ class TestKmeansSelection(unittest.TestCase):
         self.assertEqual(diag["empty_clusters"], 0)
         self.assertEqual(sorted(idx // 5 for idx in selected), [0, 1, 2, 3])
 
-    def test_rank_major_order_gives_every_cluster_one_pick_first(self) -> None:
-        """Quota 3 with a target that truncates mid-pass still covers all clusters."""
-        emb = _blobs([[0.0, 0.0], [30.0, 0.0], [0.0, 30.0]], 5, 0.02)  # 15 rows
+    def test_rank_major_order_covers_every_cluster_before_any_second_pick(self) -> None:
+        """The property the name claims, asserted: no cluster is starved by truncation.
+
+        ``clusters_represented`` is the count of distinct clusters the selection covers
+        (the diagnostic exists so this is observable in a real run's metrics too, PR #34
+        review N-4a). Whenever the target is at least the cluster count, rank-major order
+        means every cluster contributes before any cluster contributes twice — so the two
+        numbers must be equal, for every quota.
+        """
+        emb = _blobs([[0.0, 0.0], [30.0, 0.0], [0.0, 30.0], [30.0, 30.0]], 5, 0.02)  # 20 rows
+        for size, quota in ((4, 1), (8, 2), (9, 3), (12, 3), (20, 5)):
+            with self.subTest(size=size, quota=quota):
+                _, diag = self._select(emb, size, examples_per_cluster=quota)
+                self.assertGreaterEqual(size, diag["n_clusters"])
+                self.assertEqual(diag["clusters_represented"], diag["n_clusters"])
+
+        # And the truncating case: quota 3 with target 4 uses k=2 and still fills exactly 4.
         selected, diag = self._select(emb, 4, examples_per_cluster=3)
         self.assertEqual(diag["n_clusters"], 2)  # ceil(4 / 3)
         self.assertEqual(len(selected), 4)
-        emb2 = _blobs([[0.0, 0.0], [30.0, 0.0], [0.0, 30.0]], 5, 0.02)
-        selected2, _ = self._select(emb2, 3, examples_per_cluster=1)
-        self.assertEqual(sorted(idx // 5 for idx in selected2), [0, 1, 2])
+        self.assertEqual(diag["clusters_represented"], 2)
 
     def test_refusals(self) -> None:
         emb = _blobs([[0.0, 0.0], [9.0, 0.0]], 3, 0.05)  # 6 rows
@@ -207,7 +228,9 @@ class TestClusteredSampling(unittest.TestCase):
         }
         self.emb = _blobs([[0.0, 0.0], [7.0, 0.0], [0.0, 7.0]], 2, 0.03)
 
-    def _sample(self, size: int, seed: int = 42) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    def _sample(
+        self, size: int, seed: int = 42, similarity_config: str | None = None
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         import random
 
         return SP._sample_clustered(
@@ -217,9 +240,23 @@ class TestClusteredSampling(unittest.TestCase):
             clustering=self.clustering,
             embed_model_key=None,
             device=None,
+            similarity_config=similarity_config,
             seed=seed,
             embeddings=self.emb,
         )
+
+    def test_the_similarity_registry_is_the_one_passed_in(self) -> None:
+        """The sweep's registry wins over the prep config's, and is recorded (I-2)."""
+        _, from_config = self._sample(2)
+        self.assertEqual(from_config["similarity_config_source"], "clustering.similarity_config")
+        _, from_cli = self._sample(2, similarity_config="similarity.json")
+        self.assertEqual(from_cli["similarity_config_source"], "cli")
+        self.assertTrue(from_cli["similarity_config"].endswith("configs/similarity.json"))
+        self.assertEqual(from_cli["embedding"]["model_id"], "intfloat/e5-small-v2")
+
+    def test_an_unknown_similarity_registry_is_refused(self) -> None:
+        with self.assertRaises(SystemExit):
+            self._sample(2, similarity_config="no_such_similarity_config.json")
 
     def test_deterministic_including_the_shuffle(self) -> None:
         first, diag = self._sample(3)
@@ -311,6 +348,57 @@ class TestConfigWiring(unittest.TestCase):
         )
 
 
+class TestClusteredOnlyFlagsAreRefused(unittest.TestCase):
+    """Clustered-only flags on a random strategy are refused, not ignored (N-4b).
+
+    This class loads **no weights**: argparse rejects the combination before any model is
+    touched, so it runs everywhere the suite runs.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="qav2_clustered_flags_test_")
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _run(self, *extra: str, balance: str = "balanced") -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SAMPLE_POOL),
+                "--config", "musique_prep.json",
+                "--size", "3",
+                "--balance", balance,
+                "--out-dir", str(self.tmp / balance),
+                "--overwrite",
+                *extra,
+            ],
+            cwd=str(REPO_ROOT),
+            env=dict(os.environ, QAV2_PATHS_CONFIG="smoke_paths.json"),
+            capture_output=True,
+            text=True,
+        )
+
+    def test_each_flag_is_refused_on_a_random_strategy(self) -> None:
+        for flag, value in (
+            ("--embed-model", "e5-small"),
+            ("--device", "cpu"),
+            ("--similarity-config", "similarity.json"),
+        ):
+            for balance in ("balanced", "imbalanced"):
+                with self.subTest(flag=flag, balance=balance):
+                    proc = self._run(flag, value, balance=balance)
+                    self.assertNotEqual(proc.returncode, 0)
+                    self.assertIn("applies to --balance clustered only", proc.stderr)
+
+    def test_a_random_strategy_without_those_flags_still_works(self) -> None:
+        proc = self._run()
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        snapshot = json.loads((self.tmp / "balanced" / "config.json").read_text(encoding="utf-8"))
+        for key in ("embed_model_override", "device_override", "similarity_config_override"):
+            self.assertIsNone(snapshot[key])
+        self.assertIsNone(snapshot["clustering"])
+
+
 def _biencoder_available() -> bool:
     """True when e5-small-v2 can be loaded from the local cache without the network."""
     env = dict(os.environ, HF_HUB_OFFLINE="1", TRANSFORMERS_OFFLINE="1")
@@ -354,6 +442,7 @@ class TestClusteredCli(unittest.TestCase):
                 "--balance", "clustered",
                 "--device", "cpu",
                 "--embed-model", "e5-small",
+                "--similarity-config", "similarity.json",
                 "--out-dir", str(out_dir),
                 "--overwrite",
             ],
@@ -389,7 +478,10 @@ class TestClusteredCli(unittest.TestCase):
         self.assertEqual(stats["size_written"], 3)
         clustering = stats["clustering"]
         self.assertEqual(clustering["n_clusters"], 3)
+        self.assertEqual(clustering["clusters_represented"], 3)
         self.assertEqual(clustering["representative_rule"], "nearest_to_centroid")
+        self.assertEqual(clustering["similarity_config_source"], "cli")
+        self.assertTrue(clustering["similarity_config"].endswith("configs/similarity.json"))
         self.assertEqual(clustering["kmeans_params"]["random_state"], stats["seed"])
         self.assertEqual(clustering["embedding"]["model_id"], "intfloat/e5-small-v2")
         self.assertEqual(clustering["embedding"]["prefix_applied"], "passage")

--- a/tests/test_pool_clustering.py
+++ b/tests/test_pool_clustering.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Checks for the clustered pool-construction strategy (issue #14, ADR 0021).
+
+CPU only. Every check below runs on hand-made embeddings or the six fabricated rows in
+``tests/fixtures/``; nothing here touches the real MuSiQue pool, and the one check that
+loads the bi-encoder (``intfloat/e5-small-v2``, ~33M params) skips itself when the weights
+are not already in the local cache.
+
+What it covers:
+
+1. **Determinism under the fixed seed** — ``_kmeans_select`` and ``_sample_clustered``
+   (which also shuffles) return byte-identical selections on repeated calls with the same
+   seed, and the CLI writes a byte-identical ``pool.jsonl`` on a re-run.
+2. **The exact target size is reached** — for several ``(n, size, examples_per_cluster)``
+   combinations, including ``size == n``, a quota above 1, and a case where clusters cannot
+   supply the target so the top-up rule has to run.
+3. **No pool-item re-masking (ADR 0003)** — the rows written out are the input rows,
+   value-for-value, with their stored masked fields untouched. The strategy reads a text
+   field; it never masks.
+4. **Config knobs are respected, and a wrong one is refused** — ``examples_per_cluster``
+   changes the cluster count, an unknown ``representative_rule`` and a target larger than
+   the candidate set are refused with a non-zero exit, and a missing ``text_field`` on any
+   row is refused rather than silently dropping the row.
+
+Run::
+
+    .venv/bin/python -m unittest discover -s tests -v
+    .venv/bin/python -m unittest tests.test_pool_clustering -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SAMPLE_POOL = REPO_ROOT / "MusiQue" / "scripts" / "sample_pool.py"
+FIXTURE_POOL = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "data_root"
+    / "musique"
+    / "chunks_only_question_masked_fixed"
+    / "roberta_large_ner_english"
+    / "musique_ans_v1.0_train_all_questions_all_expanded_enriched.jsonl"
+)
+
+#: The clustering defaults under test, mirroring configs/musique_prep.json. Held here as a
+#: literal so a knob changing in the config makes the *config* test fail loudly rather than
+#: silently re-pointing every check below at a new value.
+DEFAULT_KMEANS = {
+    "init": "k-means++",
+    "n_init": 1,
+    "max_iter": 300,
+    "tol": 0.0001,
+    "algorithm": "lloyd",
+    "num_threads": 1,
+}
+
+
+def _import_sample_pool() -> Any:
+    """Import MusiQue/scripts/sample_pool.py the way the script itself is run."""
+    for path in (REPO_ROOT / "src", SAMPLE_POOL.parent):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    name = "sample_pool"
+    spec = importlib.util.spec_from_file_location(name, SAMPLE_POOL)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SP = _import_sample_pool()
+
+
+def _blobs(centres: list[list[float]], per_centre: int, spread: float) -> np.ndarray:
+    """Tight, deterministic blobs: centre + a fixed small offset per member.
+
+    Not random: the fixture must not depend on an RNG for the *input* to a determinism
+    check, or a failure could not be attributed.
+    """
+    rows: list[list[float]] = []
+    for centre in centres:
+        for j in range(per_centre):
+            offset = spread * ((j % 3) - 1)
+            rows.append([c + offset * (1 + i * 0.1) for i, c in enumerate(centre)])
+    return np.asarray(rows, dtype=np.float32)
+
+
+def _ids(n: int) -> list[str]:
+    return [f"row{i:04d}" for i in range(n)]
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+class TestKmeansSelection(unittest.TestCase):
+    """The selection rule, on injected embeddings. No encoder is loaded."""
+
+    def _select(self, emb: np.ndarray, size: int, **kwargs: Any) -> tuple[list[int], dict[str, Any]]:
+        params = {
+            "seed": 42,
+            "examples_per_cluster": 1,
+            "representative_rule": "nearest_to_centroid",
+            "kmeans_params": dict(DEFAULT_KMEANS),
+            "num_threads": 1,
+        }
+        params.update(kwargs)
+        return SP._kmeans_select(emb, _ids(emb.shape[0]), size, **params)
+
+    def test_deterministic_under_the_same_seed(self) -> None:
+        emb = _blobs([[0.0, 0.0], [10.0, 0.0], [0.0, 10.0], [10.0, 10.0]], 6, 0.05)
+        first, diag_a = self._select(emb, 8)
+        second, diag_b = self._select(emb, 8)
+        third, _ = self._select(emb, 8)
+        self.assertEqual(first, second)
+        self.assertEqual(first, third)
+        self.assertEqual(diag_a["kmeans_inertia"], diag_b["kmeans_inertia"])
+        self.assertEqual(diag_a["n_clusters"], 8)
+
+    def test_exact_target_size_across_shapes(self) -> None:
+        emb = _blobs([[0.0, 0.0], [5.0, 0.0], [0.0, 5.0]], 8, 0.1)  # 24 rows
+        for size, quota in ((1, 1), (3, 1), (7, 1), (24, 1), (10, 2), (9, 4), (24, 5)):
+            with self.subTest(size=size, quota=quota):
+                selected, diag = self._select(emb, size, examples_per_cluster=quota)
+                self.assertEqual(len(selected), size)
+                self.assertEqual(len(set(selected)), size)
+                self.assertEqual(
+                    diag["n_clusters"], min(-(-size // quota), emb.shape[0])
+                )
+                self.assertEqual(
+                    diag["selected_from_clusters"] + diag["selected_from_topup"], size
+                )
+
+    def test_topup_runs_when_clusters_cannot_fill_the_target(self) -> None:
+        """Three tight blobs, quota 4, target 12: k=3 and only 3 rows exist per blob.
+
+        Each cluster can supply at most its own members, so the rank-major pass cannot
+        reach 12 and the top-up rule has to close the gap — and say that it did.
+        """
+        emb = _blobs([[0.0, 0.0], [20.0, 0.0], [0.0, 20.0]], 4, 0.01)  # 12 rows, k=3
+        selected, diag = self._select(emb, 12, examples_per_cluster=4)
+        self.assertEqual(len(selected), 12)
+        self.assertEqual(len(set(selected)), 12)
+        self.assertEqual(diag["n_clusters"], 3)
+        self.assertEqual(sorted(selected), list(range(12)))
+
+    def test_one_representative_per_separated_blob(self) -> None:
+        """With k = number of blobs, the picks land one per blob — the point of the strategy."""
+        centres = [[0.0, 0.0], [50.0, 0.0], [0.0, 50.0], [50.0, 50.0]]
+        emb = _blobs(centres, 5, 0.02)  # 20 rows, blob b == indices 5b..5b+4
+        selected, diag = self._select(emb, 4)
+        self.assertEqual(diag["n_clusters"], 4)
+        self.assertEqual(diag["empty_clusters"], 0)
+        self.assertEqual(sorted(idx // 5 for idx in selected), [0, 1, 2, 3])
+
+    def test_rank_major_order_gives_every_cluster_one_pick_first(self) -> None:
+        """Quota 3 with a target that truncates mid-pass still covers all clusters."""
+        emb = _blobs([[0.0, 0.0], [30.0, 0.0], [0.0, 30.0]], 5, 0.02)  # 15 rows
+        selected, diag = self._select(emb, 4, examples_per_cluster=3)
+        self.assertEqual(diag["n_clusters"], 2)  # ceil(4 / 3)
+        self.assertEqual(len(selected), 4)
+        emb2 = _blobs([[0.0, 0.0], [30.0, 0.0], [0.0, 30.0]], 5, 0.02)
+        selected2, _ = self._select(emb2, 3, examples_per_cluster=1)
+        self.assertEqual(sorted(idx // 5 for idx in selected2), [0, 1, 2])
+
+    def test_refusals(self) -> None:
+        emb = _blobs([[0.0, 0.0], [9.0, 0.0]], 3, 0.05)  # 6 rows
+        with self.assertRaises(SystemExit):
+            self._select(emb, 7)  # size > candidates
+        with self.assertRaises(SystemExit):
+            self._select(emb, 3, representative_rule="farthest_from_centroid")
+        with self.assertRaises(SystemExit):
+            self._select(emb, 3, examples_per_cluster=0)
+        with self.assertRaises(SystemExit):
+            self._select(emb, 3, num_threads=0)
+
+
+class TestClusteredSampling(unittest.TestCase):
+    """``_sample_clustered`` on the fixture rows, with embeddings injected."""
+
+    def setUp(self) -> None:
+        self.rows = _load_jsonl(FIXTURE_POOL)
+        self.assertEqual(len(self.rows), 6, "fixture pool changed; update this expectation")
+        self.clustering = {
+            "text_field": "question",
+            "similarity_config": "similarity.json",
+            "embed_model": "e5-small",
+            "embed_prefix": "passage",
+            "embed_batch_size": 4,
+            "device": "cpu",
+            "examples_per_cluster": 1,
+            "representative_rule": "nearest_to_centroid",
+            "kmeans": dict(DEFAULT_KMEANS),
+        }
+        self.emb = _blobs([[0.0, 0.0], [7.0, 0.0], [0.0, 7.0]], 2, 0.03)
+
+    def _sample(self, size: int, seed: int = 42) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        import random
+
+        return SP._sample_clustered(
+            self.rows,
+            size,
+            random.Random(seed),
+            clustering=self.clustering,
+            embed_model_key=None,
+            device=None,
+            seed=seed,
+            embeddings=self.emb,
+        )
+
+    def test_deterministic_including_the_shuffle(self) -> None:
+        first, diag = self._sample(3)
+        second, _ = self._sample(3)
+        self.assertEqual([r["id"] for r in first], [r["id"] for r in second])
+        self.assertEqual(len(first), 3)
+        self.assertEqual(diag["embedding"]["model_id"], "intfloat/e5-small-v2")
+
+    def test_rows_are_the_input_rows_unchanged(self) -> None:
+        """ADR 0003: the pool is never re-masked. The rows out are the rows in."""
+        by_id = {r["id"]: r for r in self.rows}
+        selected, _ = self._sample(4)
+        self.assertEqual(len(selected), 4)
+        for row in selected:
+            self.assertIn(row["id"], by_id)
+            self.assertEqual(row, by_id[row["id"]])
+            self.assertEqual(
+                row["question_masked_typed"], by_id[row["id"]]["question_masked_typed"]
+            )
+            self.assertEqual(
+                row["question_masked_uniform"], by_id[row["id"]]["question_masked_uniform"]
+            )
+        self.assertEqual(len({r["id"] for r in selected}), 4)
+
+    def test_text_field_knob_is_used(self) -> None:
+        self.clustering["text_field"] = "question_masked_typed"
+        _, diag = self._sample(2)
+        self.assertEqual(diag["text_field"], "question_masked_typed")
+
+    def test_missing_text_field_is_refused(self) -> None:
+        self.clustering["text_field"] = "question_masked_nonexistent"
+        with self.assertRaises(SystemExit):
+            self._sample(2)
+
+    def test_blank_text_field_is_refused(self) -> None:
+        rows = [dict(r) for r in self.rows]
+        rows[2]["question"] = "   "
+        with self.assertRaises(SystemExit):
+            SP._clustering_texts(rows, "question")
+
+
+class TestConfigWiring(unittest.TestCase):
+    """The committed configs carry the strategy, and the orchestrator grid picks it up."""
+
+    def test_prep_config_has_every_clustering_knob(self) -> None:
+        cfg = json.loads((REPO_ROOT / "configs" / "musique_prep.json").read_text(encoding="utf-8"))
+        clustering = cfg["sample_pool"]["clustering"]
+        for key in (
+            "text_field",
+            "similarity_config",
+            "embed_model",
+            "embed_prefix",
+            "embed_batch_size",
+            "device",
+            "examples_per_cluster",
+            "representative_rule",
+            "kmeans",
+        ):
+            self.assertIn(key, clustering)
+        self.assertEqual(clustering["kmeans"], DEFAULT_KMEANS)
+        self.assertEqual(clustering["representative_rule"], "nearest_to_centroid")
+        # ADR 0018: the bi-encoder alias resolves through the similarity registry.
+        similarity = json.loads(
+            (REPO_ROOT / "configs" / clustering["similarity_config"]).read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            similarity["bi_encoder"]["embed_models"][clustering["embed_model"]],
+            "intfloat/e5-small-v2",
+        )
+
+    def test_sweep_grid_contains_the_clustered_cells(self) -> None:
+        name = "pool_sweep_orchestrator_for_clustering_test"
+        spec = importlib.util.spec_from_file_location(
+            name, REPO_ROOT / "scripts" / "pool_sweep_orchestrator.py"
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+
+        cfg = json.loads((REPO_ROOT / "configs" / "pool_sweep.json").read_text(encoding="utf-8"))
+        combos = module._grid(cfg)
+        self.assertIn((2000, "clustered"), combos)
+        # ADR 0006 fixes the pool size at 2000, so that is the size this strategy is swept at.
+        self.assertEqual([s for s, b in combos if b == "clustered"], [2000])
+        self.assertEqual(
+            module._filter_combos(combos, ["clustered"]),
+            [(s, b) for s, b in combos if b == "clustered"],
+        )
+
+
+def _biencoder_available() -> bool:
+    """True when e5-small-v2 can be loaded from the local cache without the network."""
+    env = dict(os.environ, HF_HUB_OFFLINE="1", TRANSFORMERS_OFFLINE="1")
+    probe = (
+        "from sentence_transformers import SentenceTransformer;"
+        "SentenceTransformer('intfloat/e5-small-v2', device='cpu')"
+    )
+    return subprocess.run(
+        [sys.executable, "-c", probe], env=env, capture_output=True, text=True
+    ).returncode == 0
+
+
+class TestClusteredCli(unittest.TestCase):
+    """The real script, real embeddings, CPU, on the six fabricated fixture rows."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.available = _biencoder_available()
+
+    def setUp(self) -> None:
+        if not self.available:
+            self.skipTest("intfloat/e5-small-v2 is not in the local cache (offline probe failed)")
+        self._tmp = tempfile.TemporaryDirectory(prefix="qav2_clustered_pool_test_")
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _run(self, out_dir: Path, size: int = 3) -> subprocess.CompletedProcess[str]:
+        env = dict(
+            os.environ,
+            QAV2_PATHS_CONFIG="smoke_paths.json",
+            HF_HUB_OFFLINE="1",
+            TRANSFORMERS_OFFLINE="1",
+            PYTHONUNBUFFERED="1",
+        )
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SAMPLE_POOL),
+                "--config", "musique_prep.json",
+                "--size", str(size),
+                "--balance", "clustered",
+                "--device", "cpu",
+                "--embed-model", "e5-small",
+                "--out-dir", str(out_dir),
+                "--overwrite",
+            ],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_cli_writes_a_pool_and_its_trail_reproducibly(self) -> None:
+        first_dir = self.tmp / "run_a"
+        second_dir = self.tmp / "run_b"
+        first = self._run(first_dir)
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        second = self._run(second_dir)
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+
+        pool_a = (first_dir / "pool.jsonl").read_bytes()
+        pool_b = (second_dir / "pool.jsonl").read_bytes()
+        self.assertEqual(pool_a, pool_b, "same seed produced a different pool")
+
+        rows = _load_jsonl(first_dir / "pool.jsonl")
+        self.assertEqual(len(rows), 3)
+        source = {r["id"]: r for r in _load_jsonl(FIXTURE_POOL)}
+        for row in rows:
+            self.assertEqual(row, source[row["id"]])  # ADR 0003: unchanged rows
+
+        for name in ("stats.json", "metrics.json", "notes.md", "config.json"):
+            self.assertTrue((first_dir / name).exists(), f"missing {name}")
+
+        stats = json.loads((first_dir / "stats.json").read_text(encoding="utf-8"))
+        self.assertEqual(stats["balance"], "clustered")
+        self.assertEqual(stats["size_written"], 3)
+        clustering = stats["clustering"]
+        self.assertEqual(clustering["n_clusters"], 3)
+        self.assertEqual(clustering["representative_rule"], "nearest_to_centroid")
+        self.assertEqual(clustering["kmeans_params"]["random_state"], stats["seed"])
+        self.assertEqual(clustering["embedding"]["model_id"], "intfloat/e5-small-v2")
+        self.assertEqual(clustering["embedding"]["prefix_applied"], "passage")
+        # The size ceiling is asserted at load, not assumed (src/model_size.py).
+        size_record = clustering["embedding"]["model_size"]
+        self.assertTrue(size_record["ceiling_asserted"])
+        self.assertLess(size_record["parameter_count"], size_record["parameter_ceiling"])
+
+    def test_cli_refuses_a_size_above_the_candidate_count(self) -> None:
+        proc = self._run(self.tmp / "too_big", size=99)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("exceeds pool row count", proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_pool_clustering_guards.py
+++ b/tests/test_pool_clustering_guards.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Source-level guards for the clustered pool path (ADR 0016, issue #14).
+
+Why this file exists. The clustered strategy has exactly two invariants that **no run
+without model weights can reach**:
+
+1. the bi-encoder's parameter count is asserted before it is used — the assertion lives
+   after ``SentenceTransformer(...)`` returns, and the limits config is loaded before it,
+   so neither line executes unless weights actually load;
+2. the run-note formatter in ``main()`` reads keys off the clustering diagnostics dict,
+   and that dict is only built on a real clustered run.
+
+Both are the shape ADR [0016](../docs/adr/0016-real-run-only-invariants-get-source-level-guards.md)
+exists for, and the exact shape that took down exp-002/exp-003 on 2026-08-19: a consumer
+read ``gen["raw"]`` while the producer returned ``"text"``, and every dry run, smoke stage
+and unit test passed over the broken line because a dry run never generates. The clustered
+path had the same blind spot in a worse form — its only end-to-end coverage
+(``TestClusteredCli`` in ``tests/test_pool_clustering.py``) **self-skips** when the encoder
+is not in the local model cache, so on a fresh machine the suite goes green with the whole
+strategy unexercised (PR #34 review, I-3).
+
+So these checks parse the source instead. They load no weights, need no cache, and each one
+ships a negative control that breaks the invariant in a copy of the source and asserts the
+guard catches it — a guard nobody has watched fail is not evidence.
+
+Run::
+
+    .venv/bin/python tests/test_pool_clustering_guards.py
+    .venv/bin/python -m unittest tests.test_pool_clustering_guards -v
+"""
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SAMPLE_POOL = REPO_ROOT / "MusiQue" / "scripts" / "sample_pool.py"
+SIMILARITY = REPO_ROOT / "MusiQue" / "scripts" / "check_question_similarity.py"
+POOL_EMBEDDINGS = REPO_ROOT / "src" / "pool_embeddings.py"
+
+#: The encoder construction the ceiling assertion has to bracket.
+ENCODER_CALL = "SentenceTransformer"
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name}() was not found — the guard went blind")
+
+
+def _call_linenos(node: ast.AST, func_name: str) -> list[int]:
+    """Line numbers of every call to ``func_name`` (bare name or attribute) under ``node``."""
+    out: list[int] = []
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        target = child.func
+        called = (
+            target.id
+            if isinstance(target, ast.Name)
+            else target.attr if isinstance(target, ast.Attribute) else None
+        )
+        if called == func_name:
+            out.append(child.lineno)
+    return out
+
+
+def ceiling_guard_violations(source: str, *, fn: str = "_embed_texts") -> list[str]:
+    """Ways ``fn`` could load an encoder without the ceiling being asserted around it.
+
+    The rule, in order: ``load_limits`` runs **before** the encoder is constructed (a
+    limits config missing a key must fail before weights load — ``src/model_size.py``
+    says so in as many words), the encoder is constructed, and
+    ``assert_within_ceiling`` runs **after** it with a real component name. Any of those
+    missing means a model could be embedded with its size unasserted.
+    """
+    node = _function(ast.parse(source), fn)
+    limits = _call_linenos(node, "load_limits")
+    encoder = _call_linenos(node, ENCODER_CALL)
+    asserts = _call_linenos(node, "assert_within_ceiling")
+
+    violations: list[str] = []
+    if not encoder:
+        return [f"{fn}() constructs no {ENCODER_CALL} — the guard went blind"]
+    if not limits:
+        violations.append(f"{fn}() never calls load_limits")
+    if not asserts:
+        violations.append(f"{fn}() never calls assert_within_ceiling")
+    if limits and min(limits) > min(encoder):
+        violations.append(
+            f"load_limits (line {min(limits)}) does not precede "
+            f"{ENCODER_CALL} (line {min(encoder)})"
+        )
+    if asserts and min(asserts) < min(encoder):
+        violations.append(
+            f"assert_within_ceiling (line {min(asserts)}) precedes the "
+            f"{ENCODER_CALL} it must assert (line {min(encoder)})"
+        )
+
+    components = {
+        kw.value.value
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Name)
+        and call.func.id == "assert_within_ceiling"
+        for kw in call.keywords
+        if kw.arg == "component"
+        and isinstance(kw.value, ast.Constant)
+        and isinstance(kw.value.value, str)
+    }
+    if asserts and not components:
+        violations.append("assert_within_ceiling is called without a literal component=")
+    return violations
+
+
+def _dict_literal_keys(node: ast.AST, var: str) -> list[set[str]]:
+    """Key sets of every dict literal assigned to ``var`` under ``node``."""
+    out: list[set[str]] = []
+    for stmt in ast.walk(node):
+        if not isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+        if not any(isinstance(t, ast.Name) and t.id == var for t in targets):
+            continue
+        if isinstance(stmt.value, ast.Dict):
+            out.append(
+                {
+                    key.value
+                    for key in stmt.value.keys
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                }
+            )
+    return out
+
+
+def _subscript_assigned_keys(node: ast.AST, var: str) -> set[str]:
+    """Keys written as ``var["key"] = ...`` under ``node``."""
+    keys: set[str] = set()
+    for stmt in ast.walk(node):
+        if not isinstance(stmt, ast.Assign):
+            continue
+        for target in stmt.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == var
+                and isinstance(target.slice, ast.Constant)
+                and isinstance(target.slice.value, str)
+            ):
+                keys.add(target.slice.value)
+    return keys
+
+
+def _read_keys(tree: ast.Module, var: str) -> tuple[set[str], set[str]]:
+    """Keys read as ``var["k"]`` and as ``var["embedding"]["k"]`` anywhere in the module."""
+    top: set[str] = set()
+    nested: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript) or not isinstance(node.slice, ast.Constant):
+            continue
+        key = node.slice.value
+        if not isinstance(key, str):
+            continue
+        inner = node.value
+        if isinstance(inner, ast.Name) and inner.id == var:
+            top.add(key)
+        elif (
+            isinstance(inner, ast.Subscript)
+            and isinstance(inner.value, ast.Name)
+            and inner.value.id == var
+            and isinstance(inner.slice, ast.Constant)
+            and inner.slice.value == "embedding"
+        ):
+            nested.add(key)
+    return top, nested
+
+
+def diagnostics_guard_missing(source: str) -> tuple[set[str], set[str]]:
+    """(diagnostic keys, embedding keys) the run note reads but no producer guarantees.
+
+    A key counts as produced only when **every** producer of that dict emits it, the same
+    intersection rule ``tests/test_generation_contract.py`` uses: the embedding record has
+    two shapes (a real embedding pass and the precomputed test seam), and a key present in
+    only one of them is exactly the crash that waits for whichever path is not covered.
+    """
+    tree = ast.parse(source)
+    select = _function(tree, "_kmeans_select")
+    sample = _function(tree, "_sample_clustered")
+    embed = _function(tree, "_embed_texts")
+
+    literals = _dict_literal_keys(select, "diagnostics")
+    if not literals:
+        raise AssertionError("_kmeans_select builds no diagnostics dict literal")
+    produced = set.intersection(*literals) | _subscript_assigned_keys(sample, "diagnostics")
+
+    record_literals = _dict_literal_keys(embed, "record") + _dict_literal_keys(
+        sample, "embed_record"
+    )
+    if len(record_literals) < 2:
+        raise AssertionError(
+            "expected two embedding-record producers (real pass + precomputed seam), "
+            f"found {len(record_literals)}"
+        )
+    produced_embedding = set.intersection(*record_literals)
+
+    read_top, read_nested = _read_keys(tree, "clustering_diagnostics")
+    if not read_top:
+        raise AssertionError("nothing reads clustering_diagnostics — the guard went blind")
+    return (read_top - produced), (read_nested - produced_embedding)
+
+
+class TestCeilingPrecedesEncoder(unittest.TestCase):
+    """The bi-encoder's size is asserted on every real clustered run, or the run dies."""
+
+    def setUp(self) -> None:
+        self.source = SAMPLE_POOL.read_text(encoding="utf-8")
+
+    def test_the_invariant_holds(self) -> None:
+        self.assertEqual(ceiling_guard_violations(self.source), [])
+
+    def test_limits_loaded_after_the_encoder_is_caught(self) -> None:
+        """Negative control: a limits config missing a key must fail before weights load."""
+        broken = self.source.replace(
+            '    limits = load_limits("model_limits.json")\n'
+            "    model = SentenceTransformer(model_id, device=device)\n",
+            "    model = SentenceTransformer(model_id, device=device)\n"
+            '    limits = load_limits("model_limits.json")\n',
+        )
+        self.assertNotEqual(broken, self.source, "the load order moved; update this control")
+        self.assertTrue(
+            any("does not precede" in v for v in ceiling_guard_violations(broken)),
+            ceiling_guard_violations(broken),
+        )
+
+    def test_a_dropped_assertion_is_caught(self) -> None:
+        """Negative control: embedding with the parameter count unasserted."""
+        broken = self.source.replace(
+            "    size_record = assert_within_ceiling(\n"
+            '        model, component="retrieval", model_id=model_id, limits=limits\n'
+            "    )\n",
+            '    size_record = {"ceiling_asserted": False}\n',
+        )
+        self.assertNotEqual(broken, self.source, "the assertion moved; update this control")
+        self.assertIn(
+            "_embed_texts() never calls assert_within_ceiling",
+            ceiling_guard_violations(broken),
+        )
+
+    def test_an_anonymous_assertion_is_caught(self) -> None:
+        """Negative control: asserting against no named component asserts nothing useful."""
+        broken = self.source.replace('component="retrieval", model_id=model_id', "model_id=model_id")
+        self.assertNotEqual(broken, self.source, "the assertion moved; update this control")
+        self.assertIn(
+            "assert_within_ceiling is called without a literal component=",
+            ceiling_guard_violations(broken),
+        )
+
+
+class TestDiagnosticsContract(unittest.TestCase):
+    """The run note may only read diagnostic keys some producer guarantees."""
+
+    def setUp(self) -> None:
+        self.source = SAMPLE_POOL.read_text(encoding="utf-8")
+
+    def test_every_key_the_note_reads_is_produced(self) -> None:
+        missing_top, missing_embedding = diagnostics_guard_missing(self.source)
+        self.assertEqual(missing_top, set())
+        self.assertEqual(missing_embedding, set())
+
+    def test_a_renamed_diagnostic_key_is_caught(self) -> None:
+        """Negative control, the exp-002 shape: producer renamed, consumer not."""
+        broken = self.source.replace(
+            '"selected_from_topup": size - from_clusters,',
+            '"topup_count": size - from_clusters,',
+        )
+        self.assertNotEqual(broken, self.source, "the diagnostics dict moved; update this control")
+        self.assertEqual(diagnostics_guard_missing(broken)[0], {"selected_from_topup"})
+
+    def test_a_renamed_late_assignment_is_caught(self) -> None:
+        """Keys attached after _kmeans_select returns are covered too."""
+        broken = self.source.replace(
+            'diagnostics["text_field"] = field', 'diagnostics["field"] = field'
+        )
+        self.assertNotEqual(broken, self.source, "the assignment moved; update this control")
+        self.assertEqual(diagnostics_guard_missing(broken)[0], {"text_field"})
+
+    def test_a_key_missing_from_only_one_embedding_producer_is_caught(self) -> None:
+        """The precomputed seam is a second producer; a key it lacks is still a crash."""
+        broken = self.source.replace(
+            '        embed_record = {"model_id": model_id, "precomputed": True, '
+            '"num_texts": len(texts)}',
+            '        embed_record = {"precomputed": True, "num_texts": len(texts)}',
+        )
+        self.assertNotEqual(broken, self.source, "the seam moved; update this control")
+        self.assertEqual(diagnostics_guard_missing(broken)[1], {"model_id"})
+
+
+class TestOneE5PrefixDefinition(unittest.TestCase):
+    """"Same prefix as the retrieval stage" is one function, not three copies (N-2)."""
+
+    def _defines(self, path: Path, name: str) -> bool:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        return any(
+            isinstance(node, ast.FunctionDef) and node.name == name
+            for node in ast.walk(tree)
+        )
+
+    def test_only_pool_embeddings_defines_it(self) -> None:
+        self.assertTrue(self._defines(POOL_EMBEDDINGS, "needs_e5_prefix"))
+        for path in (SAMPLE_POOL, SIMILARITY):
+            with self.subTest(path=path.name):
+                self.assertFalse(self._defines(path, "needs_e5_prefix"))
+                self.assertFalse(self._defines(path, "_needs_e5_prefix"))
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("from pool_embeddings import needs_e5_prefix", source)
+                self.assertIn("needs_e5_prefix(", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds `clustered` as a third value of the sweep's pool-construction axis (issue #14). Implementation + tests only — **no sweep or evaluation run was launched**, nothing was written to `experiments/log.md`, and the clustered arm's quality is **unmeasured**. The evaluation at pool size 2000 happens later on the GPU via the experiment-runner, which is why this is `Refs #14`, not `Closes`.

## What it does

`--balance clustered` in `MusiQue/scripts/sample_pool.py`: embed every candidate row with the sweep's bi-encoder, fit seeded k-means, keep the row nearest each centroid. It slots into the existing sweep with no new stage — same `pool.jsonl` output conventions, same pool directory names, run keys and `summary/all_runs.csv` columns — so a clustered cell is comparable with a balanced or imbalanced cell of the same size, trial seed, dev sample, variant and mode.

Selectable from committed config: `clustered_sizes: [2000]` in `configs/pool_sweep.json` (ADR 0006 fixes the pool size, so construction is what varies). Every clustering knob lives in `sample_pool.clustering` in `configs/musique_prep.json` — text field, bi-encoder alias (resolved through `configs/similarity.json`'s registry, ADR 0018), cluster-count rule, representative rule, k-means parameters, thread count. No clustering constant in source.

## The design is the implementer's, and ADR 0021 says so

Jahid decided *that* a clustering strategy exists (#14); he did not decide *how* it clusters. `docs/adr/0021-clustering-pool-construction-strategy.md` records the design as agent-authored defaults, status **Accepted (design agent-authored, pending Jahid)**, and names the arbitrary parts rather than inventing rationales for them:

- one representative per cluster (`examples_per_cluster: 1`, so `k = 2000`) — arbitrary; no evidence says 1 beats 5,
- the embedded field is the raw `question` — arguable; masked text would cluster on structure, but ADR 0018 leaves the masking default reopened, so pool construction is deliberately not tied to it. `text_field` is the knob,
- ascending-distance top-up when clusters cannot fill the target — arbitrary, and counted (`selected_from_topup`) rather than silent.

Not implemented, and recorded as such: hop-stratified clustering, alternative clusterers, criterion-based `k`, an embedding cache.

## Invariants

- **Determinism.** k-means is seeded with the trial's pool seed; the fit runs inside `threadpool_limits(kmeans.num_threads)`, default **1**, because sklearn's Lloyd loop reduces over OpenMP chunks and the thread count is part of the float result. Representatives are ranked by `(distance, id, index)`, so no library iteration order leaks in.
- **ADR 0003.** The strategy reads a *stored* text field; no masker runs, and the rows written out are the input rows value-for-value. Asserted in the tests.
- **Exact target size**, asserted in code and across seven `(size, quota)` shapes in the tests.
- **Model ceiling** printed and asserted at load (`src/model_size.py`, component `retrieval`): `intfloat/e5-small-v2`, measured **33,360,000** parameters, 0.3% of the ceiling.

## Evidence (ran-X-observed-Y)

Run in a clean worktree at this branch's commit (the shared checkout has another lane's uncommitted work in it, so verification was deliberately not run there):

- `python -m unittest discover -s tests` -> **Ran 229 tests, OK** (15 of them new, `tests/test_pool_clustering.py`).
- `python scripts/smoke_test.py` -> **36/36 stages PASS**, no failures.
- `python MusiQue/scripts/sample_pool.py --balance clustered --size 4 ...` on the 6-row fixture pool with real e5-small-v2 on **CPU** -> 4 rows written, `k=4`, 0 empty clusters, 0 top-ups, `parameter_count 33,360,000 / ceiling 10,000,000,000`, and a byte-identical `pool.jsonl` on a re-run at the same seed. The CLI test skips itself when the weights are not in the local cache.
- `pool_sweep_orchestrator.py --dry-run --only clustered` -> `combos: [(2000, 'clustered')]`, cell `size2000_clustered_trial0`, run key `size2000_clustered_trial0__biencoder_plus_ce__typed`, and the pool stage invoked as `--balance clustered --seed 42 --embed-model e5-small --device cuda`.

Cost at real scale (embedding ~the full enriched pool + a `k=2000` single-threaded fit) is **unmeasured**; only the six-row fixture has been run.

## Decision for the lead

`configs/plot_pool_sweep.json` gains `clustered` in `balances` so per-strategy plots render it. The existing `balanced_vs_imbalanced_delta` plot still pairs exactly those two — a clustered-versus-X delta plot was not added, because which comparison the thesis wants is Jahid's call.

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)