### PR TITLE
Significance battery over v1's pool-size comparisons (Refs #6)

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -198,6 +198,9 @@ significant, CI [−0.1842, +0.2259]; diagnostic +0.0273, CI [+0.0107, +0.0440],
 [`docs/analysis/2026-08-20-v1-pool-size-significance.md`](analysis/2026-08-20-v1-pool-size-significance.md)
 §4.4 (the pool-size trend **reverses direction** between the two). Both are input to issue #29.
 
+Like the rest of this section's conventions, these rules are agent-side reporting documentation
+(recorded 2026-08-20, PR #35) — Jahid's and his supervisor's to revise, not settled methodology.
+
 ## 5. Paired comparison (`--compare A_per_item.json B_per_item.json`)
 
 Compares two runs **on the same evaluation set**. Parameters live in
@@ -277,7 +280,8 @@ significant" and "equal" are different claims, and only the first is supported �
 notes cited in §4.1 both had to say so about a tie the reader would otherwise read as a null
 result.
 These are report-time figures computed from the same per-item differences as the tests; they
-are not produced by `--compare` today.
+are not produced by `--compare` today. Like §4.1, this is an agent-side reporting convention
+(recorded 2026-08-20, PR #35) — Jahid's and his supervisor's to revise, not settled methodology.
 
 ## 6. "Composite score" names two different things — proposed fix
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -164,6 +164,40 @@ term is direction-blind (it uses the MAE, so over- and under-decomposition are p
 identically). The directional metrics in §2 are reported separately precisely because the
 composite cannot express that difference.
 
+### 4.1 Non-house diagnostics — `composite_no_ref_renorm`
+
+Analysis notes sometimes need to ask *"how much of this composite difference is the
+reference term?"*. The quantity they use for it is the composite with the
+`reference_validity_micro` term **dropped** and the remaining weights **renormalized to sum
+to 1**:
+
+| term | house weight | renormalized weight |
+|---|---|---|
+| `step_f1_macro` | 0.4 | **0.5** |
+| `ordered_step_accuracy_macro` | 0.3 | **0.375** |
+| `step_count_error` (same `max(0, 1 - mae/scale)`, scale 3.0) | 0.1 | **0.125** |
+| `reference_validity_micro` | 0.2 | **dropped** |
+
+Rules, because this has now been used by two notes and it changes a headline in both:
+
+- It is a **diagnostic, not a house metric.** The evaluator does not compute it; it is not in
+  `configs/musique_eval.json`; it never appears in a run's `eval_metrics.json`. A note that
+  reports it says so at the point of use.
+- **No thesis claim may rest on it alone.** Its job is to show what the 0.2-weighted micro rate
+  is doing to a comparison, so it is reported *beside* the house composite and the directional
+  metrics in §2, never instead of them. Where it and the house composite disagree, that
+  disagreement is the finding — not a licence to pick the friendlier number.
+- Like the house composite it is built from **aggregate** values, so it has **no per-item
+  value**: bootstrap only, no paired t-test and no McNemar.
+
+Its two instances, both prior-work re-analyses under
+[ADR 0020](adr/0020-prior-work-re-analysis-convention.md):
+[`docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md`](analysis/2026-08-20-v1-masking-and-retrieval-significance.md)
+§4, "the typed-vs-raw composite gap is almost entirely one term" (house composite not
+significant, CI [−0.1842, +0.2259]; diagnostic +0.0273, CI [+0.0107, +0.0440], significant) and
+[`docs/analysis/2026-08-20-v1-pool-size-significance.md`](analysis/2026-08-20-v1-pool-size-significance.md)
+§4.4 (the pool-size trend **reverses direction** between the two). Both are input to issue #29.
+
 ## 5. Paired comparison (`--compare A_per_item.json B_per_item.json`)
 
 Compares two runs **on the same evaluation set**. Parameters live in
@@ -231,6 +265,19 @@ Output: `<out_prefix>_config.json`, `<out_prefix>_metrics.json` and `<out_prefix
 in the run directory, with a Markdown table of every statistic, its difference, its
 interval **or** p-value (the column is headed `CI or p`, because the bootstrap rows carry an
 interval and the McNemar rows a p-value), and its significant/underpowered annotations.
+
+### 5.1 Reporting power alongside a null result
+
+When a comparison reports **no significant difference**, the note states the **minimum
+detectable difference** at that n (paired, α = 0.05 two-sided, 80% power, from the observed
+per-item difference SD: `MDE = 2.8016 * sd(diff) / sqrt(n)`, the constant being
+z₀.₉₇₅ + z₀.₈ = 2.80158 rounded) and, where the observed difference is non-zero, the **n it
+would need** for 80% power: `n = (2.8016 * sd(diff) / diff)^2`. The reason is that "not
+significant" and "equal" are different claims, and only the first is supported — the two v1
+notes cited in §4.1 both had to say so about a tie the reader would otherwise read as a null
+result.
+These are report-time figures computed from the same per-item differences as the tests; they
+are not produced by `--compare` today.
 
 ## 6. "Composite score" names two different things — proposed fix
 

--- a/docs/adr/0020-prior-work-re-analysis-convention.md
+++ b/docs/adr/0020-prior-work-re-analysis-convention.md
@@ -26,6 +26,17 @@ v1 per-item artifacts **may** be re-analyzed with v2's committed statistical pro
    the note, since v1 artifacts carry no commit SHA.
 3. **Alignment is stated**: how per-item rows of the compared runs were paired (key and
    order), because bootstrap CI digits are alignment-dependent in the 3rd–4th decimal.
+
+   *Note 2026-08-20 (from `docs/analysis/2026-08-20-v1-pool-size-significance.md`, PR #35):*
+   an id or question-text key is preferred, but where a v1 artifact has neither — no
+   `item_id`, and question texts that are not unique — **positional alignment in v1 file
+   order is the accepted fallback**, under both preconditions, both verified and reported:
+   (a) the per-item sequences of *every* compared file are identical **including order**, and
+   (b) for every matched row, the alignment field (normalized question) **and** the gold
+   (`gold_steps`) are asserted equal between the two files. Without (a) and (b) positional
+   alignment silently compares different items, so a note that uses it states that it did and
+   states the check. (The pool-size note hit exactly this: one eval question appears twice
+   with identical gold, so a text key is not unique across its 750 rows.)
 4. **A machine-readable JSON companion** sits beside the note carrying every reported
    statistic and the inputs' hashes — statistics only, never dataset content.
 5. **The no-SHA caveat leads the note**: results are citable *prior work*, never v2

--- a/docs/analysis/2026-08-20-v1-pool-size-significance.json
+++ b/docs/analysis/2026-08-20-v1-pool-size-significance.json
@@ -1,0 +1,27938 @@
+{
+ "schema": "v1-pool-size-significance-analysis/1",
+ "companion_note": "docs/analysis/2026-08-20-v1-pool-size-significance.md",
+ "generated_utc": "2026-08-20T08:50:53Z",
+ "contents": "statistics only \u2014 no dataset content (no questions, no steps, no predictions, no per-item rows)",
+ "prior_work_caveat": "Every input is a v1 artifact from /cta/users/fyilmaz/Thesis---QA (read-only, unmodified). v1's runs/ is gitignored and untracked (git ls-files runs/ returns 0), so these per-item files carry no commit SHA (ADR 0005 context; convention ADR 0020). These are citable prior-work results, not v2 experimental claims, and satisfy no part of Gate 2. No experiment was run, so there is no experiments/log.md entry.",
+ "question": "Did v1's few-shot pool SIZE measurably affect decomposition quality? (unmeasured half of issue #6 item 4)",
+ "protocol": {
+  "source_of_truth": "scripts/musique_decompositions_evaluator.py --compare (v2, committed); ADR 0009 as amended 2026-08-20 (paired bootstrap + exact McNemar, paired t-test alongside per issue #30)",
+  "bootstrap_iterations": 10000,
+  "bootstrap_chunk_size": 1000,
+  "alpha": 0.05,
+  "min_items_for_significance_claim": 30,
+  "seed": 42,
+  "rng": "numpy.random.default_rng, one index matrix applied to both systems",
+  "confidence_interval": "percentile interval of (system_a - system_b)",
+  "per_stratum_seeding": "each per-hop stratum bootstraps its own subset with the same seed",
+  "composite_score_weights": {
+   "step_f1_macro": 0.4,
+   "ordered_step_accuracy_macro": 0.3,
+   "reference_validity_micro": 0.2,
+   "step_count_error": 0.1
+  },
+  "composite_step_count_error_scale": 3.0,
+  "composite_weights_identical_in_v1": "Thesis---QA/scripts/musique_decompositions_evaluator.py:411-416",
+  "composite_no_ref_renorm": {
+   "what": "diagnostic constructed for this note, NOT a house metric: the composite with the reference_validity_micro term dropped and the remaining weights renormalized to sum to 1",
+   "weights": {
+    "step_f1_macro": 0.5000000000000001,
+    "ordered_step_accuracy_macro": 0.375,
+    "step_count_error": 0.12500000000000003
+   }
+  },
+  "t_test": "scipy.stats.ttest_rel (scipy 1.17.1), two-sided, over per-item differences; the composite and the composite_no_ref diagnostic have no per-item value (micro-rate and MAE terms), so neither a t-test nor McNemar is reported for them",
+  "mcnemar": "two-sided exact McNemar on discordant pairs, via the committed _mcnemar_exact_p",
+  "multiplicity": "no correction in the headline (ADR 0009); Holm-Bonferroni computed within the stated families and reported alongside",
+  "harness_not_committed": "analyst output is analysis, not code; the harness imports v2's _statistic_arrays/_paired_bootstrap/_mcnemar_exact_p and re-implements only alignment plus the extra bootstrap columns"
+ },
+ "inputs": {
+  "v1_repo": "/cta/users/fyilmaz/Thesis---QA",
+  "v1_head_commit": "a020fd6",
+  "v1_head_does_not_pin_these_files": "runs/ is gitignored and untracked in v1; git ls-files runs/ returns 0 files",
+  "statistics_computed_from": "the 33 eval_per_item.json files listed below; no statistic in this file is computed from any aggregate CSV",
+  "per_item_files": {
+   "size1000_balanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "ee64da7b422fb297e5c38cfdd00b1fad82b937158d1683958124e3dc03fd21cc",
+    "mtime_utc": "2026-04-20T18:24:03Z"
+   },
+   "size1000_balanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "43231fdbb102fbb90ac71b544a1917e02f0ae6877d6fe7f0c980d3fbe02344ba",
+    "mtime_utc": "2026-04-20T18:49:53Z"
+   },
+   "size1000_balanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "5792aa706a922eb09ed96a793debb1cff8caa8d2846c314bd8e22bfc414116e7",
+    "mtime_utc": "2026-04-20T19:16:08Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "2e5530974c1e5d62b135ac21ca4b742a06e1b1a3f795ab89f5e042a04aee2c3c",
+    "mtime_utc": "2026-04-20T19:41:03Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "f911796f96a4851ca0508b49b692fe27bea52bb6723913f2dbc73734644c58ae",
+    "mtime_utc": "2026-04-20T20:05:27Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "4c3fc18b7138f33a8c10997b44b0f9d408f6f7bd8c091c6441728163aee5ac23",
+    "mtime_utc": "2026-04-20T20:30:46Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "7144c097bfe47250c5f538b176bbc543606bc4eddc89d1f7cc0cfb16f8b8f523",
+    "mtime_utc": "2026-04-20T02:32:52Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "e353c76ae359e8ad3af38ab279e00c0c5d3edb151994b461332a86b90ef7fbf1",
+    "mtime_utc": "2026-04-20T02:58:15Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "9547be04e6eae412fdd3eb4aee6872a9e64c00c47e2d39910909e414eea79069",
+    "mtime_utc": "2026-04-20T02:05:33Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "648a213520d07dfbc4a84d8960e43de8a10882e5fa62c6f34ee15469823d8269",
+    "mtime_utc": "2026-04-20T03:23:36Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "bd2f1d6fd49901bcb9e2d3bff0c3ca0556aa2ebf641317d5eb696115f2f2baac",
+    "mtime_utc": "2026-04-20T03:47:31Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "c1e6f975938596db9f7b3d14222110ee7466defb3ba5dc2a7d5759e7fe79cab6",
+    "mtime_utc": "2026-04-20T04:12:07Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "70e58b63076cd33dc16df27f9a9046d8971bf9b59cce2830a12023eb62248415",
+    "mtime_utc": "2026-04-20T20:57:38Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "5fad3c5f009ec09a0a556b32b18766f4ed4fe84ac0d20c6f43f7bdc9a082fcac",
+    "mtime_utc": "2026-04-20T21:24:18Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "dc5abb6406e03bff23fa8fcbd26b155af11e9195fd399f152db84d6764cfccfc",
+    "mtime_utc": "2026-04-20T21:51:10Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "b2bfd5eda5d8a721d860f0b8969cee0da0ea572f9460a2e37a6730f28b574cb0",
+    "mtime_utc": "2026-04-20T04:37:19Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "b054f418dd52ba3484d44b45f123468026aafc4aa7c2714d780bf833fbed4ec3",
+    "mtime_utc": "2026-04-20T05:02:19Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "543f4cfc77c7863ab3afcee8ca0429012dcb61d9d2d710b8babe2d673d17f707",
+    "mtime_utc": "2026-04-20T05:27:50Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "e06ffc80a9c15be24ff7248712787292aba2809c4160b3af92d4543e4c0a1665",
+    "mtime_utc": "2026-04-20T05:53:28Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "fd64acc34395a0434b9c95fe3c9fa513ca923b66afdd270b1099969cba738f0e",
+    "mtime_utc": "2026-04-20T06:17:55Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "21fd8dd22295ddbead1f298aa5cf58e55174590de7c92fb9c2fce04bd048a18b",
+    "mtime_utc": "2026-04-20T06:42:23Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "a53aabd9f3ccb6a9107d64463533443d01fe33cb74786efb2d116635ae2a72bb",
+    "mtime_utc": "2026-04-20T07:07:32Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "3a0fb90b6f0c1ed798cf0c4aa0d121ce68b7c8d57ee28ca61727cd27c7ab62ce",
+    "mtime_utc": "2026-04-20T07:33:32Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "6ac7af550531c9a1d887d3049e6f6c13d088ccf8d8ced0abc9b200d5af1ed684",
+    "mtime_utc": "2026-04-20T07:58:55Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "1ab9623bce72b4b2f7e04f09f719dae0093087008074ffc6b56c22cc5e0c2a55",
+    "mtime_utc": "2026-04-20T08:23:25Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "5444b2e2a60e701598d5d6c67344873e0d729033cf8fb46452b0612dc1fc8af9",
+    "mtime_utc": "2026-04-20T08:48:29Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "18451b8cfe7b1f74f07c85b1f7e73e6af56b07a0ebd19f1214f03f855912d3a0",
+    "mtime_utc": "2026-04-20T09:12:47Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__raw/eval_per_item.json",
+    "sha256": "0c5bf23b087a077102313430b2fc85cc9c9adf615b3bcee58ac7887a4202c60c",
+    "mtime_utc": "2026-04-20T09:38:25Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__typed/eval_per_item.json",
+    "sha256": "2a2dd118ee3293408d0d1ce2e3a848cebc044c98463bec9dd3a01c6a9a1929c0",
+    "mtime_utc": "2026-04-20T10:04:36Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__uniform/eval_per_item.json",
+    "sha256": "18fcac5e02139f6047f0922ae39924b97b75de063deee10cf21f71b99a9c326f",
+    "mtime_utc": "2026-04-20T10:29:56Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__raw/eval_per_item.json",
+    "sha256": "fb5399e1ddc2d4e71bf627eddca8616aa2436869734e99e37478a0db0e6e417f",
+    "mtime_utc": "2026-04-20T10:54:19Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__typed/eval_per_item.json",
+    "sha256": "a0df3f17bbd7dc2f716494736919e7c02181e5a688a69f222a1cd974781d1980",
+    "mtime_utc": "2026-04-20T11:19:06Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_per_item.json",
+    "sha256": "c5ccdb504f2398e9368506b9bce5f248dac63f3996690589750526f7e0d279f8",
+    "mtime_utc": "2026-04-20T11:44:19Z"
+   }
+  },
+  "metrics_files_used_for_crosscheck_only": {
+   "size1000_balanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__raw/eval_metrics.json",
+    "sha256": "fb198cf75b95a689af39e3dd96aebcbe480f71bc0ac6ef1fe2d06c69bb0dba7f",
+    "mtime_utc": "2026-04-20T18:24:03Z"
+   },
+   "size1000_balanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__typed/eval_metrics.json",
+    "sha256": "7dfd962d78c385563e3746c43e469d253172bb2a16f9cf00110c7c690f6ad270",
+    "mtime_utc": "2026-04-20T18:49:53Z"
+   },
+   "size1000_balanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__uniform/eval_metrics.json",
+    "sha256": "500cd17d4485b3aaf8dc0a1791749f0cb04d0f2dfc8977f3008382ba7abb07f0",
+    "mtime_utc": "2026-04-20T19:16:08Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__raw/eval_metrics.json",
+    "sha256": "b536fde6d8470a3ed884acdacf0177412cbeaaa7c3f33706a730af07ff5a9dbf",
+    "mtime_utc": "2026-04-20T19:41:03Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__typed/eval_metrics.json",
+    "sha256": "5603600a05a24bf48a3699eb0cb4bacebe24fd7704e2ef04bf2ffb010cff7480",
+    "mtime_utc": "2026-04-20T20:05:27Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__uniform/eval_metrics.json",
+    "sha256": "9afae2123336b1437b985d5fa6c355536c4c75ca4d0279a2413c0289d8224d67",
+    "mtime_utc": "2026-04-20T20:30:46Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__raw/eval_metrics.json",
+    "sha256": "d6f798329aed5d18997e1894e6586a664bf9c8f223aca977aee6ef77803abe3b",
+    "mtime_utc": "2026-04-20T02:32:52Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__typed/eval_metrics.json",
+    "sha256": "8b88086d210cd9322037268b65123557306005e85a2e8b73b6374eec5e8a7ead",
+    "mtime_utc": "2026-04-20T02:58:15Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__uniform/eval_metrics.json",
+    "sha256": "3310c9b5e0cb74f629c4a8dbc3d7077c9c91c59721bd470de92640dd557c673f",
+    "mtime_utc": "2026-04-20T02:05:33Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__raw/eval_metrics.json",
+    "sha256": "a949eef9d2636bb8f26586584532dd6505044cea2067c6c4e99ab59d3ef3cba3",
+    "mtime_utc": "2026-04-20T03:23:36Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__typed/eval_metrics.json",
+    "sha256": "f41e72e8fb400b9c0592fd477ef574cb224479a181b87c000302bcaf30c8fea3",
+    "mtime_utc": "2026-04-20T03:47:31Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_metrics.json",
+    "sha256": "883d6e3e5e0b8796264c27dab3b4e87af70a5dc2494923af43cee7211b68f7cd",
+    "mtime_utc": "2026-04-20T04:12:07Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__raw/eval_metrics.json",
+    "sha256": "612b38b28b4bd83292d733ff60122142cd948447d1c3cb75722ffb1f38d95ff7",
+    "mtime_utc": "2026-04-20T20:57:38Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__typed/eval_metrics.json",
+    "sha256": "5b630783e901f5c8154c9dcdf9c381cc18871e9d4ba1d0076b96594d7a64c7d2",
+    "mtime_utc": "2026-04-20T21:24:18Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__uniform/eval_metrics.json",
+    "sha256": "ac81be8f5bf6a56bb08dd0004e4257205be18373d0e26957ad16c5bab46fc8db",
+    "mtime_utc": "2026-04-20T21:51:10Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__raw/eval_metrics.json",
+    "sha256": "0c3007297211341f4cc2a05ee21b5729a9f0d7f85e952f940e70c4facba111a5",
+    "mtime_utc": "2026-04-20T04:37:19Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__typed/eval_metrics.json",
+    "sha256": "abaa54c96c36418141c3da0d4a92d91bcf2892fae91eccd395d2d7bc9e2cfb7f",
+    "mtime_utc": "2026-04-20T05:02:19Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__uniform/eval_metrics.json",
+    "sha256": "82b51dec30d32ade9ea4797b04419082bc4c559507192c253ae324fb671c74ef",
+    "mtime_utc": "2026-04-20T05:27:50Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__raw/eval_metrics.json",
+    "sha256": "5449472211927c4a93c72562362e1c5e95bb01877e7bd639b033e2ce8ea08e6b",
+    "mtime_utc": "2026-04-20T05:53:28Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__typed/eval_metrics.json",
+    "sha256": "f34101b307def0fcbef831202079c4f3cf5c32e9b7f7eb478f5b6019685c1af9",
+    "mtime_utc": "2026-04-20T06:17:55Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_metrics.json",
+    "sha256": "ed189391773499228a90790b5afe31143fc67fe7aad06dfb34900abfe335b90d",
+    "mtime_utc": "2026-04-20T06:42:23Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__raw/eval_metrics.json",
+    "sha256": "bf899ccfda4ebdcb914994a126722026809834ff4b874375f03a7f287f4960b6",
+    "mtime_utc": "2026-04-20T07:07:32Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__typed/eval_metrics.json",
+    "sha256": "b02cf5d17f63b1a6e4714b06b66a19e6a5a1a21aa3bcef75ee1ba2376e87d6bc",
+    "mtime_utc": "2026-04-20T07:33:32Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__uniform/eval_metrics.json",
+    "sha256": "2fbb597d62c288b401c969dc4c7c693f21a67d0971231d536c01c2787b3ce194",
+    "mtime_utc": "2026-04-20T07:58:55Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__raw/eval_metrics.json",
+    "sha256": "3c6d2015e1ba5fb7b19bb4e7caac032400e3e87523643a89fefa6a63959bb36c",
+    "mtime_utc": "2026-04-20T08:23:25Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__typed/eval_metrics.json",
+    "sha256": "1e718c78880bbeafe08323c810d3d7fa4fa9aaa4bf9a80b15acd19c4874baa92",
+    "mtime_utc": "2026-04-20T08:48:29Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_metrics.json",
+    "sha256": "704677ed05b1019252271503b9018192002bfd3ee55e89686af739ddf84bbcbb",
+    "mtime_utc": "2026-04-20T09:12:47Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__raw/eval_metrics.json",
+    "sha256": "9bf824cfc6e0573e6e879d12f9a4db7a5c7b9e510d256e431e7c03829a916ebf",
+    "mtime_utc": "2026-04-20T09:38:25Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__typed/eval_metrics.json",
+    "sha256": "f9791c4732697b518d2a7ba529df8590cbe4919e8228d75743eae7b7665a518e",
+    "mtime_utc": "2026-04-20T10:04:36Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__uniform/eval_metrics.json",
+    "sha256": "92e700a1168556e702ece5081e648af7050cdeafa1cd289cd55e03b9e07b91ff",
+    "mtime_utc": "2026-04-20T10:29:56Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__raw/eval_metrics.json",
+    "sha256": "7bda47784533affe5ba7cfea0d09ae487dc81f3f254068ae90382536401e85e8",
+    "mtime_utc": "2026-04-20T10:54:19Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__typed/eval_metrics.json",
+    "sha256": "b55064772eead106c7bc9db827938e63ef0f954c25de951f75edc046b0697664",
+    "mtime_utc": "2026-04-20T11:19:06Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_metrics.json",
+    "sha256": "258906cfafcd88efd5aadc382d257b9a396d38d7c82a63155decb8e331e7768d",
+    "mtime_utc": "2026-04-20T11:44:19Z"
+   }
+  },
+  "eval_config_files_used_for_provenance_only": {
+   "size1000_balanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__raw/eval_config.json",
+    "sha256": "fdf75cf5c1e963b351e336d64a0d23acc0402a8ec1b5c9cbeb8fef0f2fe839a1",
+    "mtime_utc": "2026-04-20T18:24:03Z"
+   },
+   "size1000_balanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__typed/eval_config.json",
+    "sha256": "9490d9d5259a39a2095a3b84757d85739d4796e169b8deb896213d98507432ab",
+    "mtime_utc": "2026-04-20T18:49:53Z"
+   },
+   "size1000_balanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__uniform/eval_config.json",
+    "sha256": "dfe165a8baa510997f9646192f570d5731d905889b6226b00e68313d63fb21c7",
+    "mtime_utc": "2026-04-20T19:16:08Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__raw/eval_config.json",
+    "sha256": "dee766d5919c015ec087bbb7625329e4fe4b185ce4e16af25f7eb99752403ce0",
+    "mtime_utc": "2026-04-20T19:41:03Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__typed/eval_config.json",
+    "sha256": "4de39732472c44078f9fbcf1a3a4769addfcc432ea824b8b78a5b047b9f9f5a0",
+    "mtime_utc": "2026-04-20T20:05:27Z"
+   },
+   "size1000_balanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_plus_ce__uniform/eval_config.json",
+    "sha256": "7debad8614635af20a407d9375297bfb4adc2995eba4d72b654fdf4ccfc90be9",
+    "mtime_utc": "2026-04-20T20:30:46Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__raw/eval_config.json",
+    "sha256": "3d4016fd59ac24e1574b38f3fec12586a12c19bd04b7790f3a76f85958aebe64",
+    "mtime_utc": "2026-04-20T02:32:52Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__typed/eval_config.json",
+    "sha256": "5e2af8b60ded13e638080c67af93dc6478352113020657cac8bf36039a7f92b7",
+    "mtime_utc": "2026-04-20T02:58:15Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_only__uniform/eval_config.json",
+    "sha256": "84df571a776cfd4d44a89f9c63b7cedc11fc8a180119f426d565ac1bf6cd5c66",
+    "mtime_utc": "2026-04-20T02:05:33Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__raw/eval_config.json",
+    "sha256": "b48d08be340c8478b80dcf3679b7fe827836902c5af0b0b7c7de881f86e778e1",
+    "mtime_utc": "2026-04-20T03:23:36Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__typed/eval_config.json",
+    "sha256": "15d1e74b93517dff224924879ad46450605d003e8c2ab8faa7c406b2e42345fb",
+    "mtime_utc": "2026-04-20T03:47:31Z"
+   },
+   "size1000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_config.json",
+    "sha256": "16c484b509d0f8a2e7bdb5ce5874c321dd9a538b29af12eff7854cec8c3b4673",
+    "mtime_utc": "2026-04-20T04:12:07Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__raw/eval_config.json",
+    "sha256": "9ca32e49efed7a24f50afb4155cc119f8a4513949b2e9e3fda43fac1e4ce2993",
+    "mtime_utc": "2026-04-20T20:57:38Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__typed/eval_config.json",
+    "sha256": "f52c6c9f19392ca8c6bf972a07714697ee6323dd7cf98317066899f620572e3e",
+    "mtime_utc": "2026-04-20T21:24:18Z"
+   },
+   "size2000_balanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_balanced_trial0__biencoder_only__uniform/eval_config.json",
+    "sha256": "4aaf831ff45b88489a96a3a4e1f4fb4bbbc45d0454c48f41b67a17720fd72a9f",
+    "mtime_utc": "2026-04-20T21:51:10Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__raw/eval_config.json",
+    "sha256": "d8319f1755e5707332dc0c7e8fbd94324d9fd6c26d51c6fda8c7911d24fe86eb",
+    "mtime_utc": "2026-04-20T04:37:19Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__typed/eval_config.json",
+    "sha256": "2833da129a244f5679fbd0d837fdafe3b0a041c55e77bc446988a97bf21ad2e2",
+    "mtime_utc": "2026-04-20T05:02:19Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_only__uniform/eval_config.json",
+    "sha256": "2cc9c402c608ccecf049f581860728f2a4721584bfc697ccac70f45c92f692b0",
+    "mtime_utc": "2026-04-20T05:27:50Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__raw/eval_config.json",
+    "sha256": "f5931ba322311bcd6e65148c75f5e2eccd51f58c4be2559afbc51fab546443a9",
+    "mtime_utc": "2026-04-20T05:53:28Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__typed/eval_config.json",
+    "sha256": "1602d33e95bd2fbe8b31f0248b2564661be835f5b2359f1a62b65abff874f311",
+    "mtime_utc": "2026-04-20T06:17:55Z"
+   },
+   "size2000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size2000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_config.json",
+    "sha256": "53cda89320bc3e299e6003a67ace07cfc71b8fc8e74bafb63aee71ce571c317f",
+    "mtime_utc": "2026-04-20T06:42:23Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__raw/eval_config.json",
+    "sha256": "d408a40d8ced1fa4e7999d84f18b23e1229785de72eadbee8b8c137d00e71f5f",
+    "mtime_utc": "2026-04-20T07:07:32Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__typed/eval_config.json",
+    "sha256": "3ab427ab3247ade955be94b9a3626d4c72ccbb77e5381ccc7a9eccae2a1d39fc",
+    "mtime_utc": "2026-04-20T07:33:32Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_only__uniform/eval_config.json",
+    "sha256": "4dfadeff6295d5b4f408d3ac0c72412295054cd43bc98eb2801b46d7dda92e40",
+    "mtime_utc": "2026-04-20T07:58:55Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__raw/eval_config.json",
+    "sha256": "a635edf0cde0713237dd3c512dda4f85f1187ff2be48259c66f227e0eaff8b26",
+    "mtime_utc": "2026-04-20T08:23:25Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__typed/eval_config.json",
+    "sha256": "df7e14fb54d2ff538e7e35478bb02f78e1984483001cbdeea34d955e646e8c40",
+    "mtime_utc": "2026-04-20T08:48:29Z"
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size4000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_config.json",
+    "sha256": "8003bc9d43f06ff6df04b1d463166c20283551dc74e28a1bdfb1e7a5257d4f49",
+    "mtime_utc": "2026-04-20T09:12:47Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__raw/eval_config.json",
+    "sha256": "40f2a63e9571cd149c63c40797b6e42a9865b5c38419cdb0d66c8c2683abc649",
+    "mtime_utc": "2026-04-20T09:38:25Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__typed/eval_config.json",
+    "sha256": "34cc4d7a867d450626366723b796c39472a0293b82c8513b00d0fd3e491d01bd",
+    "mtime_utc": "2026-04-20T10:04:36Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_only__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_only__uniform/eval_config.json",
+    "sha256": "3763b8c6b4fc3a23daba9bdec9f4faeaf97d404c6ec63e926b2b0f6c04bc5913",
+    "mtime_utc": "2026-04-20T10:29:56Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__raw": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__raw/eval_config.json",
+    "sha256": "ea452ee3cd37152c3c6063745a22cff7a21d997df1bd84e772ef37136236ebfd",
+    "mtime_utc": "2026-04-20T10:54:19Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__typed": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__typed/eval_config.json",
+    "sha256": "9707e22ef22aacfee5fbaba9ba821f723b96f099a4a61ac7d2775a9e23f7d500",
+    "mtime_utc": "2026-04-20T11:19:06Z"
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size8000_imbalanced_trial0__biencoder_plus_ce__uniform/eval_config.json",
+    "sha256": "dc4e5caa47b0dfa3c4e8c8fbdf4df356b860512fbca3e84c4e333f78f52dfa88",
+    "mtime_utc": "2026-04-20T11:44:19Z"
+   }
+  },
+  "pool_stats_files_used_for_composition_only": {
+   "size1000_balanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size1000_balanced_trial0_poolseed42/stats.json",
+    "sha256": "73956d0eace09916546597c04bfb0ec68865f5b787c2dfe3b88b29aa3b98c003",
+    "mtime_utc": "2026-04-20T17:56:47Z"
+   },
+   "size1000_imbalanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size1000_imbalanced_trial0_poolseed42/stats.json",
+    "sha256": "84c550bc8d9587b993cd8d5deb010202706106b061a533e6bce8410b802f7569",
+    "mtime_utc": "2026-04-20T01:37:46Z"
+   },
+   "size2000_balanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size2000_balanced_trial0_poolseed42/stats.json",
+    "sha256": "d933328f3fa4fa5dac38e04f3fdfcd6721557fbfbb54f8d6aa6931e29c3fde38",
+    "mtime_utc": "2026-04-20T20:30:46Z"
+   },
+   "size2000_imbalanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size2000_imbalanced_trial0_poolseed42/stats.json",
+    "sha256": "f7d032ccc9bdf7e74804b12e8a929e65b51c1aa2c7cdeee213cb8b915b27e7aa",
+    "mtime_utc": "2026-04-20T04:12:07Z"
+   },
+   "size4000_imbalanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size4000_imbalanced_trial0_poolseed42/stats.json",
+    "sha256": "83344565a620d6c9417635f5698cf93b2f9e950980d1a1ca93e049471d36a73d",
+    "mtime_utc": "2026-04-20T06:42:23Z"
+   },
+   "size8000_imbalanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size8000_imbalanced_trial0_poolseed42/stats.json",
+    "sha256": "6bfa4d2f6affa00f1009b7a1cbd3881ef89516eb6cff503646cf3340fa4759f5",
+    "mtime_utc": "2026-04-20T09:12:47Z"
+   }
+  },
+  "eval_sample": {
+   "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/dev_sample/dev_sample_250per_hop_seed42.jsonl",
+   "sha256": "3ec876260e74c2748a31a68fbdc9cb54cbec56faf06ec5d2d7e42e340b2e6af9",
+   "mtime_utc": "2026-04-20T01:37:46Z"
+  },
+  "eval_sample_stats": {
+   "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/dev_sample/dev_sample_250per_hop_seed42_stats.json",
+   "sha256": "8be5dfb55c13739b091594c9f14d69bf219ba75ed853139e17582fbf3066facb",
+   "mtime_utc": "2026-04-20T01:37:46Z"
+  },
+  "summary_csv_crosscheck_only": {
+   "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/summary/all_runs.csv",
+   "sha256": "89c5e923ddbb2a8737c12bda160e12b7df7d4f1ed7add3767604b6419ba51e6e",
+   "mtime_utc": "2026-04-20T21:51:10Z"
+  },
+  "handoff_summary_csv_crosscheck_only": {
+   "path": "/cta/users/fyilmaz/Thesis---QA/handoff/results_analysis/pool_sweep_summary/all_runs.csv",
+   "sha256": "89c5e923ddbb2a8737c12bda160e12b7df7d4f1ed7add3767604b6419ba51e6e",
+   "mtime_utc": "2026-04-20T21:51:10Z"
+  },
+  "handoff_summary_csv_is_byte_identical_to_runs_copy": true
+ },
+ "grid": {
+  "requested_grid": "size{1000,2000,4000,8000}_{balanced,imbalanced}_trial0__{biencoder_only,biencoder_plus_ce}__{raw,typed,uniform}",
+  "full_grid_size": 48,
+  "cells_present": 33,
+  "cells_absent": [
+   "size2000_balanced_trial0__biencoder_plus_ce__raw",
+   "size2000_balanced_trial0__biencoder_plus_ce__typed",
+   "size2000_balanced_trial0__biencoder_plus_ce__uniform",
+   "size4000_balanced_trial0__biencoder_only__raw",
+   "size4000_balanced_trial0__biencoder_only__typed",
+   "size4000_balanced_trial0__biencoder_only__uniform",
+   "size4000_balanced_trial0__biencoder_plus_ce__raw",
+   "size4000_balanced_trial0__biencoder_plus_ce__typed",
+   "size4000_balanced_trial0__biencoder_plus_ce__uniform",
+   "size8000_balanced_trial0__biencoder_only__raw",
+   "size8000_balanced_trial0__biencoder_only__typed",
+   "size8000_balanced_trial0__biencoder_only__uniform",
+   "size8000_balanced_trial0__biencoder_plus_ce__raw",
+   "size8000_balanced_trial0__biencoder_plus_ce__typed",
+   "size8000_balanced_trial0__biencoder_plus_ce__uniform"
+  ],
+  "balanced_arm": "exists at sizes 1000 (both retrieval variants) and 2000 (biencoder_only only)",
+  "imbalanced_arm": "complete: all 4 sizes x both retrieval variants x 3 mask modes",
+  "trials": "trial0 only; no repeated trial exists, so no within-cell seed variance is measurable",
+  "rows_per_cell": 750
+ },
+ "alignment": {
+  "method": "positional (row index), verified row-by-row",
+  "key_verified_per_row": "normalized question text (strip, lowercase, collapse whitespace) AND json-serialized gold_steps asserted equal between the two cells of every pair, for all 750 rows of all 36 pairs",
+  "why_not_id_based": "v1 per-item files are bare JSON lists with no item_id; one normalized question appears twice (rows 370 and 376, identical gold), so a question-text key is not unique and v2's --compare would abort on these files",
+  "question_sequence_identical_across_all_33_cells": true,
+  "order_included": true,
+  "gold_steps_identical_across_all_33_cells": true,
+  "gold_hop_count_identical_across_all_33_cells": true,
+  "matches_committed_eval_sample": {
+   "file": "runs/pool_sweep/dev_sample/dev_sample_250per_hop_seed42.jsonl",
+   "question_sequence_identical_order_included": true,
+   "n": 750
+  },
+  "duplicate_normalized_questions": 1,
+  "duplicate_rows": [
+   370,
+   376
+  ],
+  "duplicate_gold_identical": true,
+  "hop_distribution": {
+   "2": 250,
+   "3": 250,
+   "4": 250
+  },
+  "deviation_from_v2_protocol": "v2's --compare aligns by item_id; positional alignment is a documented deviation forced by v1's file format, safe here only because the 33 sequences are literally identical"
+ },
+ "aggregate_crosscheck": {
+  "recomputed_from_per_item_vs_committed_eval_metrics_json": {
+   "cells": 33,
+   "max_abs_delta": 1.2212453270876722e-15,
+   "fields": [
+    "exact_match_rate",
+    "step_f1_macro",
+    "ordered_step_accuracy_macro",
+    "rouge_l_f1_macro",
+    "hop_count_exact_match_rate",
+    "reference_validity_micro",
+    "step_count_abs_error_mae",
+    "composite_score"
+   ]
+  },
+  "recomputed_vs_v1_summary_csv": {
+   "cells": 33,
+   "max_abs_delta": 1.2212453270876722e-15,
+   "disagreements": 0,
+   "note": "all_runs.csv agrees with the per-item recomputation to floating-point noise; it is used only as a cross-check"
+  },
+  "v1_prior_work_md_per_size_mean_composite_claim": {
+   "quoted_in_v2_docs_prior_work_md": {
+    "1000": 0.232,
+    "2000": 0.271,
+    "4000": 0.311,
+    "8000": 0.23
+   },
+   "recomputed_all_cells": {
+    "1000": 0.2322,
+    "2000": 0.2707,
+    "4000": 0.3105,
+    "8000": 0.2295
+   },
+   "agrees": true
+  }
+ },
+ "pool_composition": {
+  "definition": {
+   "balanced": "equal 2/3/4-hop exemplars in the pool",
+   "imbalanced": "the MuSiQue train hop distribution (input buckets 2hop 14376 / 3hop 4387 / 4hop 1175)"
+  },
+  "pools": {
+   "size1000_balanced_trial0_poolseed42": {
+    "size": 1000,
+    "balance": "balanced",
+    "seed": 42,
+    "sampled_bucket_counts": {
+     "2hop": 334,
+     "3hop": 333,
+     "4hop": 333
+    }
+   },
+   "size1000_imbalanced_trial0_poolseed42": {
+    "size": 1000,
+    "balance": "imbalanced",
+    "seed": 42,
+    "sampled_bucket_counts": {
+     "2hop": 709,
+     "3hop": 210,
+     "4hop": 81
+    }
+   },
+   "size2000_balanced_trial0_poolseed42": {
+    "size": 2000,
+    "balance": "balanced",
+    "seed": 42,
+    "sampled_bucket_counts": {
+     "2hop": 667,
+     "3hop": 667,
+     "4hop": 666
+    }
+   },
+   "size2000_imbalanced_trial0_poolseed42": {
+    "size": 2000,
+    "balance": "imbalanced",
+    "seed": 42,
+    "sampled_bucket_counts": {
+     "2hop": 1461,
+     "3hop": 413,
+     "4hop": 126
+    }
+   },
+   "size4000_imbalanced_trial0_poolseed42": {
+    "size": 4000,
+    "balance": "imbalanced",
+    "seed": 42,
+    "sampled_bucket_counts": {
+     "2hop": 2889,
+     "3hop": 866,
+     "4hop": 245
+    }
+   },
+   "size8000_imbalanced_trial0_poolseed42": {
+    "size": 8000,
+    "balance": "imbalanced",
+    "seed": 42,
+    "sampled_bucket_counts": {
+     "2hop": 5788,
+     "3hop": 1717,
+     "4hop": 495
+    }
+   }
+  },
+  "eval_set_is_hop_balanced": "the 750-item eval sample is 250/250/250, so an imbalanced pool holds proportionally fewer 3/4-hop exemplars than the eval set asks for",
+  "nesting_by_pool_item_id": {
+   "imbalanced_1000_subset_of_2000": {
+    "is_subset": true,
+    "overlap": "1000/1000"
+   },
+   "imbalanced_2000_subset_of_4000": {
+    "is_subset": true,
+    "overlap": "2000/2000"
+   },
+   "imbalanced_4000_subset_of_8000": {
+    "is_subset": false,
+    "overlap": "3484/4000"
+   },
+   "imbalanced_1000_subset_of_8000": {
+    "is_subset": false,
+    "overlap": "982/1000"
+   },
+   "balanced_1000_subset_of_2000": {
+    "is_subset": false,
+    "overlap": "682/1000"
+   },
+   "size1000_balanced_vs_imbalanced_overlap": "50/1000",
+   "size2000_balanced_vs_imbalanced_overlap": "198/2000"
+  },
+  "consequence": "1000/2000/4000 imbalanced are strictly nested, so those contrasts add exemplars and hold the existing ones; the 8000 pool is a different draw (87% of the 4000 pool survives into it), so 4000-vs-8000 and 1000-vs-8000 change which exemplars are available as well as how many"
+ },
+ "validation_against_committed_paired_bootstrap": [
+  {
+   "pair": "size2000_balanced_trial0__biencoder_only__raw vs size1000_balanced_trial0__biencoder_only__raw",
+   "fields_checked": 12,
+   "bit_identical": true,
+   "tolerance": "abs_tol=0 (exact float equality)"
+  },
+  {
+   "pair": "size1000_balanced_trial0__biencoder_only__raw vs size1000_imbalanced_trial0__biencoder_only__raw",
+   "fields_checked": 12,
+   "bit_identical": true,
+   "tolerance": "abs_tol=0 (exact float equality)"
+  },
+  {
+   "pair": "size8000_imbalanced_trial0__biencoder_only__raw vs size4000_imbalanced_trial0__biencoder_only__raw",
+   "fields_checked": 12,
+   "bit_identical": true,
+   "tolerance": "abs_tol=0 (exact float equality)"
+  }
+ ],
+ "per_cell_recomputed_aggregates": {
+  "size1000_balanced_trial0__biencoder_only__raw": {
+   "exact_match_rate": 0.03866666666666667,
+   "step_f1_macro": 0.16133865393865393,
+   "ordered_step_accuracy_macro": 0.14889870129870128,
+   "rouge_l_f1_macro": 0.5237267087627537,
+   "hop_count_exact_match_rate": 0.448,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.9893333333333333,
+   "composite_score": 0.1762272941872942,
+   "composite_no_ref_renorm": 0.22028411773411774,
+   "reference_total_count": 9,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 1
+  },
+  "size1000_balanced_trial0__biencoder_only__typed": {
+   "exact_match_rate": 0.04133333333333333,
+   "step_f1_macro": 0.16963798053798054,
+   "ordered_step_accuracy_macro": 0.1504810152810153,
+   "rouge_l_f1_macro": 0.5223531262239298,
+   "hop_count_exact_match_rate": 0.43733333333333335,
+   "reference_validity_micro": 0.3333333333333333,
+   "step_count_abs_error_mae": 1.0173333333333334,
+   "composite_score": 0.24575505235505238,
+   "composite_no_ref_renorm": 0.22386048211048215,
+   "reference_total_count": 6,
+   "reference_valid_count": 2,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size1000_balanced_trial0__biencoder_only__uniform": {
+   "exact_match_rate": 0.044,
+   "step_f1_macro": 0.16026169386169387,
+   "ordered_step_accuracy_macro": 0.14410089540089538,
+   "rouge_l_f1_macro": 0.5131405987843701,
+   "hop_count_exact_match_rate": 0.43466666666666665,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 1.088,
+   "composite_score": 0.1710682794982795,
+   "composite_no_ref_renorm": 0.21383534937284937,
+   "reference_total_count": 2,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size1000_balanced_trial0__biencoder_plus_ce__raw": {
+   "exact_match_rate": 0.03333333333333333,
+   "step_f1_macro": 0.1732798460798461,
+   "ordered_step_accuracy_macro": 0.15338015873015873,
+   "rouge_l_f1_macro": 0.5316132147257072,
+   "hop_count_exact_match_rate": 0.44533333333333336,
+   "reference_validity_micro": 0.9090909090909091,
+   "step_count_abs_error_mae": 0.98,
+   "composite_score": 0.3644775012025012,
+   "composite_no_ref_renorm": 0.22832414923039926,
+   "reference_total_count": 11,
+   "reference_valid_count": 10,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size1000_balanced_trial0__biencoder_plus_ce__typed": {
+   "exact_match_rate": 0.037333333333333336,
+   "step_f1_macro": 0.18273849113849114,
+   "ordered_step_accuracy_macro": 0.1615867724867725,
+   "rouge_l_f1_macro": 0.5295583400541953,
+   "hop_count_exact_match_rate": 0.456,
+   "reference_validity_micro": 0.75,
+   "step_count_abs_error_mae": 0.9346666666666666,
+   "composite_score": 0.34041587264587264,
+   "composite_no_ref_renorm": 0.23801984080734087,
+   "reference_total_count": 4,
+   "reference_valid_count": 3,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size1000_balanced_trial0__biencoder_plus_ce__uniform": {
+   "exact_match_rate": 0.036,
+   "step_f1_macro": 0.1681929107929108,
+   "ordered_step_accuracy_macro": 0.1484761090761091,
+   "rouge_l_f1_macro": 0.5259928206019984,
+   "hop_count_exact_match_rate": 0.4226666666666667,
+   "reference_validity_micro": 0.13793103448275862,
+   "step_count_abs_error_mae": 1.0146666666666666,
+   "composite_score": 0.20558398171432654,
+   "composite_no_ref_renorm": 0.22249721852221854,
+   "reference_total_count": 29,
+   "reference_valid_count": 4,
+   "items_emitting_at_least_one_reference": 5
+  },
+  "size1000_imbalanced_trial0__biencoder_only__raw": {
+   "exact_match_rate": 0.030666666666666665,
+   "step_f1_macro": 0.1599082251082251,
+   "ordered_step_accuracy_macro": 0.1431714285714286,
+   "rouge_l_f1_macro": 0.5253321480880906,
+   "hop_count_exact_match_rate": 0.46266666666666667,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.8853333333333333,
+   "composite_score": 0.1774036075036075,
+   "composite_no_ref_renorm": 0.2217545093795094,
+   "reference_total_count": 2,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size1000_imbalanced_trial0__biencoder_only__typed": {
+   "exact_match_rate": 0.02666666666666667,
+   "step_f1_macro": 0.16706542825366355,
+   "ordered_step_accuracy_macro": 0.14791856661856662,
+   "rouge_l_f1_macro": 0.517633339818622,
+   "hop_count_exact_match_rate": 0.47333333333333333,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.9053333333333333,
+   "composite_score": 0.18102396350925765,
+   "composite_no_ref_renorm": 0.22627995438657209,
+   "reference_total_count": 8,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size1000_imbalanced_trial0__biencoder_only__uniform": {
+   "exact_match_rate": 0.032,
+   "step_f1_macro": 0.16287219914588336,
+   "ordered_step_accuracy_macro": 0.14818973544973546,
+   "rouge_l_f1_macro": 0.5193862670378518,
+   "hop_count_exact_match_rate": 0.444,
+   "reference_validity_micro": 0.3888888888888889,
+   "step_count_abs_error_mae": 1.0306666666666666,
+   "composite_score": 0.2530280225154962,
+   "composite_no_ref_renorm": 0.21906280592214808,
+   "reference_total_count": 18,
+   "reference_valid_count": 7,
+   "items_emitting_at_least_one_reference": 4
+  },
+  "size1000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "exact_match_rate": 0.034666666666666665,
+   "step_f1_macro": 0.17549110149110148,
+   "ordered_step_accuracy_macro": 0.16043398692810457,
+   "rouge_l_f1_macro": 0.5302035628451818,
+   "hop_count_exact_match_rate": 0.4786666666666667,
+   "reference_validity_micro": 0.14285714285714285,
+   "step_count_abs_error_mae": 0.8186666666666667,
+   "composite_score": 0.21960917635741162,
+   "composite_no_ref_renorm": 0.23879718473247882,
+   "reference_total_count": 7,
+   "reference_valid_count": 1,
+   "items_emitting_at_least_one_reference": 3
+  },
+  "size1000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "exact_match_rate": 0.032,
+   "step_f1_macro": 0.1817014541014541,
+   "ordered_step_accuracy_macro": 0.1630063492063492,
+   "rouge_l_f1_macro": 0.5375348919863999,
+   "hop_count_exact_match_rate": 0.5093333333333333,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.7946666666666666,
+   "composite_score": 0.19509359751359753,
+   "composite_no_ref_renorm": 0.24386699689199692,
+   "reference_total_count": 3,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size1000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "exact_match_rate": 0.03333333333333333,
+   "step_f1_macro": 0.17149318089318089,
+   "ordered_step_accuracy_macro": 0.15812698412698412,
+   "rouge_l_f1_macro": 0.5309588431125554,
+   "hop_count_exact_match_rate": 0.5333333333333333,
+   "reference_validity_micro": 0.3333333333333333,
+   "step_count_abs_error_mae": 0.7853333333333333,
+   "composite_score": 0.2565242564842565,
+   "composite_no_ref_renorm": 0.2373219872719873,
+   "reference_total_count": 3,
+   "reference_valid_count": 1,
+   "items_emitting_at_least_one_reference": 1
+  },
+  "size2000_balanced_trial0__biencoder_only__raw": {
+   "exact_match_rate": 0.037333333333333336,
+   "step_f1_macro": 0.16260299781631052,
+   "ordered_step_accuracy_macro": 0.14760017259429023,
+   "rouge_l_f1_macro": 0.519834172694174,
+   "hop_count_exact_match_rate": 0.43733333333333335,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 1.048,
+   "composite_score": 0.17438791757147798,
+   "composite_no_ref_renorm": 0.2179848969643475,
+   "reference_total_count": 1,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 1
+  },
+  "size2000_balanced_trial0__biencoder_only__typed": {
+   "exact_match_rate": 0.030666666666666665,
+   "step_f1_macro": 0.1654905353905354,
+   "ordered_step_accuracy_macro": 0.1437026455026455,
+   "rouge_l_f1_macro": 0.5173918350863802,
+   "hop_count_exact_match_rate": 0.4226666666666667,
+   "reference_validity_micro": 0.7142857142857143,
+   "step_count_abs_error_mae": 1.0493333333333332,
+   "composite_score": 0.31718637288637297,
+   "composite_no_ref_renorm": 0.2179115375365376,
+   "reference_total_count": 14,
+   "reference_valid_count": 10,
+   "items_emitting_at_least_one_reference": 4
+  },
+  "size2000_balanced_trial0__biencoder_only__uniform": {
+   "exact_match_rate": 0.03333333333333333,
+   "step_f1_macro": 0.15718394922307966,
+   "ordered_step_accuracy_macro": 0.13800283283967496,
+   "rouge_l_f1_macro": 0.5166398652512152,
+   "hop_count_exact_match_rate": 0.4146666666666667,
+   "reference_validity_micro": 1.0,
+   "step_count_abs_error_mae": 1.1333333333333333,
+   "composite_score": 0.3664966517633566,
+   "composite_no_ref_renorm": 0.20812081470419577,
+   "reference_total_count": 0,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 0
+  },
+  "size2000_imbalanced_trial0__biencoder_only__raw": {
+   "exact_match_rate": 0.04666666666666667,
+   "step_f1_macro": 0.17804892884892884,
+   "ordered_step_accuracy_macro": 0.1595999185999186,
+   "rouge_l_f1_macro": 0.5233271649996762,
+   "hop_count_exact_match_rate": 0.47333333333333333,
+   "reference_validity_micro": 1.0,
+   "step_count_abs_error_mae": 0.9146666666666666,
+   "composite_score": 0.38861065823065827,
+   "composite_no_ref_renorm": 0.23576332278832285,
+   "reference_total_count": 3,
+   "reference_valid_count": 3,
+   "items_emitting_at_least_one_reference": 1
+  },
+  "size2000_imbalanced_trial0__biencoder_only__typed": {
+   "exact_match_rate": 0.050666666666666665,
+   "step_f1_macro": 0.19121384541384542,
+   "ordered_step_accuracy_macro": 0.17263756613756615,
+   "rouge_l_f1_macro": 0.5310403311127952,
+   "hop_count_exact_match_rate": 0.468,
+   "reference_validity_micro": 0.125,
+   "step_count_abs_error_mae": 0.9333333333333333,
+   "composite_score": 0.2221656968956969,
+   "composite_no_ref_renorm": 0.24645712111962115,
+   "reference_total_count": 8,
+   "reference_valid_count": 1,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size2000_imbalanced_trial0__biencoder_only__uniform": {
+   "exact_match_rate": 0.037333333333333336,
+   "step_f1_macro": 0.17253788433788433,
+   "ordered_step_accuracy_macro": 0.1565830687830688,
+   "rouge_l_f1_macro": 0.5235959820198607,
+   "hop_count_exact_match_rate": 0.472,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.9746666666666667,
+   "composite_score": 0.1835011854811855,
+   "composite_no_ref_renorm": 0.22937648185148188,
+   "reference_total_count": 4,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 3
+  },
+  "size2000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "exact_match_rate": 0.037333333333333336,
+   "step_f1_macro": 0.17911729751729752,
+   "ordered_step_accuracy_macro": 0.1601707045391256,
+   "rouge_l_f1_macro": 0.5400628557221581,
+   "hop_count_exact_match_rate": 0.47333333333333333,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.8426666666666667,
+   "composite_score": 0.1916092414797678,
+   "composite_no_ref_renorm": 0.23951155184970976,
+   "reference_total_count": 4,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size2000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "exact_match_rate": 0.04666666666666667,
+   "step_f1_macro": 0.19266641007945357,
+   "ordered_step_accuracy_macro": 0.17403280423280426,
+   "rouge_l_f1_macro": 0.5471138456044015,
+   "hop_count_exact_match_rate": 0.52,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.8106666666666666,
+   "composite_score": 0.20225418307940052,
+   "composite_no_ref_renorm": 0.2528177288492507,
+   "reference_total_count": 10,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 3
+  },
+  "size2000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "exact_match_rate": 0.042666666666666665,
+   "step_f1_macro": 0.1763048877048877,
+   "ordered_step_accuracy_macro": 0.1599015873015873,
+   "rouge_l_f1_macro": 0.5330499591507277,
+   "hop_count_exact_match_rate": 0.5026666666666667,
+   "reference_validity_micro": 1.0,
+   "step_count_abs_error_mae": 0.8613333333333333,
+   "composite_score": 0.38978132016132017,
+   "composite_no_ref_renorm": 0.2372266502016502,
+   "reference_total_count": 0,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 0
+  },
+  "size4000_imbalanced_trial0__biencoder_only__raw": {
+   "exact_match_rate": 0.04533333333333334,
+   "step_f1_macro": 0.1762028463910817,
+   "ordered_step_accuracy_macro": 0.16001478151478152,
+   "rouge_l_f1_macro": 0.5284008790902841,
+   "hop_count_exact_match_rate": 0.46266666666666667,
+   "reference_validity_micro": 1.0,
+   "step_count_abs_error_mae": 0.832,
+   "composite_score": 0.3907522396775338,
+   "composite_no_ref_renorm": 0.23844029959691726,
+   "reference_total_count": 1,
+   "reference_valid_count": 1,
+   "items_emitting_at_least_one_reference": 1
+  },
+  "size4000_imbalanced_trial0__biencoder_only__typed": {
+   "exact_match_rate": 0.04666666666666667,
+   "step_f1_macro": 0.18659219766588186,
+   "ordered_step_accuracy_macro": 0.16572157842157842,
+   "rouge_l_f1_macro": 0.5287493632947979,
+   "hop_count_exact_match_rate": 0.4706666666666667,
+   "reference_validity_micro": 1.0,
+   "step_count_abs_error_mae": 0.9813333333333333,
+   "composite_score": 0.39164224148171517,
+   "composite_no_ref_renorm": 0.23955280185214398,
+   "reference_total_count": 1,
+   "reference_valid_count": 1,
+   "items_emitting_at_least_one_reference": 1
+  },
+  "size4000_imbalanced_trial0__biencoder_only__uniform": {
+   "exact_match_rate": 0.04666666666666667,
+   "step_f1_macro": 0.17242183742183742,
+   "ordered_step_accuracy_macro": 0.1576,
+   "rouge_l_f1_macro": 0.5226512379903042,
+   "hop_count_exact_match_rate": 0.448,
+   "reference_validity_micro": 1.0,
+   "step_count_abs_error_mae": 1.0373333333333334,
+   "composite_score": 0.38167095719095717,
+   "composite_no_ref_renorm": 0.22708869648869653,
+   "reference_total_count": 0,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 0
+  },
+  "size4000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "exact_match_rate": 0.04,
+   "step_f1_macro": 0.1885769981652335,
+   "ordered_step_accuracy_macro": 0.17118095238095235,
+   "rouge_l_f1_macro": 0.5461039107256191,
+   "hop_count_exact_match_rate": 0.52,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.7773333333333333,
+   "composite_score": 0.200873973869268,
+   "composite_no_ref_renorm": 0.251092467336585,
+   "reference_total_count": 4,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size4000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "exact_match_rate": 0.05333333333333334,
+   "step_f1_macro": 0.19801275761275763,
+   "ordered_step_accuracy_macro": 0.18347809042809043,
+   "rouge_l_f1_macro": 0.5459401505709149,
+   "hop_count_exact_match_rate": 0.488,
+   "reference_validity_micro": 0.5,
+   "step_count_abs_error_mae": 0.8693333333333333,
+   "composite_score": 0.3052707523957524,
+   "composite_no_ref_renorm": 0.25658844049469054,
+   "reference_total_count": 4,
+   "reference_valid_count": 2,
+   "items_emitting_at_least_one_reference": 3
+  },
+  "size4000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "exact_match_rate": 0.04133333333333333,
+   "step_f1_macro": 0.18295842305842305,
+   "ordered_step_accuracy_macro": 0.16658422873422873,
+   "rouge_l_f1_macro": 0.5327379194016908,
+   "hop_count_exact_match_rate": 0.49733333333333335,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.9106666666666666,
+   "composite_score": 0.1928030822880823,
+   "composite_no_ref_renorm": 0.2410038528601029,
+   "reference_total_count": 3,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size8000_imbalanced_trial0__biencoder_only__raw": {
+   "exact_match_rate": 0.044,
+   "step_f1_macro": 0.18505331444154974,
+   "ordered_step_accuracy_macro": 0.16524013024013023,
+   "rouge_l_f1_macro": 0.5351094175638953,
+   "hop_count_exact_match_rate": 0.48933333333333334,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.8946666666666667,
+   "composite_score": 0.19377114262643674,
+   "composite_no_ref_renorm": 0.24221392828304594,
+   "reference_total_count": 5,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size8000_imbalanced_trial0__biencoder_only__typed": {
+   "exact_match_rate": 0.048,
+   "step_f1_macro": 0.1947480984100179,
+   "ordered_step_accuracy_macro": 0.1727852332852333,
+   "rouge_l_f1_macro": 0.5303738748559566,
+   "hop_count_exact_match_rate": 0.492,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.952,
+   "composite_score": 0.19800147601624385,
+   "composite_no_ref_renorm": 0.24750184502030484,
+   "reference_total_count": 3,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 1
+  },
+  "size8000_imbalanced_trial0__biencoder_only__uniform": {
+   "exact_match_rate": 0.048,
+   "step_f1_macro": 0.1816171236171236,
+   "ordered_step_accuracy_macro": 0.1649904761904762,
+   "rouge_l_f1_macro": 0.5222343296012064,
+   "hop_count_exact_match_rate": 0.48933333333333334,
+   "reference_validity_micro": 0.08333333333333333,
+   "step_count_abs_error_mae": 0.9186666666666666,
+   "composite_score": 0.20818843674843676,
+   "composite_no_ref_renorm": 0.23940221260221264,
+   "reference_total_count": 12,
+   "reference_valid_count": 1,
+   "items_emitting_at_least_one_reference": 4
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "exact_match_rate": 0.048,
+   "step_f1_macro": 0.1907283605283605,
+   "ordered_step_accuracy_macro": 0.17273968253968253,
+   "rouge_l_f1_macro": 0.5421902806691635,
+   "hop_count_exact_match_rate": 0.5013333333333333,
+   "reference_validity_micro": 0.0,
+   "step_count_abs_error_mae": 0.8413333333333334,
+   "composite_score": 0.20006880452880452,
+   "composite_no_ref_renorm": 0.2500860056610057,
+   "reference_total_count": 5,
+   "reference_valid_count": 0,
+   "items_emitting_at_least_one_reference": 2
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "exact_match_rate": 0.050666666666666665,
+   "step_f1_macro": 0.21126165686165685,
+   "ordered_step_accuracy_macro": 0.19383973063973065,
+   "rouge_l_f1_macro": 0.5439559318584793,
+   "hop_count_exact_match_rate": 0.5133333333333333,
+   "reference_validity_micro": 0.6,
+   "step_count_abs_error_mae": 0.856,
+   "composite_score": 0.3341232486032486,
+   "composite_no_ref_renorm": 0.2676540607540608,
+   "reference_total_count": 5,
+   "reference_valid_count": 3,
+   "items_emitting_at_least_one_reference": 3
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "exact_match_rate": 0.042666666666666665,
+   "step_f1_macro": 0.17474454913278442,
+   "ordered_step_accuracy_macro": 0.1575314659197012,
+   "rouge_l_f1_macro": 0.5301727377283058,
+   "hop_count_exact_match_rate": 0.4746666666666667,
+   "reference_validity_micro": 0.2857142857142857,
+   "step_count_abs_error_mae": 0.94,
+   "composite_score": 0.24296678323854795,
+   "composite_no_ref_renorm": 0.23227990761961353,
+   "reference_total_count": 7,
+   "reference_valid_count": 2,
+   "items_emitting_at_least_one_reference": 3
+  }
+ },
+ "primary_pool_size_pairs": {
+  "num_pairs": 27,
+  "sign_convention": "difference = larger pool - smaller pool; positive favours the larger pool",
+  "families": [
+   "size_1000_vs_2000",
+   "size_1000_vs_8000",
+   "size_2000_vs_4000",
+   "size_4000_vs_8000"
+  ],
+  "pairs": [
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_balanced_trial0__biencoder_only__raw",
+    "cell_b": "size1000_balanced_trial0__biencoder_only__raw",
+    "fixed": {
+     "balance": "balanced",
+     "retrieval": "biencoder_only",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.519834172694174,
+       "system_b": 0.5237267087627537,
+       "difference": -0.003892536068579755,
+       "ci_low": -0.01567861956350817,
+       "ci_high": 0.007883788148443718,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.16260299781631052,
+       "system_b": 0.16133865393865393,
+       "difference": 0.0012643438776565874,
+       "ci_low": -0.014243761004790407,
+       "ci_high": 0.016739803948774546,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.14760017259429023,
+       "system_b": 0.14889870129870128,
+       "difference": -0.0012985287044110505,
+       "ci_low": -0.016576746031746022,
+       "ci_high": 0.014118389992360576,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.17438791757147798,
+       "system_b": 0.1762272941872942,
+       "difference": -0.0018393766158162073,
+       "ci_low": -0.20998523863947088,
+       "ci_high": 0.2063293584329041,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.037333333333333336,
+       "system_b": 0.03866666666666667,
+       "difference": -0.0013333333333333322,
+       "ci_low": -0.017333333333333333,
+       "ci_high": 0.013333333333333336,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.43733333333333335,
+       "system_b": 0.448,
+       "difference": -0.010666666666666658,
+       "ci_low": -0.053333333333333344,
+       "ci_high": 0.033333333333333326,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.21798489696434747,
+       "system_b": 0.22028411773411777,
+       "difference": -0.0022992207697702938,
+       "ci_low": -0.01800991259371289,
+       "ci_high": 0.013215879410550411,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.037333333333333336,
+       "system_b_rate": 0.03866666666666667,
+       "difference": -0.0013333333333333333,
+       "correct_only_in_a": 17,
+       "correct_only_in_b": 18,
+       "discordant_pairs": 35,
+       "p_value": 1.0,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.820766091346741e-11,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.43733333333333335,
+       "system_b_rate": 0.448,
+       "difference": -0.010666666666666666,
+       "correct_only_in_a": 132,
+       "correct_only_in_b": 140,
+       "discordant_pairs": 272,
+       "p_value": 0.67132513537123,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.635549485807631e-82,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -0.16892134370431347,
+       "p_value": 0.8659041175833334,
+       "dof": 749,
+       "mean_difference": -0.0013333333333333333,
+       "sd_difference": 0.21616473304242756,
+       "significant": false,
+       "mde_80_power": 0.02211364523127032,
+       "n_needed_for_observed_diff": 206303
+      },
+      "step_f1": {
+       "t_statistic": 0.15897867592486736,
+       "p_value": 0.8737285306323359,
+       "dof": 749,
+       "mean_difference": 0.0012643438776565711,
+       "sd_difference": 0.21779954393485235,
+       "significant": false,
+       "mde_80_power": 0.02228088633293607,
+       "n_needed_for_observed_diff": 232915
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.16497619043677839,
+       "p_value": 0.8690072366328843,
+       "dof": 749,
+       "mean_difference": -0.001298528704411057,
+       "sd_difference": 0.21555639668090482,
+       "significant": false,
+       "mde_80_power": 0.02205141244107066,
+       "n_needed_for_observed_diff": 216288
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.650346202014083,
+       "p_value": 0.5156680472361544,
+       "dof": 749,
+       "mean_difference": -0.003892536068579722,
+       "sd_difference": 0.16391498897516604,
+       "significant": false,
+       "mde_80_power": 0.016768498095260344,
+       "n_needed_for_observed_diff": 13919
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.48482381813445624,
+       "p_value": 0.627943080710632,
+       "dof": 749,
+       "mean_difference": -0.010666666666666666,
+       "sd_difference": 0.6025254667976632,
+       "significant": false,
+       "mde_80_power": 0.06163833585635777,
+       "n_needed_for_observed_diff": 25045
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.000505737551062635,
+      "ordered_step_accuracy": -0.00038955861132331513,
+      "reference_validity_micro": 0.0,
+      "step_count_term": -0.001955555555555555,
+      "_sum": -0.001839376615816235,
+      "_total_delta_composite": -0.0018393766158162073,
+      "_residual": -2.7755575615628914e-17,
+      "_share_reference_term": -0.0
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6506666666666667,
+      "step_count_term_b": 0.6702222222222223
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5645599680995477,
+        "system_b": 0.5746685352352963,
+        "difference": -0.010108567135748592,
+        "ci_low": -0.037213605175829174,
+        "ci_high": 0.016454009992311898,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.2362745324850588,
+        "system_b": 0.24200952380952379,
+        "difference": -0.0057349913244649775,
+        "ci_low": -0.04102090225563912,
+        "ci_high": 0.02994324561403507,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.22721797810033104,
+        "system_b": 0.23298181818181818,
+        "difference": -0.005763840081487143,
+        "ci_low": -0.04133810033104154,
+        "ci_high": 0.030224339190221505,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.43587520642412286,
+        "system_b": 0.4424316883116883,
+        "difference": -0.006556481887565413,
+        "ci_low": -0.034647237298820965,
+        "ci_high": 0.021686746042914717,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.084,
+        "system_b": 0.088,
+        "difference": -0.00399999999999999,
+        "ci_low": -0.04000000000000001,
+        "ci_high": 0.03599999999999999,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.552,
+        "system_b": 0.576,
+        "difference": -0.02399999999999991,
+        "ci_low": -0.09200000000000003,
+        "ci_high": 0.04400000000000004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2948440080301536,
+        "system_b": 0.3030396103896104,
+        "difference": -0.008195602359456822,
+        "ci_low": -0.04330904662352615,
+        "ci_high": 0.027108432553643515,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.084,
+        "system_b_rate": 0.088,
+        "difference": -0.004,
+        "correct_only_in_a": 11,
+        "correct_only_in_b": 12,
+        "discordant_pairs": 23,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.384185791015625e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.552,
+        "system_b_rate": 0.576,
+        "difference": -0.024,
+        "correct_only_in_a": 36,
+        "correct_only_in_b": 42,
+        "discordant_pairs": 78,
+        "p_value": 0.5715867180030725,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.617444900424222e-24,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.20811506511306044,
+        "p_value": 0.8353092490917973,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.3038970444979985,
+        "significant": false,
+        "mde_80_power": 0.05384713496791795,
+        "n_needed_for_observed_diff": 45305
+       },
+       "step_f1": {
+        "t_statistic": -0.31309468402514085,
+        "p_value": 0.7544708156874033,
+        "dof": 249,
+        "mean_difference": -0.0057349913244650105,
+        "sd_difference": 0.2896190173762087,
+        "significant": false,
+        "mde_80_power": 0.051317229306042815,
+        "n_needed_for_observed_diff": 20018
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.31193192435477113,
+        "p_value": 0.7553532967098842,
+        "dof": 249,
+        "mean_difference": -0.005763840081487139,
+        "sd_difference": 0.2921609060081299,
+        "significant": false,
+        "mde_80_power": 0.05176762335466733,
+        "n_needed_for_observed_diff": 20167
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.738866660404467,
+        "p_value": 0.4606838639323701,
+        "dof": 249,
+        "mean_difference": -0.010108567135748536,
+        "sd_difference": 0.21631843567140463,
+        "significant": false,
+        "mde_80_power": 0.0383291914565616,
+        "n_needed_for_observed_diff": 3595
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.6786328462976006,
+        "p_value": 0.4980007572540333,
+        "dof": 249,
+        "mean_difference": -0.024,
+        "sd_difference": 0.5591732278955965,
+        "significant": false,
+        "mde_80_power": 0.09907920072957091,
+        "n_needed_for_observed_diff": 4261
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.002293996529785991,
+       "ordered_step_accuracy": -0.0017291520244461427,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.002533333333333332,
+       "_sum": -0.006556481887565466,
+       "_total_delta_composite": -0.006556481887565413,
+       "_residual": -5.2909066017292616e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5197125765838334,
+        "system_b": 0.5178867205844552,
+        "difference": 0.0018258559993782342,
+        "ci_low": -0.01597495285669716,
+        "ci_high": 0.019548924524922528,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1529126050420168,
+        "system_b": 0.15595873015873013,
+        "difference": -0.0030461251167133163,
+        "ci_low": -0.025337343604108335,
+        "ci_high": 0.018992250233426686,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.1263047619047619,
+        "system_b": 0.13907619047619044,
+        "difference": -0.012771428571428545,
+        "ci_low": -0.033962142857142844,
+        "ci_high": 0.00828666666666668,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.36798980392156866,
+        "system_b": 0.3685063492063492,
+        "difference": -0.0005165452847805674,
+        "ci_low": -0.017629100373482733,
+        "ci_high": 0.016453737161531284,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.024,
+        "system_b": 0.028,
+        "difference": -0.004,
+        "ci_low": -0.032,
+        "ci_high": 0.023999999999999997,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.432,
+        "system_b": 0.436,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.08000000000000002,
+        "ci_high": 0.07200000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2099872549019608,
+        "system_b": 0.21063293650793652,
+        "difference": -0.0006456816059757231,
+        "ci_low": -0.022036375466853414,
+        "ci_high": 0.020567171451914102,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.024,
+        "system_b_rate": 0.028,
+        "difference": -0.004,
+        "correct_only_in_a": 5,
+        "correct_only_in_b": 6,
+        "discordant_pairs": 11,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0009765625,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.432,
+        "system_b_rate": 0.436,
+        "difference": -0.004,
+        "correct_only_in_a": 45,
+        "correct_only_in_b": 46,
+        "discordant_pairs": 91,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.077935669463161e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.30096244307653625,
+        "p_value": 0.7636942911220497,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.21014433746899086,
+        "significant": false,
+        "mde_80_power": 0.03723521076398943,
+        "n_needed_for_observed_diff": 21664
+       },
+       "step_f1": {
+        "t_statistic": -0.27349413658533045,
+        "p_value": 0.7847001147445423,
+        "dof": 249,
+        "mean_difference": -0.003046125116713352,
+        "sd_difference": 0.17610420330994958,
+        "significant": false,
+        "mde_80_power": 0.031203682219788663,
+        "n_needed_for_observed_diff": 26234
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.202700404672159,
+        "p_value": 0.23023465736270549,
+        "dof": 249,
+        "mean_difference": -0.01277142857142857,
+        "sd_difference": 0.1679005141387379,
+        "significant": false,
+        "mde_80_power": 0.029750080856975832,
+        "n_needed_for_observed_diff": 1357
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.20595419979575644,
+        "p_value": 0.8369949767409595,
+        "dof": 249,
+        "mean_difference": 0.001825855999378311,
+        "sd_difference": 0.14017348622277062,
+        "significant": false,
+        "mde_80_power": 0.024837163665179476,
+        "n_needed_for_observed_diff": 46261
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.1046209160135747,
+        "p_value": 0.9167608399568073,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.6045211188474147,
+        "significant": false,
+        "mde_80_power": 0.1071143364730811,
+        "n_needed_for_observed_diff": 179274
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0012184500466853267,
+       "ordered_step_accuracy": -0.0038314285714285633,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.004533333333333345,
+       "_sum": -0.000516545284780545,
+       "_total_delta_composite": -0.0005165452847805674,
+       "_residual": 2.233456475320139e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.475229973399141,
+        "system_b": 0.47862487046850993,
+        "difference": -0.0033948970693689073,
+        "ci_low": -0.017422138860767402,
+        "ci_high": 0.011271290449307136,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.09862185592185592,
+        "system_b": 0.08604770784770785,
+        "difference": 0.01257414807414807,
+        "ci_low": -0.0070440773115773144,
+        "ci_high": 0.03336193445443444,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08927777777777778,
+        "system_b": 0.07463809523809525,
+        "difference": 0.014639682539682522,
+        "ci_low": -0.00423880952380952,
+        "ci_high": 0.03513968253968254,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.11929874236874237,
+        "system_b": 0.11774384504384505,
+        "difference": 0.001554897324897317,
+        "ci_low": -0.21016019247419246,
+        "ci_high": 0.21346198246198242,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.328,
+        "system_b": 0.332,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.08400000000000002,
+        "ci_high": 0.07600000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14912342796092798,
+        "system_b": 0.14717980630480632,
+        "difference": 0.0019436216561216635,
+        "ci_low": -0.01974589691558439,
+        "ci_high": 0.024519815947940973,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.0,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.328,
+        "system_b_rate": 0.332,
+        "difference": -0.004,
+        "correct_only_in_a": 51,
+        "correct_only_in_b": 52,
+        "discordant_pairs": 103,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.9721522630525295e-31,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 1.1966632186045494,
+        "p_value": 0.23257597798272442,
+        "dof": 249,
+        "mean_difference": 0.012574148074148073,
+        "sd_difference": 0.16614092809209927,
+        "significant": false,
+        "mde_80_power": 0.0294383020191871,
+        "n_needed_for_observed_diff": 1371
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.4407827132507898,
+        "p_value": 0.15090234903137426,
+        "dof": 249,
+        "mean_difference": 0.01463968253968254,
+        "sd_difference": 0.1606583026761263,
+        "significant": false,
+        "mde_80_power": 0.02846684251967105,
+        "n_needed_for_observed_diff": 946
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.4487836271152439,
+        "p_value": 0.6539780645828261,
+        "dof": 249,
+        "mean_difference": -0.0033948970693689355,
+        "sd_difference": 0.11960783005882333,
+        "significant": false,
+        "mde_80_power": 0.02119316092407629,
+        "n_needed_for_observed_diff": 9743
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.09833757398581594,
+        "p_value": 0.9217433581181761,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.6431473814118094,
+        "significant": false,
+        "mde_80_power": 0.11395847533940988,
+        "n_needed_for_observed_diff": 202915
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.005029659229659228,
+       "ordered_step_accuracy": 0.004391904761904757,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.007866666666666666,
+       "_sum": 0.0015548973248973186,
+       "_total_delta_composite": 0.001554897324897317,
+       "_residual": 1.734723475976807e-18,
+       "_share_reference_term": 0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_balanced_trial0__biencoder_only__typed",
+    "cell_b": "size1000_balanced_trial0__biencoder_only__typed",
+    "fixed": {
+     "balance": "balanced",
+     "retrieval": "biencoder_only",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5173918350863802,
+       "system_b": 0.5223531262239297,
+       "difference": -0.004961291137549506,
+       "ci_low": -0.015803432578330546,
+       "ci_high": 0.005930021913037726,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.16549053539053538,
+       "system_b": 0.16963798053798052,
+       "difference": -0.004147445147445139,
+       "ci_low": -0.019258368205868216,
+       "ci_high": 0.01080290959040959,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1437026455026455,
+       "system_b": 0.1504810152810153,
+       "difference": -0.006778369778369792,
+       "ci_low": -0.021124062419062443,
+       "ci_high": 0.007797947792947794,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.31718637288637286,
+       "system_b": 0.24575505235505235,
+       "difference": 0.07143132053132051,
+       "ci_low": -0.04813924097199098,
+       "ci_high": 0.15388709718059718,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.030666666666666665,
+       "system_b": 0.04133333333333333,
+       "difference": -0.010666666666666668,
+       "ci_low": -0.024000000000000004,
+       "ci_high": 0.002666666666666668,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4226666666666667,
+       "system_b": 0.43733333333333335,
+       "difference": -0.014666666666666661,
+       "ci_low": -0.05733333333333335,
+       "ci_high": 0.028000000000000025,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.21791153753653758,
+       "system_b": 0.22386048211048215,
+       "difference": -0.00594894457394457,
+       "ci_low": -0.02057282122969625,
+       "ci_high": 0.008654077843452863,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.030666666666666665,
+       "system_b_rate": 0.04133333333333333,
+       "difference": -0.010666666666666666,
+       "correct_only_in_a": 10,
+       "correct_only_in_b": 18,
+       "discordant_pairs": 28,
+       "p_value": 0.1849333420395851,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 7.450580596923828e-09,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.4226666666666667,
+       "system_b_rate": 0.43733333333333335,
+       "difference": -0.014666666666666666,
+       "correct_only_in_a": 130,
+       "correct_only_in_b": 141,
+       "discordant_pairs": 271,
+       "p_value": 0.5436267147012667,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.271098971615262e-82,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -1.5131571733488776,
+       "p_value": 0.13066156246466126,
+       "dof": 749,
+       "mean_difference": -0.010666666666666666,
+       "sd_difference": 0.19305244853684272,
+       "significant": false,
+       "mde_80_power": 0.019749259270400495,
+       "n_needed_for_observed_diff": 2572
+      },
+      "step_f1": {
+       "t_statistic": -0.5391891950150417,
+       "p_value": 0.5899165473307767,
+       "dof": 749,
+       "mean_difference": -0.004147445147445149,
+       "sd_difference": 0.21065419005732075,
+       "significant": false,
+       "mde_80_power": 0.021549916861294264,
+       "n_needed_for_observed_diff": 20249
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.9180255920095989,
+       "p_value": 0.3589009849076828,
+       "dof": 749,
+       "mean_difference": -0.006778369778369777,
+       "sd_difference": 0.20220928822894954,
+       "significant": false,
+       "mde_80_power": 0.02068600367611778,
+       "n_needed_for_observed_diff": 6985
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.9003792995371819,
+       "p_value": 0.3682078303483273,
+       "dof": 749,
+       "mean_difference": -0.004961291137549515,
+       "sd_difference": 0.15090368424635897,
+       "significant": false,
+       "mde_80_power": 0.015437442040375038,
+       "n_needed_for_observed_diff": 7262
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.66795565155776,
+       "p_value": 0.5043676678890018,
+       "dof": 749,
+       "mean_difference": -0.014666666666666666,
+       "sd_difference": 0.6013321511696033,
+       "significant": false,
+       "mde_80_power": 0.061516259706023535,
+       "n_needed_for_observed_diff": 13195
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.0016589780589780557,
+      "ordered_step_accuracy": -0.0020335109335109375,
+      "reference_validity_micro": 0.0761904761904762,
+      "step_count_term": -0.0010666666666666602,
+      "_sum": 0.07143132053132055,
+      "_total_delta_composite": 0.07143132053132051,
+      "_residual": 4.163336342344337e-17,
+      "_share_reference_term": 1.0666256149789215
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.7142857142857143,
+      "ref_micro_b": 0.3333333333333333,
+      "step_count_term_a": 0.6502222222222223,
+      "step_count_term_b": 0.6608888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5819558117386785,
+        "system_b": 0.5774413470405243,
+        "difference": 0.004514464698154197,
+        "ci_low": -0.016587336556166992,
+        "ci_high": 0.02591649943620425,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.25376507936507936,
+        "system_b": 0.2392095238095238,
+        "difference": 0.014555555555555572,
+        "ci_low": -0.017181428571428625,
+        "ci_high": 0.047279603174603155,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.23537142857142856,
+        "system_b": 0.2253047619047619,
+        "difference": 0.010066666666666668,
+        "ci_low": -0.022505476190476173,
+        "ci_high": 0.04360000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4498507936507936,
+        "system_b": 0.4388752380952381,
+        "difference": 0.010975555555555516,
+        "ci_low": -0.01340963492063491,
+        "ci_high": 0.03578064285714288,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.084,
+        "system_b": 0.096,
+        "difference": -0.011999999999999997,
+        "ci_low": -0.048,
+        "ci_high": 0.023999999999999994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.58,
+        "system_b": 0.576,
+        "difference": 0.0040000000000000036,
+        "ci_low": -0.06800000000000006,
+        "ci_high": 0.07999999999999996,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3123134920634921,
+        "system_b": 0.2985940476190477,
+        "difference": 0.01371944444444445,
+        "ci_low": -0.01676204365079365,
+        "ci_high": 0.04472580357142863,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.084,
+        "system_b_rate": 0.096,
+        "difference": -0.012,
+        "correct_only_in_a": 9,
+        "correct_only_in_b": 12,
+        "discordant_pairs": 21,
+        "p_value": 0.6636238098144531,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 9.5367431640625e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.58,
+        "system_b_rate": 0.576,
+        "difference": 0.004,
+        "correct_only_in_a": 46,
+        "correct_only_in_b": 45,
+        "discordant_pairs": 91,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.077935669463161e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.6539037808046826,
+        "p_value": 0.5137772357147493,
+        "dof": 249,
+        "mean_difference": -0.012,
+        "sd_difference": 0.2901599060592923,
+        "significant": false,
+        "mde_80_power": 0.05141306869128177,
+        "n_needed_for_observed_diff": 4590
+       },
+       "step_f1": {
+        "t_statistic": 0.8815045276161905,
+        "p_value": 0.37889491069928855,
+        "dof": 249,
+        "mean_difference": 0.014555555555555558,
+        "sd_difference": 0.2610803842899495,
+        "significant": false,
+        "mde_80_power": 0.04626050481523978,
+        "n_needed_for_observed_diff": 2526
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.5882391543055784,
+        "p_value": 0.5569049361389564,
+        "dof": 249,
+        "mean_difference": 0.010066666666666665,
+        "sd_difference": 0.2705837827978445,
+        "significant": false,
+        "mde_80_power": 0.04794440004019616,
+        "n_needed_for_observed_diff": 5671
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.4116098752716918,
+        "p_value": 0.6809794684020232,
+        "dof": 249,
+        "mean_difference": 0.004514464698154154,
+        "sd_difference": 0.17341652521296408,
+        "significant": false,
+        "mde_80_power": 0.03072745591927376,
+        "n_needed_for_observed_diff": 11582
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.1046209160135747,
+        "p_value": 0.9167608399568073,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.6045211188474148,
+        "significant": false,
+        "mde_80_power": 0.10711433647308112,
+        "n_needed_for_observed_diff": 179274
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.005822222222222229,
+       "ordered_step_accuracy": 0.0030200000000000005,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0021333333333333317,
+       "_sum": 0.010975555555555561,
+       "_total_delta_composite": 0.010975555555555516,
+       "_residual": 4.5102810375396984e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5086571217607104,
+        "system_b": 0.5244788966279009,
+        "difference": -0.015821774867190497,
+        "ci_low": -0.034210340661533827,
+        "ci_high": 0.0024569889844051587,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13869206349206348,
+        "system_b": 0.16013333333333332,
+        "difference": -0.021441269841269844,
+        "ci_low": -0.04664912698412699,
+        "ci_high": 0.0029178571428571092,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11366666666666665,
+        "system_b": 0.13906666666666667,
+        "difference": -0.02540000000000002,
+        "ci_low": -0.04646833333333332,
+        "ci_high": -0.00466500000000001,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3555768253968254,
+        "system_b": 0.37550666666666666,
+        "difference": -0.019929841269841264,
+        "ci_low": -0.03731282539682539,
+        "ci_high": -0.002691912698412733,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.024,
+        "difference": -0.02,
+        "ci_low": -0.04,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.416,
+        "system_b": 0.452,
+        "difference": -0.03600000000000003,
+        "ci_low": -0.10800000000000004,
+        "ci_high": 0.03600000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19447103174603175,
+        "system_b": 0.21938333333333337,
+        "difference": -0.024912301587301622,
+        "ci_low": -0.04664103174603173,
+        "ci_high": -0.0033648908730158607,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.024,
+        "difference": -0.02,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 6,
+        "discordant_pairs": 7,
+        "p_value": 0.125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.015625,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.416,
+        "system_b_rate": 0.452,
+        "difference": -0.036,
+        "correct_only_in_a": 38,
+        "correct_only_in_b": 47,
+        "discordant_pairs": 85,
+        "p_value": 0.38566942011927957,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.169878828456423e-26,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.8996567195611724,
+        "p_value": 0.05863365889700317,
+        "dof": 249,
+        "mean_difference": -0.02,
+        "sd_difference": 0.16646574234206257,
+        "significant": false,
+        "mde_80_power": 0.02949585544747453,
+        "n_needed_for_observed_diff": 544
+       },
+       "step_f1": {
+        "t_statistic": -1.6917281524802372,
+        "p_value": 0.0919488520253363,
+        "dof": 249,
+        "mean_difference": -0.021441269841269844,
+        "sd_difference": 0.20039640684965698,
+        "significant": false,
+        "mde_80_power": 0.035507987201864176,
+        "n_needed_for_observed_diff": 686
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -2.3664119646740405,
+        "p_value": 0.01872758385714683,
+        "dof": 249,
+        "mean_difference": -0.0254,
+        "sd_difference": 0.16971231925659383,
+        "significant": true,
+        "mde_80_power": 0.030071112326294367,
+        "n_needed_for_observed_diff": 351
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.6752017030499422,
+        "p_value": 0.09514998596978486,
+        "dof": 249,
+        "mean_difference": -0.015821774867190483,
+        "sd_difference": 0.14933379400115848,
+        "significant": false,
+        "mde_80_power": 0.02646026707543251,
+        "n_needed_for_observed_diff": 700
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.9760948278462389,
+        "p_value": 0.32996480798265815,
+        "dof": 249,
+        "mean_difference": -0.036,
+        "sd_difference": 0.5831502868284576,
+        "significant": false,
+        "mde_80_power": 0.10332766563525707,
+        "n_needed_for_observed_diff": 2060
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.008576507936507938,
+       "ordered_step_accuracy": -0.007620000000000005,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.003733333333333344,
+       "_sum": -0.01992984126984129,
+       "_total_delta_composite": -0.019929841269841264,
+       "_residual": -2.42861286636753e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.46156257175975196,
+        "system_b": 0.4651391350033641,
+        "difference": -0.003576563243612163,
+        "ci_low": -0.019082315899780943,
+        "ci_high": 0.012413773237743135,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10401446331446332,
+        "system_b": 0.10957108447108448,
+        "difference": -0.005556621156621158,
+        "ci_low": -0.024883175990676003,
+        "ci_high": 0.014182870185370188,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08206984126984128,
+        "system_b": 0.08707161727161727,
+        "difference": -0.0050017760017759955,
+        "ci_low": -0.022333099955599966,
+        "ci_high": 0.013221594516594512,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.2560216095016095,
+        "system_b": 0.12288325230325232,
+        "difference": 0.1331383571983572,
+        "ci_low": -0.019240938616938565,
+        "ci_high": 0.1639214893994894,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.004,
+        "difference": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.272,
+        "system_b": 0.284,
+        "difference": -0.011999999999999955,
+        "ci_low": -0.08800000000000002,
+        "ci_high": 0.064,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14695008880008886,
+        "system_b": 0.1536040653790654,
+        "difference": -0.006653976578976539,
+        "ci_low": -0.028250234730547264,
+        "ci_high": 0.014937527021589512,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.004,
+        "difference": 0.0,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 0,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.272,
+        "system_b_rate": 0.284,
+        "difference": -0.012,
+        "correct_only_in_a": 46,
+        "correct_only_in_b": 49,
+        "discordant_pairs": 95,
+        "p_value": 0.8375560707290739,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.048709793414476e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.0,
+        "significant": false,
+        "degenerate_all_zero_differences": true
+       },
+       "step_f1": {
+        "t_statistic": -0.5612253309261236,
+        "p_value": 0.575148658932956,
+        "dof": 249,
+        "mean_difference": -0.005556621156621158,
+        "sd_difference": 0.1565465596555111,
+        "significant": false,
+        "mde_80_power": 0.027738287947018995,
+        "n_needed_for_observed_diff": 6230
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.5545201461175725,
+        "p_value": 0.5797206374313151,
+        "dof": 249,
+        "mean_difference": -0.005001776001776002,
+        "sd_difference": 0.14261884462020033,
+        "significant": false,
+        "mde_80_power": 0.025270453643003513,
+        "n_needed_for_observed_diff": 6382
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.4482725474394092,
+        "p_value": 0.6543463205309297,
+        "dof": 249,
+        "mean_difference": -0.00357656324361222,
+        "sd_difference": 0.12615189252675582,
+        "significant": false,
+        "mde_80_power": 0.022352695119386857,
+        "n_needed_for_observed_diff": 9765
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.3072355203549506,
+        "p_value": 0.7589209094548853,
+        "dof": 249,
+        "mean_difference": -0.012,
+        "sd_difference": 0.61756094930332,
+        "significant": false,
+        "mde_80_power": 0.10942484762555967,
+        "n_needed_for_observed_diff": 20788
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.002222648462648463,
+       "ordered_step_accuracy": -0.0015005328005327986,
+       "reference_validity_micro": 0.13846153846153847,
+       "step_count_term": -0.0016000000000000016,
+       "_sum": 0.1331383571983572,
+       "_total_delta_composite": 0.1331383571983572,
+       "_residual": 0.0,
+       "_share_reference_term": 1.039982326469978
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_balanced_trial0__biencoder_only__uniform",
+    "cell_b": "size1000_balanced_trial0__biencoder_only__uniform",
+    "fixed": {
+     "balance": "balanced",
+     "retrieval": "biencoder_only",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5166398652512153,
+       "system_b": 0.5131405987843701,
+       "difference": 0.0034992664668451745,
+       "ci_low": -0.007543615200249648,
+       "ci_high": 0.014289077867152028,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.15718394922307963,
+       "system_b": 0.16026169386169387,
+       "difference": -0.003077744638614238,
+       "ci_low": -0.017704527328549068,
+       "ci_high": 0.01156219372817198,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.13800283283967493,
+       "system_b": 0.14410089540089538,
+       "difference": -0.006098062561220446,
+       "ci_low": -0.020411568947621535,
+       "ci_high": 0.008139563087984138,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.3664966517633566,
+       "system_b": 0.1710682794982795,
+       "difference": 0.19542837226507712,
+       "ci_low": -0.009743741063453859,
+       "ci_high": 0.2063780199060199,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.03333333333333333,
+       "system_b": 0.044,
+       "difference": -0.010666666666666665,
+       "ci_low": -0.025333333333333333,
+       "ci_high": 0.003999999999999997,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4146666666666667,
+       "system_b": 0.43466666666666665,
+       "difference": -0.019999999999999962,
+       "ci_low": -0.06,
+       "ci_high": 0.018666666666666665,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2081208147041957,
+       "system_b": 0.21383534937284937,
+       "difference": -0.005714534668653681,
+       "ci_low": -0.02022791830917834,
+       "ci_high": 0.008596038916085425,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.03333333333333333,
+       "system_b_rate": 0.044,
+       "difference": -0.010666666666666666,
+       "correct_only_in_a": 11,
+       "correct_only_in_b": 19,
+       "discordant_pairs": 30,
+       "p_value": 0.20048842206597328,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.862645149230957e-09,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.4146666666666667,
+       "system_b_rate": 0.43466666666666665,
+       "difference": -0.02,
+       "correct_only_in_a": 108,
+       "correct_only_in_b": 123,
+       "discordant_pairs": 231,
+       "p_value": 0.3570086314360989,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.795634610449096e-70,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -1.4616997752069603,
+       "p_value": 0.1442429053861577,
+       "dof": 749,
+       "mean_difference": -0.010666666666666666,
+       "sd_difference": 0.1998486298561056,
+       "significant": false,
+       "mde_80_power": 0.02044450840057229,
+       "n_needed_for_observed_diff": 2756
+      },
+      "step_f1": {
+       "t_statistic": -0.4165876261750866,
+       "p_value": 0.6770994153134903,
+       "dof": 749,
+       "mean_difference": -0.003077744638614205,
+       "sd_difference": 0.20232840090419366,
+       "significant": false,
+       "mde_80_power": 0.020698188898960676,
+       "n_needed_for_observed_diff": 33921
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.8402198150816125,
+       "p_value": 0.401053274552458,
+       "dof": 749,
+       "mean_difference": -0.006098062561220457,
+       "sd_difference": 0.19876027450826936,
+       "significant": false,
+       "mde_80_power": 0.02033316968352596,
+       "n_needed_for_observed_diff": 8339
+      },
+      "rouge_l_f1": {
+       "t_statistic": 0.6246413286477612,
+       "p_value": 0.5323967151232296,
+       "dof": 749,
+       "mean_difference": 0.0034992664668450843,
+       "sd_difference": 0.15341821703997857,
+       "significant": false,
+       "mde_80_power": 0.015694678664212217,
+       "n_needed_for_observed_diff": 15088
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.9869104304136714,
+       "p_value": 0.32400524744818016,
+       "dof": 749,
+       "mean_difference": -0.02,
+       "sd_difference": 0.554987099767082,
+       "significant": false,
+       "mde_80_power": 0.05677516243952731,
+       "n_needed_for_observed_diff": 6044
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.0012310978554456954,
+      "ordered_step_accuracy": -0.001829418768366134,
+      "reference_validity_micro": 0.2,
+      "step_count_term": -0.0015111111111111076,
+      "_sum": 0.19542837226507706,
+      "_total_delta_composite": 0.19542837226507712,
+      "_residual": -5.551115123125783e-17,
+      "_share_reference_term": 1.023392855816872
+     },
+     "reference_terms": {
+      "ref_micro_a": 1.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6222222222222222,
+      "step_count_term_b": 0.6373333333333333
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5781508098928904,
+        "system_b": 0.5836673787198069,
+        "difference": -0.005516568826916535,
+        "ci_low": -0.02727563463321164,
+        "ci_high": 0.016820078632741892,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.253352380952381,
+        "system_b": 0.25767619047619045,
+        "difference": -0.004323809523809452,
+        "ci_low": -0.03746809523809527,
+        "ci_high": 0.029409999999999957,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.23393333333333333,
+        "system_b": 0.24946666666666664,
+        "difference": -0.015533333333333316,
+        "ci_low": -0.04840166666666666,
+        "ci_high": 0.018335000000000008,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.45058761904761907,
+        "system_b": 0.25857714285714284,
+        "difference": 0.19201047619047623,
+        "ci_low": -0.02694880952380953,
+        "ci_high": 0.21473619047619047,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.084,
+        "system_b": 0.112,
+        "difference": -0.027999999999999997,
+        "ci_low": -0.068,
+        "ci_high": 0.011999999999999997,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.568,
+        "system_b": 0.584,
+        "difference": -0.016000000000000014,
+        "ci_low": -0.07600000000000007,
+        "ci_high": 0.04400000000000004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3132345238095239,
+        "system_b": 0.3232214285714286,
+        "difference": -0.009986904761904725,
+        "ci_low": -0.04030125000000004,
+        "ci_high": 0.020844494047618994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.084,
+        "system_b_rate": 0.112,
+        "difference": -0.028,
+        "correct_only_in_a": 9,
+        "correct_only_in_b": 16,
+        "discordant_pairs": 25,
+        "p_value": 0.2295229434967041,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.960464477539063e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.568,
+        "system_b_rate": 0.584,
+        "difference": -0.016,
+        "correct_only_in_a": 29,
+        "correct_only_in_b": 33,
+        "discordant_pairs": 62,
+        "p_value": 0.7035366713552734,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.336808689942018e-19,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.4027066240829729,
+        "p_value": 0.16194993307179467,
+        "dof": 249,
+        "mean_difference": -0.028,
+        "sd_difference": 0.3156175816258107,
+        "significant": false,
+        "mde_80_power": 0.055923882195454605,
+        "n_needed_for_observed_diff": 998
+       },
+       "step_f1": {
+        "t_statistic": -0.25399256222665373,
+        "p_value": 0.7997109151094858,
+        "dof": 249,
+        "mean_difference": -0.004323809523809523,
+        "sd_difference": 0.26916312320525293,
+        "significant": false,
+        "mde_80_power": 0.04769267515438125,
+        "n_needed_for_observed_diff": 30417
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.9013209017638788,
+        "p_value": 0.3682886848240648,
+        "dof": 249,
+        "mean_difference": -0.015533333333333335,
+        "sd_difference": 0.27249292062249936,
+        "significant": false,
+        "mde_80_power": 0.048282677769373686,
+        "n_needed_for_observed_diff": 2416
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.4811779329188059,
+        "p_value": 0.6308126039672912,
+        "dof": 249,
+        "mean_difference": -0.005516568826916584,
+        "sd_difference": 0.18127309222515048,
+        "significant": false,
+        "mde_80_power": 0.03211955114345907,
+        "n_needed_for_observed_diff": 8476
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.5072453606009633,
+        "p_value": 0.612431615954809,
+        "dof": 249,
+        "mean_difference": -0.016,
+        "sd_difference": 0.4987373615674819,
+        "significant": false,
+        "mde_80_power": 0.08837064561200222,
+        "n_needed_for_observed_diff": 7627
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0017295238095237809,
+       "ordered_step_accuracy": -0.004659999999999995,
+       "reference_validity_micro": 0.2,
+       "step_count_term": -0.0016000000000000016,
+       "_sum": 0.19201047619047623,
+       "_total_delta_composite": 0.19201047619047623,
+       "_residual": 0.0,
+       "_share_reference_term": 1.0416098327968215
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5173086224698142,
+        "system_b": 0.5035458587859397,
+        "difference": 0.013762763683874524,
+        "ci_low": -0.004817895988161186,
+        "ci_high": 0.03241254074078227,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13418730158730158,
+        "system_b": 0.13755642135642138,
+        "difference": -0.0033691197691197994,
+        "ci_low": -0.023845324675324683,
+        "ci_high": 0.01682599567099567,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11173333333333332,
+        "system_b": 0.11288681318681318,
+        "difference": -0.0011534798534798552,
+        "ci_low": -0.02017678571428571,
+        "ci_high": 0.017928754578754553,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3546615873015873,
+        "system_b": 0.3491552791652792,
+        "difference": 0.005506308136308091,
+        "ci_low": -0.010861510822510842,
+        "ci_high": 0.02236734643134644,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.02,
+        "difference": -0.008,
+        "ci_low": -0.024,
+        "ci_high": 0.008,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.424,
+        "system_b": 0.416,
+        "difference": 0.008000000000000007,
+        "ci_low": -0.068,
+        "ci_high": 0.08400000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19332698412698415,
+        "system_b": 0.186444098956599,
+        "difference": 0.006882885170385156,
+        "ci_low": -0.013576888528138523,
+        "ci_high": 0.027959183039183048,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.02,
+        "difference": -0.008,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 3,
+        "discordant_pairs": 4,
+        "p_value": 0.625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.424,
+        "system_b_rate": 0.416,
+        "difference": 0.008,
+        "correct_only_in_a": 47,
+        "correct_only_in_b": 45,
+        "discordant_pairs": 92,
+        "p_value": 0.917040519652471,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.0389678347315804e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.12649110640673517,
+        "significant": false,
+        "mde_80_power": 0.0224128,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -0.32241234607583125,
+        "p_value": 0.7474108725411038,
+        "dof": 249,
+        "mean_difference": -0.003369119769119768,
+        "sd_difference": 0.16522463097323906,
+        "significant": false,
+        "mde_80_power": 0.02927594448553131,
+        "n_needed_for_observed_diff": 18877
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.1172569346936253,
+        "p_value": 0.9067509748683673,
+        "dof": 249,
+        "mean_difference": -0.0011534798534798547,
+        "sd_difference": 0.155539780297188,
+        "significant": false,
+        "mde_80_power": 0.02755989797919259,
+        "n_needed_for_observed_diff": 142717
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.4625772374040786,
+        "p_value": 0.1448441172448069,
+        "dof": 249,
+        "mean_difference": 0.0137627636838746,
+        "sd_difference": 0.1487842112767314,
+        "significant": false,
+        "mde_80_power": 0.026362887203946275,
+        "n_needed_for_observed_diff": 918
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.20811506511306044,
+        "p_value": 0.8353092490917973,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.607794088995997,
+        "significant": false,
+        "mde_80_power": 0.1076942699358359,
+        "n_needed_for_observed_diff": 45305
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.00134764790764792,
+       "ordered_step_accuracy": -0.00034604395604395655,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.007200000000000007,
+       "_sum": 0.00550630813630813,
+       "_total_delta_composite": 0.005506308136308091,
+       "_residual": 3.903127820947816e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.45446016339094103,
+        "system_b": 0.4522085588473638,
+        "difference": 0.002251604543577257,
+        "ci_low": -0.012661205785006938,
+        "ci_high": 0.0174927800269374,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.08401216512955643,
+        "system_b": 0.08555246975246976,
+        "difference": -0.0015403046229133244,
+        "ci_low": -0.020322698883242347,
+        "ci_high": 0.01764791105030235,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.06834183185235818,
+        "system_b": 0.06994920634920634,
+        "difference": -0.0016073744968481685,
+        "ci_low": -0.01890557074504444,
+        "ci_high": 0.01616140654666968,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.2942407489408634,
+        "system_b": 0.10547241647241647,
+        "difference": 0.18876833246844693,
+        "ci_low": -0.02397061699100538,
+        "ci_high": 0.2033333412698413,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.252,
+        "system_b": 0.304,
+        "difference": -0.05199999999999999,
+        "ci_low": -0.12000000000000002,
+        "ci_high": 0.016000000000000014,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.11780093617607922,
+        "system_b": 0.1318405205905206,
+        "difference": -0.014039584414441378,
+        "ci_low": -0.03480323504433846,
+        "ci_high": 0.006673690268065282,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.0,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.252,
+        "system_b_rate": 0.304,
+        "difference": -0.052,
+        "correct_only_in_a": 32,
+        "correct_only_in_b": 45,
+        "discordant_pairs": 77,
+        "p_value": 0.17106097355391156,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.3234889800848443e-23,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -0.15925305360494404,
+        "p_value": 0.8735986031670141,
+        "dof": 249,
+        "mean_difference": -0.00154030462291332,
+        "sd_difference": 0.1529286499892161,
+        "significant": false,
+        "mde_80_power": 0.02709723508510475,
+        "n_needed_for_observed_diff": 77371
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.17857484216084102,
+        "p_value": 0.8584167562052334,
+        "dof": 249,
+        "mean_difference": -0.0016073744968481813,
+        "sd_difference": 0.14232028435251826,
+        "significant": false,
+        "mde_80_power": 0.025217552124805167,
+        "n_needed_for_observed_diff": 61534
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.28490014659227814,
+        "p_value": 0.775957458110005,
+        "dof": 249,
+        "mean_difference": 0.0022516045435772318,
+        "sd_difference": 0.12495954868492308,
+        "significant": false,
+        "mde_80_power": 0.022141425214194488,
+        "n_needed_for_observed_diff": 24176
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.4850547324270817,
+        "p_value": 0.13879420301585693,
+        "dof": 249,
+        "mean_difference": -0.052,
+        "sd_difference": 0.5536443699283988,
+        "significant": false,
+        "mde_80_power": 0.09809954934247062,
+        "n_needed_for_observed_diff": 890
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0006161218491653298,
+       "ordered_step_accuracy": -0.00048221234905445053,
+       "reference_validity_micro": 0.2,
+       "step_count_term": -0.010133333333333328,
+       "_sum": 0.1887683324684469,
+       "_total_delta_composite": 0.18876833246844693,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 1.059499744393994
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_imbalanced_trial0__biencoder_only__raw",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__raw",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5233271649996762,
+       "system_b": 0.5253321480880906,
+       "difference": -0.002004983088414347,
+       "ci_low": -0.012572554065902597,
+       "ci_high": 0.008611541479882166,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.17804892884892884,
+       "system_b": 0.1599082251082251,
+       "difference": 0.01814070374070373,
+       "ci_low": 0.0019428754578754601,
+       "ci_high": 0.03419255559255561,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1595999185999186,
+       "system_b": 0.14317142857142856,
+       "difference": 0.016428490028490034,
+       "ci_low": 0.0008379609279609138,
+       "ci_high": 0.031778463573463575,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.38861065823065827,
+       "system_b": 0.1774036075036075,
+       "difference": 0.21120705072705076,
+       "ci_low": 0.006635571780071717,
+       "ci_high": 0.22278747387797387,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.04666666666666667,
+       "system_b": 0.030666666666666665,
+       "difference": 0.016000000000000004,
+       "ci_low": 0.0,
+       "ci_high": 0.032,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.47333333333333333,
+       "system_b": 0.46266666666666667,
+       "difference": 0.010666666666666658,
+       "ci_low": -0.028000000000000025,
+       "ci_high": 0.05066666666666664,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2357633227883228,
+       "system_b": 0.2217545093795094,
+       "difference": 0.014008813408813381,
+       "ci_low": -0.0014357490657490816,
+       "ci_high": 0.0291662076118326,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.04666666666666667,
+       "system_b_rate": 0.030666666666666665,
+       "difference": 0.016,
+       "correct_only_in_a": 24,
+       "correct_only_in_b": 12,
+       "discordant_pairs": 36,
+       "p_value": 0.06524533522315323,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.9103830456733704e-11,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.47333333333333333,
+       "system_b_rate": 0.46266666666666667,
+       "difference": 0.010666666666666666,
+       "correct_only_in_a": 121,
+       "correct_only_in_b": 113,
+       "discordant_pairs": 234,
+       "p_value": 0.6473300545214401,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 7.24454326306137e-71,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 2.004017412819738,
+       "p_value": 0.04542783048444692,
+       "dof": 749,
+       "mean_difference": 0.016,
+       "sd_difference": 0.21864981970770284,
+       "significant": true,
+       "mde_80_power": 0.02236786951712583,
+       "n_needed_for_observed_diff": 1466
+      },
+      "step_f1": {
+       "t_statistic": 2.208002007033803,
+       "p_value": 0.027546409238864363,
+       "dof": 749,
+       "mean_difference": 0.01814070374070374,
+       "sd_difference": 0.22500144058179,
+       "significant": true,
+       "mde_80_power": 0.02301764012806784,
+       "n_needed_for_observed_diff": 1208
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 2.0774603661063953,
+       "p_value": 0.03809927832012546,
+       "dof": 749,
+       "mean_difference": 0.01642849002849003,
+       "sd_difference": 0.21656862198573087,
+       "significant": true,
+       "mde_80_power": 0.022154963057167895,
+       "n_needed_for_observed_diff": 1364
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.3757042594843445,
+       "p_value": 0.7072431499320002,
+       "dof": 749,
+       "mean_difference": -0.0020049830884143393,
+       "sd_difference": 0.14614879086653915,
+       "significant": false,
+       "mde_80_power": 0.014951016600693286,
+       "n_needed_for_observed_diff": 41705
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 0.5227229131584058,
+       "p_value": 0.6013216712738614,
+       "dof": 749,
+       "mean_difference": 0.010666666666666666,
+       "sd_difference": 0.5588404295710776,
+       "significant": false,
+       "mde_80_power": 0.05716935795442618,
+       "n_needed_for_observed_diff": 21545
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0072562814962814914,
+      "ordered_step_accuracy": 0.00492854700854701,
+      "reference_validity_micro": 0.2,
+      "step_count_term": -0.0009777777777777775,
+      "_sum": 0.21120705072705073,
+      "_total_delta_composite": 0.21120705072705076,
+      "_residual": -2.7755575615628914e-17,
+      "_share_reference_term": 0.9469380842709936
+     },
+     "reference_terms": {
+      "ref_micro_a": 1.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6951111111111111,
+      "step_count_term_b": 0.7048888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5905492351780087,
+        "system_b": 0.5881874136887768,
+        "difference": 0.002361821489231919,
+        "ci_low": -0.0193505878285605,
+        "ci_high": 0.024303627099327374,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.30019740259740263,
+        "system_b": 0.25001904761904764,
+        "difference": 0.05017835497835499,
+        "ci_low": 0.01559939393939389,
+        "ci_high": 0.0846239826839827,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.28255555555555556,
+        "system_b": 0.2339333333333333,
+        "difference": 0.04862222222222226,
+        "ci_low": 0.012755000000000048,
+        "ci_high": 0.08406666666666665,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.48471229437229435,
+        "system_b": 0.4517876190476191,
+        "difference": 0.032924675324675245,
+        "ci_low": 0.006406041125541129,
+        "ci_high": 0.05929143722943719,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.12,
+        "system_b": 0.076,
+        "difference": 0.044,
+        "ci_low": 0.0040000000000000036,
+        "ci_high": 0.08400000000000002,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.664,
+        "system_b": 0.624,
+        "difference": 0.040000000000000036,
+        "ci_low": -0.02400000000000002,
+        "ci_high": 0.10399999999999998,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.355890367965368,
+        "system_b": 0.3147345238095239,
+        "difference": 0.04115584415584411,
+        "ci_low": 0.008007551406926359,
+        "ci_high": 0.07411429653679652,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.12,
+        "system_b_rate": 0.076,
+        "difference": 0.044,
+        "correct_only_in_a": 19,
+        "correct_only_in_b": 8,
+        "discordant_pairs": 27,
+        "p_value": 0.052238985896110535,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.4901161193847656e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.664,
+        "system_b_rate": 0.624,
+        "difference": 0.04,
+        "correct_only_in_a": 38,
+        "correct_only_in_b": 28,
+        "discordant_pairs": 66,
+        "p_value": 0.267811664846587,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.710505431213761e-20,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.1319074595773473,
+        "p_value": 0.033993610150440445,
+        "dof": 249,
+        "mean_difference": 0.044,
+        "sd_difference": 0.3263279942624559,
+        "significant": true,
+        "mde_80_power": 0.057821646735284886,
+        "n_needed_for_observed_diff": 432
+       },
+       "step_f1": {
+        "t_statistic": 2.8656914202575816,
+        "p_value": 0.004516566871350826,
+        "dof": 249,
+        "mean_difference": 0.050178354978354975,
+        "sd_difference": 0.2768579510172592,
+        "significant": true,
+        "mde_80_power": 0.04905611201317807,
+        "n_needed_for_observed_diff": 239
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.7217475532685125,
+        "p_value": 0.006952325341469151,
+        "dof": 249,
+        "mean_difference": 0.048622222222222226,
+        "sd_difference": 0.2824600079761825,
+        "significant": true,
+        "mde_80_power": 0.05004873343752724,
+        "n_needed_for_observed_diff": 265
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.21254113590619564,
+        "p_value": 0.8318587797114988,
+        "dof": 249,
+        "mean_difference": 0.002361821489232101,
+        "sd_difference": 0.17570093668833567,
+        "significant": false,
+        "mde_80_power": 0.031132227914472958,
+        "n_needed_for_observed_diff": 43438
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.2321901975453422,
+        "p_value": 0.2190403029437473,
+        "dof": 249,
+        "mean_difference": 0.04,
+        "sd_difference": 0.5132775226532369,
+        "significant": false,
+        "mde_80_power": 0.0909469984611497,
+        "n_needed_for_observed_diff": 1293
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.020071341991341998,
+       "ordered_step_accuracy": 0.014586666666666678,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0017333333333333313,
+       "_sum": 0.03292467532467534,
+       "_total_delta_composite": 0.032924675324675245,
+       "_residual": 9.71445146547012e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5059093683799802,
+        "system_b": 0.5224520146829778,
+        "difference": -0.01654264630299751,
+        "ci_low": -0.03395453020450259,
+        "ci_high": 0.0008781304672839336,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.12465079365079365,
+        "system_b": 0.14063174603174602,
+        "difference": -0.015980952380952373,
+        "ci_low": -0.041444920634920654,
+        "ci_high": 0.009210476190476173,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.10033333333333334,
+        "system_b": 0.11897142857142856,
+        "difference": -0.018638095238095218,
+        "ci_low": -0.04107619047619046,
+        "ci_high": 0.0027333333333333376,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3500936507936508,
+        "system_b": 0.36221079365079367,
+        "difference": -0.012117142857142882,
+        "ci_low": -0.030265539682539665,
+        "ci_high": 0.005366499999999977,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.012,
+        "difference": -0.004,
+        "ci_low": -0.023999999999999997,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.44,
+        "system_b": 0.456,
+        "difference": -0.016000000000000014,
+        "ci_low": -0.09599999999999997,
+        "ci_high": 0.06,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.18761706349206353,
+        "system_b": 0.2027634920634921,
+        "difference": -0.01514642857142856,
+        "ci_low": -0.03783192460317457,
+        "ci_high": 0.006708124999999985,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.012,
+        "difference": -0.004,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 3,
+        "discordant_pairs": 5,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.44,
+        "system_b_rate": 0.456,
+        "difference": -0.016,
+        "correct_only_in_a": 47,
+        "correct_only_in_b": 51,
+        "discordant_pairs": 98,
+        "p_value": 0.7620362195292433,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.310887241768095e-30,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.44649690658510954,
+        "p_value": 0.655626407259774,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.14164835695521658,
+        "significant": false,
+        "mde_80_power": 0.02509849415465968,
+        "n_needed_for_observed_diff": 9843
+       },
+       "step_f1": {
+        "t_statistic": -1.227379348057347,
+        "p_value": 0.22083916272631499,
+        "dof": 249,
+        "mean_difference": -0.01598095238095238,
+        "sd_difference": 0.2058703724422581,
+        "significant": false,
+        "mde_80_power": 0.036477912278172285,
+        "n_needed_for_observed_diff": 1303
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.6653386982375322,
+        "p_value": 0.09710283032900778,
+        "dof": 249,
+        "mean_difference": -0.018638095238095235,
+        "sd_difference": 0.1769574929769409,
+        "significant": false,
+        "mde_80_power": 0.031354875542320346,
+        "n_needed_for_observed_diff": 708
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.8926595997408358,
+        "p_value": 0.059562969579278945,
+        "dof": 249,
+        "mean_difference": -0.016542646302997496,
+        "sd_difference": 0.13819822870208467,
+        "significant": false,
+        "mde_80_power": 0.024487170270250384,
+        "n_needed_for_observed_diff": 548
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.4033838247220355,
+        "p_value": 0.6870120545311943,
+        "dof": 249,
+        "mean_difference": -0.016,
+        "sd_difference": 0.6271501168590382,
+        "significant": false,
+        "mde_80_power": 0.1111239401601899,
+        "n_needed_for_observed_diff": 12060
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.00639238095238095,
+       "ordered_step_accuracy": -0.005591428571428565,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.00013333333333332976,
+       "_sum": -0.012117142857142844,
+       "_total_delta_composite": -0.012117142857142882,
+       "_residual": 3.8163916471489756e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.47352289144103965,
+        "system_b": 0.4653570158925172,
+        "difference": 0.008165875548522439,
+        "ci_low": -0.006323681427042536,
+        "ci_high": 0.02308526891237614,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10929859029859029,
+        "system_b": 0.08907388167388168,
+        "difference": 0.020224708624708612,
+        "ci_low": -0.0013205555555555696,
+        "ci_high": 0.04216818348318349,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09591086691086691,
+        "system_b": 0.07660952380952381,
+        "difference": 0.0193013431013431,
+        "ci_low": -0.0006796886446886571,
+        "ci_high": 0.04019768009768009,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.33102602952602955,
+        "system_b": 0.11821240981240982,
+        "difference": 0.21281361971361973,
+        "ci_low": 0.0072269251859251905,
+        "ci_high": 0.22935133472083474,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.004,
+        "difference": 0.008,
+        "ci_low": -0.008,
+        "ci_high": 0.024,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.316,
+        "system_b": 0.308,
+        "difference": 0.008000000000000007,
+        "ci_low": -0.055999999999999994,
+        "ci_high": 0.07599999999999996,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1637825369075369,
+        "system_b": 0.14776551226551232,
+        "difference": 0.01601702464202459,
+        "ci_low": -0.005090063616938613,
+        "ci_high": 0.03789407377344882,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.004,
+        "difference": 0.008,
+        "correct_only_in_a": 3,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 4,
+        "p_value": 0.625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.316,
+        "system_b_rate": 0.308,
+        "difference": 0.008,
+        "correct_only_in_a": 36,
+        "correct_only_in_b": 34,
+        "discordant_pairs": 70,
+        "p_value": 0.9049745264594623,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.6940658945086007e-21,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.12649110640673517,
+        "significant": false,
+        "mde_80_power": 0.0224128,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 1.8148635001667053,
+        "p_value": 0.07074806280767783,
+        "dof": 249,
+        "mean_difference": 0.020224708624708626,
+        "sd_difference": 0.17620097671658533,
+        "significant": false,
+        "mde_80_power": 0.03122082937795543,
+        "n_needed_for_observed_diff": 596
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.833604551823731,
+        "p_value": 0.06790630576483399,
+        "dof": 249,
+        "mean_difference": 0.0193013431013431,
+        "sd_difference": 0.16643775791218124,
+        "significant": false,
+        "mde_80_power": 0.02949089692155234,
+        "n_needed_for_observed_diff": 584
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.093352972220772,
+        "p_value": 0.2752954698392419,
+        "dof": 249,
+        "mean_difference": 0.00816587554852238,
+        "sd_difference": 0.11808979569679787,
+        "significant": false,
+        "mde_80_power": 0.020924182325377017,
+        "n_needed_for_observed_diff": 1642
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.2385944208652801,
+        "p_value": 0.8116163355541196,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.5301511491677213,
+        "significant": false,
+        "mde_80_power": 0.09393681511377486,
+        "n_needed_for_observed_diff": 34470
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.008089883449883446,
+       "ordered_step_accuracy": 0.005790402930402929,
+       "reference_validity_micro": 0.2,
+       "step_count_term": -0.0010666666666666825,
+       "_sum": 0.2128136197136197,
+       "_total_delta_composite": 0.21281361971361973,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 0.9397894752654327
+      }
+     }
+    }
+   },
+   {
+    "family": "size_2000_vs_4000",
+    "kind": "pool_size",
+    "contrast": "4000 vs 2000",
+    "cell_a": "size4000_imbalanced_trial0__biencoder_only__raw",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_only__raw",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5284008790902841,
+       "system_b": 0.5233271649996762,
+       "difference": 0.0050737140906078615,
+       "ci_low": -0.005136101068305682,
+       "ci_high": 0.015595569003158961,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1762028463910817,
+       "system_b": 0.17804892884892884,
+       "difference": -0.001846082457847148,
+       "ci_low": -0.015403718199012286,
+       "ci_high": 0.011882458902753043,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.16001478151478152,
+       "system_b": 0.1595999185999186,
+       "difference": 0.0004148629148629235,
+       "ci_low": -0.01271795778295779,
+       "ci_high": 0.013962056647056652,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.3907522396775338,
+       "system_b": 0.38861065823065827,
+       "difference": 0.00214158144687554,
+       "ci_low": -0.008579178543134384,
+       "ci_high": 0.012776415593665597,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.04533333333333334,
+       "system_b": 0.04666666666666667,
+       "difference": -0.0013333333333333322,
+       "ci_low": -0.014666666666666668,
+       "ci_high": 0.012000000000000004,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.46266666666666667,
+       "system_b": 0.47333333333333333,
+       "difference": -0.010666666666666658,
+       "ci_low": -0.049333333333333285,
+       "ci_high": 0.02799999999999997,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2384402995969173,
+       "system_b": 0.2357633227883228,
+       "difference": 0.0026769768085944945,
+       "ci_low": -0.010723973178917993,
+       "ci_high": 0.015970519492081954,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.04533333333333334,
+       "system_b_rate": 0.04666666666666667,
+       "difference": -0.0013333333333333333,
+       "correct_only_in_a": 13,
+       "correct_only_in_b": 14,
+       "discordant_pairs": 27,
+       "p_value": 1.0,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.4901161193847656e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.46266666666666667,
+       "system_b_rate": 0.47333333333333333,
+       "difference": -0.010666666666666666,
+       "correct_only_in_a": 104,
+       "correct_only_in_b": 112,
+       "discordant_pairs": 216,
+       "p_value": 0.6339701087145501,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.8991135491519597e-65,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -0.19232649573582628,
+       "p_value": 0.847538597277353,
+       "dof": 749,
+       "mean_difference": -0.0013333333333333333,
+       "sd_difference": 0.18985858930829125,
+       "significant": false,
+       "mde_80_power": 0.01942252757413928,
+       "n_needed_for_observed_diff": 159146
+      },
+      "step_f1": {
+       "t_statistic": -0.26861970164469146,
+       "p_value": 0.7882963185283501,
+       "dof": 749,
+       "mean_difference": -0.0018460824578471638,
+       "sd_difference": 0.18821050708241194,
+       "significant": false,
+       "mde_80_power": 0.019253928815488375,
+       "n_needed_for_observed_diff": 81583
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 0.061780651866950746,
+       "p_value": 0.9507539933842699,
+       "dof": 749,
+       "mean_difference": 0.0004148629148629149,
+       "sd_difference": 0.18390043636324854,
+       "significant": false,
+       "mde_80_power": 0.018813008719671644,
+       "n_needed_for_observed_diff": 1542299
+      },
+      "rouge_l_f1": {
+       "t_statistic": 0.9654094153089452,
+       "p_value": 0.33465138517994447,
+       "dof": 749,
+       "mean_difference": 0.005073714090607813,
+       "sd_difference": 0.14392793428829326,
+       "significant": false,
+       "mde_80_power": 0.014723823044234549,
+       "n_needed_for_observed_diff": 6317
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.5440755278651457,
+       "p_value": 0.5865514180840279,
+       "dof": 749,
+       "mean_difference": -0.010666666666666666,
+       "sd_difference": 0.5369083562392701,
+       "significant": false,
+       "mde_80_power": 0.05492570755863936,
+       "n_needed_for_observed_diff": 19887
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.0007384329831388592,
+      "ordered_step_accuracy": 0.00012445887445887703,
+      "reference_validity_micro": 0.0,
+      "step_count_term": 0.002755555555555556,
+      "_sum": 0.0021415814468755735,
+      "_total_delta_composite": 0.00214158144687554,
+      "_residual": 3.3393426912553537e-17,
+      "_share_reference_term": 0.0
+     },
+     "reference_terms": {
+      "ref_micro_a": 1.0,
+      "ref_micro_b": 1.0,
+      "step_count_term_a": 0.7226666666666667,
+      "step_count_term_b": 0.6951111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6094034287187494,
+        "system_b": 0.5905492351780087,
+        "difference": 0.018854193540740694,
+        "ci_low": -0.003835728837287383,
+        "ci_high": 0.041712907728592874,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.29987965367965363,
+        "system_b": 0.30019740259740263,
+        "difference": -0.0003177489177489945,
+        "ci_low": -0.032890887445887515,
+        "ci_high": 0.03309564935064933,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.28357777777777776,
+        "system_b": 0.28255555555555556,
+        "difference": 0.0010222222222222022,
+        "ci_low": -0.03175888888888892,
+        "ci_high": 0.03537944444444443,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.48782519480519476,
+        "system_b": 0.48471229437229435,
+        "difference": 0.0031129004329004117,
+        "ci_low": -0.02238804112554112,
+        "ci_high": 0.029484770562770542,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.12,
+        "difference": -0.00399999999999999,
+        "ci_low": -0.044,
+        "ci_high": 0.036000000000000004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.668,
+        "system_b": 0.664,
+        "difference": 0.0040000000000000036,
+        "ci_low": -0.052000000000000046,
+        "ci_high": 0.06000000000000005,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3597814935064936,
+        "system_b": 0.355890367965368,
+        "difference": 0.003891125541125584,
+        "ci_low": -0.02798505140692638,
+        "ci_high": 0.03685596320346321,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.116,
+        "system_b_rate": 0.12,
+        "difference": -0.004,
+        "correct_only_in_a": 12,
+        "correct_only_in_b": 13,
+        "discordant_pairs": 25,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.960464477539063e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.668,
+        "system_b_rate": 0.664,
+        "difference": 0.004,
+        "correct_only_in_a": 28,
+        "correct_only_in_b": 27,
+        "discordant_pairs": 55,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.551115123125783e-17,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.19961556908234188,
+        "p_value": 0.841944167443241,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.31683677527817805,
+        "significant": false,
+        "mde_80_power": 0.05613990958479463,
+        "n_needed_for_observed_diff": 49246
+       },
+       "step_f1": {
+        "t_statistic": -0.018962983766398534,
+        "p_value": 0.9848858208707578,
+        "dof": 249,
+        "mean_difference": -0.00031774891774891947,
+        "sd_difference": 0.2649399262579557,
+        "significant": false,
+        "mde_80_power": 0.04694437220068566,
+        "n_needed_for_observed_diff": 5456812
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.06055116404928387,
+        "p_value": 0.951765238520927,
+        "dof": 249,
+        "mean_difference": 0.0010222222222222212,
+        "sd_difference": 0.2669271968438101,
+        "significant": false,
+        "mde_80_power": 0.04729649417551776,
+        "n_needed_for_observed_diff": 535190
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.629221822306448,
+        "p_value": 0.10453049549528226,
+        "dof": 249,
+        "mean_difference": 0.018854193540740548,
+        "sd_difference": 0.18297752404877918,
+        "significant": false,
+        "mde_80_power": 0.0324215572738647,
+        "n_needed_for_observed_diff": 740
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.13457491604929533,
+        "p_value": 0.8930566891864592,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.46996539221470135,
+        "significant": false,
+        "mde_80_power": 0.08327257656170524,
+        "n_needed_for_observed_diff": 108349
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.00012709956709959782,
+       "ordered_step_accuracy": 0.00030666666666666066,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0029333333333333325,
+       "_sum": 0.0031129004329003953,
+       "_total_delta_composite": 0.0031129004329004117,
+       "_residual": -1.6479873021779667e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.507201623981248,
+        "system_b": 0.5059093683799802,
+        "difference": 0.0012922556012677777,
+        "ci_low": -0.015179501029127072,
+        "ci_high": 0.017784425769040654,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1275968253968254,
+        "system_b": 0.12465079365079365,
+        "difference": 0.002946031746031752,
+        "ci_low": -0.016268730158730142,
+        "ci_high": 0.02257793650793651,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.10594285714285713,
+        "system_b": 0.10033333333333334,
+        "difference": 0.0056095238095237865,
+        "ci_low": -0.011829285714285709,
+        "ci_high": 0.023419761904761905,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.35428825396825403,
+        "system_b": 0.3500936507936508,
+        "difference": 0.00419460317460324,
+        "ci_low": -0.009989309523809515,
+        "ci_high": 0.01865173809523817,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.008,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.404,
+        "system_b": 0.44,
+        "difference": -0.035999999999999976,
+        "ci_low": -0.10799999999999998,
+        "ci_high": 0.03600000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19286031746031748,
+        "system_b": 0.18761706349206353,
+        "difference": 0.0052432539682539525,
+        "ci_low": -0.01248663690476188,
+        "ci_high": 0.02331467261904763,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.008,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.404,
+        "system_b_rate": 0.44,
+        "difference": -0.036,
+        "correct_only_in_a": 37,
+        "correct_only_in_b": 46,
+        "discordant_pairs": 83,
+        "p_value": 0.379999396411918,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.0679515313825692e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 0.295558200978952,
+        "p_value": 0.7678138145097065,
+        "dof": 249,
+        "mean_difference": 0.0029460317460317472,
+        "sd_difference": 0.15760297541678572,
+        "significant": false,
+        "mde_80_power": 0.027925472926634567,
+        "n_needed_for_observed_diff": 22463
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.6201775752201216,
+        "p_value": 0.5357080408975021,
+        "dof": 249,
+        "mean_difference": 0.00560952380952381,
+        "sd_difference": 0.143014456954072,
+        "significant": false,
+        "mde_80_power": 0.02534055169470438,
+        "n_needed_for_observed_diff": 5102
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.15048249770505773,
+        "p_value": 0.8805057875889741,
+        "dof": 249,
+        "mean_difference": 0.0012922556012677359,
+        "sd_difference": 0.13577894710140337,
+        "significant": false,
+        "mde_80_power": 0.024058500807233794,
+        "n_needed_for_observed_diff": 86653
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.9878305435823476,
+        "p_value": 0.3241945629963503,
+        "dof": 249,
+        "mean_difference": -0.036,
+        "sd_difference": 0.5762222908861269,
+        "significant": false,
+        "mde_80_power": 0.10210010275066203,
+        "n_needed_for_observed_diff": 2011
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.001178412698412701,
+       "ordered_step_accuracy": 0.001682857142857136,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.001333333333333331,
+       "_sum": 0.004194603174603168,
+       "_total_delta_composite": 0.00419460317460324,
+       "_residual": -7.19910242530375e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4685975845708547,
+        "system_b": 0.47352289144103965,
+        "difference": -0.004925306870184942,
+        "ci_low": -0.01727131356297415,
+        "ci_high": 0.007468732464126068,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10113206009676598,
+        "system_b": 0.10929859029859029,
+        "difference": -0.008166530201824312,
+        "ci_low": -0.02123583223965577,
+        "ci_high": 0.0051189489595372065,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09052370962370963,
+        "system_b": 0.09591086691086691,
+        "difference": -0.005387157287157274,
+        "ci_low": -0.017692221112221115,
+        "ci_high": 0.007181035353535357,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.33014327025915263,
+        "system_b": 0.33102602952602955,
+        "difference": -0.0008827592668769202,
+        "ci_low": -0.012953738929371307,
+        "ci_high": 0.011323916976813996,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.012,
+        "difference": -0.004,
+        "ci_low": -0.012,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.316,
+        "system_b": 0.316,
+        "difference": 0.0,
+        "ci_low": -0.068,
+        "ci_high": 0.07199999999999995,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1626790878239408,
+        "system_b": 0.1637825369075369,
+        "difference": -0.0011034490835961086,
+        "ci_low": -0.016192173661714104,
+        "ci_high": 0.014154896221017522,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.012,
+        "difference": -0.004,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.316,
+        "system_b_rate": 0.316,
+        "difference": 0.0,
+        "correct_only_in_a": 39,
+        "correct_only_in_b": 39,
+        "discordant_pairs": 78,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.617444900424222e-24,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -1.2063605463014397,
+        "p_value": 0.2288234293074336,
+        "dof": 249,
+        "mean_difference": -0.00816653020182432,
+        "sd_difference": 0.10703614312278088,
+        "significant": false,
+        "mde_80_power": 0.018965599532889586,
+        "n_needed_for_observed_diff": 1349
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.8532691499910571,
+        "p_value": 0.39433011770362736,
+        "dof": 249,
+        "mean_difference": -0.005387157287157287,
+        "sd_difference": 0.09982598773885899,
+        "significant": false,
+        "mde_80_power": 0.017688041171836623,
+        "n_needed_for_observed_diff": 2696
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.7752769766675789,
+        "p_value": 0.4389116551479461,
+        "dof": 249,
+        "mean_difference": -0.004925306870184846,
+        "sd_difference": 0.1004491836711518,
+        "significant": false,
+        "mde_80_power": 0.01779846447500846,
+        "n_needed_for_observed_diff": 3265
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.5596901035825028,
+        "significant": false,
+        "mde_80_power": 0.09917078528222904,
+        "n_needed_for_observed_diff": null
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0032666120807297253,
+       "ordered_step_accuracy": -0.0016161471861471822,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0040000000000000036,
+       "_sum": -0.0008827592668769039,
+       "_total_delta_composite": -0.0008827592668769202,
+       "_residual": 1.6263032587282567e-17,
+       "_share_reference_term": -0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_4000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 4000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_only__raw",
+    "cell_b": "size4000_imbalanced_trial0__biencoder_only__raw",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5351094175638953,
+       "system_b": 0.5284008790902841,
+       "difference": 0.006708538473611192,
+       "ci_low": -0.0028666073894118207,
+       "ci_high": 0.016362903798806977,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.18505331444154974,
+       "system_b": 0.1762028463910817,
+       "difference": 0.008850468050468047,
+       "ci_low": -0.005149063539945882,
+       "ci_high": 0.023020608879138277,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.16524013024013023,
+       "system_b": 0.16001478151478152,
+       "difference": 0.005225348725348716,
+       "ci_low": -0.007977773800273789,
+       "ci_high": 0.018686307488807462,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.19377114262643674,
+       "system_b": 0.3907522396775338,
+       "difference": -0.19698109705109706,
+       "ci_low": -0.20728570013156783,
+       "ci_high": 0.007943021880624882,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.044,
+       "system_b": 0.04533333333333334,
+       "difference": -0.0013333333333333391,
+       "ci_low": -0.014666666666666661,
+       "ci_high": 0.011999999999999997,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.48933333333333334,
+       "system_b": 0.46266666666666667,
+       "difference": 0.026666666666666672,
+       "ci_low": -0.013333333333333308,
+       "ci_high": 0.06666666666666671,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.24221392828304594,
+       "system_b": 0.2384402995969173,
+       "difference": 0.003773628686128655,
+       "ci_low": -0.009643768886342437,
+       "ci_high": 0.017442019335511972,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.044,
+       "system_b_rate": 0.04533333333333334,
+       "difference": -0.0013333333333333333,
+       "correct_only_in_a": 12,
+       "correct_only_in_b": 13,
+       "discordant_pairs": 25,
+       "p_value": 1.0,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.960464477539063e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.48933333333333334,
+       "system_b_rate": 0.46266666666666667,
+       "difference": 0.02666666666666667,
+       "correct_only_in_a": 131,
+       "correct_only_in_b": 111,
+       "discordant_pairs": 242,
+       "p_value": 0.22186976184417947,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.8298997121333476e-73,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -0.19987195218236017,
+       "p_value": 0.8416349783344649,
+       "dof": 749,
+       "mean_difference": -0.0013333333333333333,
+       "sd_difference": 0.18269115185153886,
+       "significant": false,
+       "mde_80_power": 0.01868929895305412,
+       "n_needed_for_observed_diff": 147357
+      },
+      "step_f1": {
+       "t_statistic": 1.2280544884167175,
+       "p_value": 0.21981228050558815,
+       "dof": 749,
+       "mean_difference": 0.00885046805046805,
+       "sd_difference": 0.19736913310621682,
+       "significant": false,
+       "mde_80_power": 0.020190855962880862,
+       "n_needed_for_observed_diff": 3904
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 0.7639583799716582,
+       "p_value": 0.4451326315284238,
+       "dof": 749,
+       "mean_difference": 0.005225348725348725,
+       "sd_difference": 0.18731657657911555,
+       "significant": false,
+       "mde_80_power": 0.01916247975377937,
+       "n_needed_for_observed_diff": 10087
+      },
+      "rouge_l_f1": {
+       "t_statistic": 1.3522404300899253,
+       "p_value": 0.1767065492103723,
+       "dof": 749,
+       "mean_difference": 0.0067085384736111945,
+       "sd_difference": 0.1358640729904731,
+       "significant": false,
+       "mde_80_power": 0.013898890293066641,
+       "n_needed_for_observed_diff": 3220
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 1.2862094004305584,
+       "p_value": 0.19876743709621675,
+       "dof": 749,
+       "mean_difference": 0.02666666666666667,
+       "sd_difference": 0.5677899283707263,
+       "significant": false,
+       "mde_80_power": 0.058084891393519904,
+       "n_needed_for_observed_diff": 3559
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.003540187220187219,
+      "ordered_step_accuracy": 0.0015676046176046148,
+      "reference_validity_micro": -0.2,
+      "step_count_term": -0.0020888888888888845,
+      "_sum": -0.19698109705109706,
+      "_total_delta_composite": -0.19698109705109706,
+      "_residual": 0.0,
+      "_share_reference_term": 1.0153258510288419
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 1.0,
+      "step_count_term_a": 0.7017777777777778,
+      "step_count_term_b": 0.7226666666666667
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6220761386132809,
+        "system_b": 0.6094034287187494,
+        "difference": 0.012672709894531509,
+        "ci_low": -0.007744198909632177,
+        "ci_high": 0.03314070055058155,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.31041344537815124,
+        "system_b": 0.29987965367965363,
+        "difference": 0.010533791698497608,
+        "ci_low": -0.019495017825311895,
+        "ci_high": 0.04120669213139798,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2887076923076923,
+        "system_b": 0.28357777777777776,
+        "difference": 0.005129914529914514,
+        "ci_low": -0.024499444444444466,
+        "ci_high": 0.03477444444444448,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4919776858435682,
+        "system_b": 0.48782519480519476,
+        "difference": 0.0041524910383734515,
+        "ci_low": -0.018663095238095236,
+        "ci_high": 0.0274990232512585,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.108,
+        "system_b": 0.116,
+        "difference": -0.008000000000000007,
+        "ci_low": -0.04000000000000001,
+        "ci_high": 0.024000000000000007,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.684,
+        "system_b": 0.668,
+        "difference": 0.016000000000000014,
+        "ci_low": -0.04399999999999993,
+        "ci_high": 0.07599999999999996,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3649721073044603,
+        "system_b": 0.3597814935064936,
+        "difference": 0.005190613797966703,
+        "ci_low": -0.023328869047619046,
+        "ci_high": 0.03437377906407315,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.108,
+        "system_b_rate": 0.116,
+        "difference": -0.008,
+        "correct_only_in_a": 8,
+        "correct_only_in_b": 10,
+        "discordant_pairs": 18,
+        "p_value": 0.8145294189453125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 7.62939453125e-06,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.684,
+        "system_b_rate": 0.668,
+        "difference": 0.016,
+        "correct_only_in_a": 31,
+        "correct_only_in_b": 27,
+        "discordant_pairs": 58,
+        "p_value": 0.6940040940761316,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.938893903907228e-18,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.47067000022342653,
+        "p_value": 0.6382884447377812,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.26874690621176195,
+        "significant": false,
+        "mde_80_power": 0.04761892618896609,
+        "n_needed_for_observed_diff": 8858
+       },
+       "step_f1": {
+        "t_statistic": 0.6780466439949563,
+        "p_value": 0.498371714333418,
+        "dof": 249,
+        "mean_difference": 0.01053379169849758,
+        "sd_difference": 0.24563777772546436,
+        "significant": false,
+        "mde_80_power": 0.04352424878712378,
+        "n_needed_for_observed_diff": 4269
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.33533047488873124,
+        "p_value": 0.7376581499788509,
+        "dof": 249,
+        "mean_difference": 0.005129914529914531,
+        "sd_difference": 0.2418839820911702,
+        "significant": false,
+        "mde_80_power": 0.04285911846150408,
+        "n_needed_for_observed_diff": 17451
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.2162684738521226,
+        "p_value": 0.22503437765755635,
+        "dof": 249,
+        "mean_difference": 0.01267270989453162,
+        "sd_difference": 0.1647441673233097,
+        "significant": false,
+        "mde_80_power": 0.029190811735893482,
+        "n_needed_for_observed_diff": 1327
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.5244636665499992,
+        "p_value": 0.6004226595596188,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.4823636582446699,
+        "significant": false,
+        "mde_80_power": 0.08546940972073344,
+        "n_needed_for_observed_diff": 7134
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.004213516679399044,
+       "ordered_step_accuracy": 0.0015389743589743542,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0015999999999999903,
+       "_sum": 0.004152491038373407,
+       "_total_delta_composite": 0.0041524910383734515,
+       "_residual": -4.423544863740858e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5127014729135133,
+        "system_b": 0.507201623981248,
+        "difference": 0.005499848932265294,
+        "ci_low": -0.010122286630162427,
+        "ci_high": 0.021017252383222808,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13543174603174604,
+        "system_b": 0.1275968253968254,
+        "difference": 0.007834920634920639,
+        "ci_low": -0.014276904761904755,
+        "ci_high": 0.030505476190476184,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11206666666666665,
+        "system_b": 0.10594285714285713,
+        "difference": 0.0061238095238095175,
+        "ci_low": -0.013705000000000009,
+        "ci_high": 0.02648571428571428,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3589926984126984,
+        "system_b": 0.35428825396825403,
+        "difference": 0.0047044444444443445,
+        "ci_low": -0.011175698412698389,
+        "ci_high": 0.02139300793650794,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.012,
+        "difference": -0.004,
+        "ci_low": -0.02,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.472,
+        "system_b": 0.404,
+        "difference": 0.06799999999999995,
+        "ci_low": -0.0040000000000000036,
+        "ci_high": 0.14399999999999996,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19874087301587304,
+        "system_b": 0.19286031746031748,
+        "difference": 0.0058805555555555555,
+        "ci_low": -0.013969623015873,
+        "ci_high": 0.026741259920634922,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.012,
+        "difference": -0.004,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 3,
+        "discordant_pairs": 5,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.472,
+        "system_b_rate": 0.404,
+        "difference": 0.068,
+        "correct_only_in_a": 53,
+        "correct_only_in_b": 36,
+        "discordant_pairs": 89,
+        "p_value": 0.08932073673118934,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.2311742677852644e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.4464969065851096,
+        "p_value": 0.655626407259774,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.14164835695521658,
+        "significant": false,
+        "mde_80_power": 0.02509849415465968,
+        "n_needed_for_observed_diff": 9843
+       },
+       "step_f1": {
+        "t_statistic": 0.6979844525169173,
+        "p_value": 0.48583820017217016,
+        "dof": 249,
+        "mean_difference": 0.007834920634920632,
+        "sd_difference": 0.1774838565791783,
+        "significant": false,
+        "mde_80_power": 0.03144814124675883,
+        "n_needed_for_observed_diff": 4028
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.6025524051697702,
+        "p_value": 0.547354836997511,
+        "dof": 249,
+        "mean_difference": 0.006123809523809524,
+        "sd_difference": 0.16069296119408108,
+        "significant": false,
+        "mde_80_power": 0.028472983618862,
+        "n_needed_for_observed_diff": 5405
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.6850776620387091,
+        "p_value": 0.4939321509680216,
+        "dof": 249,
+        "mean_difference": 0.005499848932265198,
+        "sd_difference": 0.12693487451514981,
+        "significant": false,
+        "mde_80_power": 0.022491430712805165,
+        "n_needed_for_observed_diff": 4181
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.810183237469916,
+        "p_value": 0.07147285412756481,
+        "dof": 249,
+        "mean_difference": 0.068,
+        "sd_difference": 0.5939588778647706,
+        "significant": false,
+        "mde_80_power": 0.1052428262822018,
+        "n_needed_for_observed_diff": 599
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0031339682539682557,
+       "ordered_step_accuracy": 0.0018371428571428551,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.00026666666666667064,
+       "_sum": 0.00470444444444444,
+       "_total_delta_composite": 0.0047044444444443445,
+       "_residual": 9.540979117872439e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4705506411648915,
+        "system_b": 0.4685975845708547,
+        "difference": 0.0019530565940367728,
+        "ci_low": -0.011359459511846703,
+        "ci_high": 0.01605670945069435,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10931475191475193,
+        "system_b": 0.10113206009676598,
+        "difference": 0.008182691817985949,
+        "ci_low": -0.011721219140336792,
+        "ci_high": 0.027768479331126403,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09494603174603175,
+        "system_b": 0.09052370962370963,
+        "difference": 0.004422322122322117,
+        "ci_low": -0.013687659840159827,
+        "ci_high": 0.02257730880230878,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.1303430436230436,
+        "system_b": 0.33014327025915263,
+        "difference": -0.19980022663610902,
+        "ci_low": -0.21524678760292,
+        "ci_high": 0.007020700882450849,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.008,
+        "difference": 0.008,
+        "ci_low": 0.0,
+        "ci_high": 0.02,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.312,
+        "system_b": 0.316,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.08000000000000002,
+        "ci_high": 0.07200000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16292880452880454,
+        "system_b": 0.1626790878239408,
+        "difference": 0.0002497167048637339,
+        "ci_low": -0.019672172486418803,
+        "ci_high": 0.02019736843222135,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.008,
+        "difference": 0.008,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.312,
+        "system_b_rate": 0.316,
+        "difference": -0.004,
+        "correct_only_in_a": 47,
+        "correct_only_in_b": 48,
+        "discordant_pairs": 95,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.048709793414476e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.417061930943398,
+        "p_value": 0.1577147927470212,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.08926293455821277,
+        "significant": false,
+        "mde_80_power": 0.015816387068615167,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": 0.8128597665716454,
+        "p_value": 0.41707497549999994,
+        "dof": 249,
+        "mean_difference": 0.008182691817985937,
+        "sd_difference": 0.15916609850918736,
+        "significant": false,
+        "mde_80_power": 0.028202440740741016,
+        "n_needed_for_observed_diff": 2970
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.4800889092789892,
+        "p_value": 0.6315856410906553,
+        "dof": 249,
+        "mean_difference": 0.004422322122322122,
+        "sd_difference": 0.14564604787986185,
+        "significant": false,
+        "mde_80_power": 0.025806839979920948,
+        "n_needed_for_observed_diff": 8514
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.2794370939403354,
+        "p_value": 0.7801413762419717,
+        "dof": 249,
+        "mean_difference": 0.001953056594036766,
+        "sd_difference": 0.11050979576973619,
+        "significant": false,
+        "mde_80_power": 0.01958109167504334,
+        "n_needed_for_observed_diff": 25130
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.10239458962927071,
+        "p_value": 0.9185258898695725,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.617664990233899,
+        "significant": false,
+        "mde_80_power": 0.10944328250715035,
+        "n_needed_for_observed_diff": 187154
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0032730767271943796,
+       "ordered_step_accuracy": 0.0013266966366966351,
+       "reference_validity_micro": -0.2,
+       "step_count_term": -0.004400000000000004,
+       "_sum": -0.199800226636109,
+       "_total_delta_composite": -0.19980022663610902,
+       "_residual": 2.7755575615628914e-17,
+       "_share_reference_term": 1.0009998655519787
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 1000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_only__raw",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__raw",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5351094175638953,
+       "system_b": 0.5253321480880906,
+       "difference": 0.009777269475804706,
+       "ci_low": -0.0016490680028039078,
+       "ci_high": 0.02126043667680926,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.18505331444154974,
+       "system_b": 0.1599082251082251,
+       "difference": 0.025145089333324627,
+       "ci_low": 0.008789742947684118,
+       "ci_high": 0.0421155640437993,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.16524013024013023,
+       "system_b": 0.14317142857142856,
+       "difference": 0.022068701668701673,
+       "ci_low": 0.006466477411477425,
+       "ci_high": 0.03844555352055352,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.19377114262643674,
+       "system_b": 0.1774036075036075,
+       "difference": 0.016367535122829235,
+       "ci_low": -0.18676671830783598,
+       "ci_high": 0.21992557704060645,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.044,
+       "system_b": 0.030666666666666665,
+       "difference": 0.013333333333333332,
+       "ci_low": -0.0013333333333333357,
+       "ci_high": 0.029333333333333333,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.48933333333333334,
+       "system_b": 0.46266666666666667,
+       "difference": 0.026666666666666672,
+       "ci_low": -0.016000000000000014,
+       "ci_high": 0.0693333333333333,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.24221392828304594,
+       "system_b": 0.2217545093795094,
+       "difference": 0.02045941890353653,
+       "ci_low": 0.005022646331065409,
+       "ci_high": 0.0365239324441898,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.044,
+       "system_b_rate": 0.030666666666666665,
+       "difference": 0.013333333333333334,
+       "correct_only_in_a": 23,
+       "correct_only_in_b": 13,
+       "discordant_pairs": 36,
+       "p_value": 0.13249816396273673,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.9103830456733704e-11,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.48933333333333334,
+       "system_b_rate": 0.46266666666666667,
+       "difference": 0.02666666666666667,
+       "correct_only_in_a": 143,
+       "correct_only_in_b": 123,
+       "discordant_pairs": 266,
+       "p_value": 0.24398110770721304,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.6867516709168837e-80,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.6686481405917704,
+       "p_value": 0.09560505432274495,
+       "dof": 749,
+       "mean_difference": 0.013333333333333334,
+       "sd_difference": 0.21882886079303357,
+       "significant": false,
+       "mde_80_power": 0.022386185414391312,
+       "n_needed_for_observed_diff": 2115
+      },
+      "step_f1": {
+       "t_statistic": 2.9237467040314375,
+       "p_value": 0.003562774014612541,
+       "dof": 749,
+       "mean_difference": 0.025145089333324624,
+       "sd_difference": 0.235528827092888,
+       "significant": true,
+       "mde_80_power": 0.024094591429246047,
+       "n_needed_for_observed_diff": 689
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 2.6604435444679546,
+       "p_value": 0.00797077574712027,
+       "dof": 749,
+       "mean_difference": 0.02206870166870167,
+       "sd_difference": 0.22717125014613146,
+       "significant": true,
+       "mde_80_power": 0.023239611576647504,
+       "n_needed_for_observed_diff": 832
+      },
+      "rouge_l_f1": {
+       "t_statistic": 1.6769256445685103,
+       "p_value": 0.09397427831480368,
+       "dof": 749,
+       "mean_difference": 0.009777269475804668,
+       "sd_difference": 0.15967407559334218,
+       "significant": false,
+       "mde_80_power": 0.016334652792827073,
+       "n_needed_for_observed_diff": 2094
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 1.2266912698891683,
+       "p_value": 0.22032411861900394,
+       "dof": 749,
+       "mean_difference": 0.02666666666666667,
+       "sd_difference": 0.59533866529123,
+       "significant": false,
+       "mde_80_power": 0.06090312629361366,
+       "n_needed_for_observed_diff": 3913
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.010058035733329852,
+      "ordered_step_accuracy": 0.006620610500610502,
+      "reference_validity_micro": 0.0,
+      "step_count_term": -0.00031111111111110646,
+      "_sum": 0.016367535122829246,
+      "_total_delta_composite": 0.016367535122829235,
+      "_residual": 1.0408340855860843e-17,
+      "_share_reference_term": 0.0
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.7017777777777778,
+      "step_count_term_b": 0.7048888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6220761386132809,
+        "system_b": 0.5881874136887768,
+        "difference": 0.03388872492450412,
+        "ci_low": 0.009807096552833076,
+        "ci_high": 0.058739183955778575,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.31041344537815124,
+        "system_b": 0.25001904761904764,
+        "difference": 0.0603943977591036,
+        "ci_low": 0.023460168067226922,
+        "ci_high": 0.09858487394957982,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2887076923076923,
+        "system_b": 0.2339333333333333,
+        "difference": 0.05477435897435898,
+        "ci_low": 0.01766602564102564,
+        "ci_high": 0.09200000000000003,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4919776858435682,
+        "system_b": 0.4517876190476191,
+        "difference": 0.04019006679594911,
+        "ci_low": 0.011996675070027977,
+        "ci_high": 0.06890109523809522,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.108,
+        "system_b": 0.076,
+        "difference": 0.032,
+        "ci_low": -0.007999999999999993,
+        "ci_high": 0.07200000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.684,
+        "system_b": 0.624,
+        "difference": 0.06000000000000005,
+        "ci_low": -0.008000000000000007,
+        "ci_high": 0.124,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3649721073044603,
+        "system_b": 0.3147345238095239,
+        "difference": 0.0502375834949364,
+        "ci_low": 0.014995843837535012,
+        "ci_high": 0.08612636904761904,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.108,
+        "system_b_rate": 0.076,
+        "difference": 0.032,
+        "correct_only_in_a": 17,
+        "correct_only_in_b": 9,
+        "discordant_pairs": 26,
+        "p_value": 0.16863754391670227,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.9802322387695312e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.684,
+        "system_b_rate": 0.624,
+        "difference": 0.06,
+        "correct_only_in_a": 44,
+        "correct_only_in_b": 29,
+        "discordant_pairs": 73,
+        "p_value": 0.1006436775202357,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.117582368135751e-22,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.5735539693536453,
+        "p_value": 0.11686032863101328,
+        "dof": 249,
+        "mean_difference": 0.032,
+        "sd_difference": 0.32154246723089586,
+        "significant": false,
+        "mde_80_power": 0.0569737052214518,
+        "n_needed_for_observed_diff": 793
+       },
+       "step_f1": {
+        "t_statistic": 3.190132204534205,
+        "p_value": 0.0016045428540597975,
+        "dof": 249,
+        "mean_difference": 0.06039439775910365,
+        "sd_difference": 0.2993353293657973,
+        "significant": true,
+        "mde_80_power": 0.05303885040294435,
+        "n_needed_for_observed_diff": 193
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.898597063369439,
+        "p_value": 0.004082626501238673,
+        "dof": 249,
+        "mean_difference": 0.05477435897435898,
+        "sd_difference": 0.2987854606002238,
+        "significant": true,
+        "mde_80_power": 0.05294141984818726,
+        "n_needed_for_observed_diff": 234
+       },
+       "rouge_l_f1": {
+        "t_statistic": 2.763033281149966,
+        "p_value": 0.0061541262913218505,
+        "dof": 249,
+        "mean_difference": 0.03388872492450427,
+        "sd_difference": 0.19392737411354888,
+        "significant": true,
+        "mde_80_power": 0.03436174743033725,
+        "n_needed_for_observed_diff": 258
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.7630039929214185,
+        "p_value": 0.07912644943012093,
+        "dof": 249,
+        "mean_difference": 0.06,
+        "sd_difference": 0.5381061539619547,
+        "significant": false,
+        "mde_80_power": 0.09534635240471202,
+        "n_needed_for_observed_diff": 632
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.024157759103641444,
+       "ordered_step_accuracy": 0.016432307692307694,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0003999999999999893,
+       "_sum": 0.04019006679594915,
+       "_total_delta_composite": 0.04019006679594911,
+       "_residual": 4.163336342344337e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5127014729135133,
+        "system_b": 0.5224520146829778,
+        "difference": -0.009750541769464438,
+        "ci_low": -0.026986401246244622,
+        "ci_high": 0.0071095916701412985,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13543174603174604,
+        "system_b": 0.14063174603174602,
+        "difference": -0.005199999999999982,
+        "ci_low": -0.028927301587301568,
+        "ci_high": 0.017511984126984133,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11206666666666665,
+        "system_b": 0.11897142857142856,
+        "difference": -0.0069047619047619135,
+        "ci_low": -0.02794285714285713,
+        "ci_high": 0.013019285714285716,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3589926984126984,
+        "system_b": 0.36221079365079367,
+        "difference": -0.0032180952380952976,
+        "ci_low": -0.020354341269841272,
+        "ci_high": 0.013260960317460308,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.012,
+        "difference": -0.004,
+        "ci_low": -0.024,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.472,
+        "system_b": 0.456,
+        "difference": 0.01599999999999996,
+        "ci_low": -0.064,
+        "ci_high": 0.09199999999999997,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19874087301587304,
+        "system_b": 0.2027634920634921,
+        "difference": -0.004022619047619053,
+        "ci_low": -0.0254429265873016,
+        "ci_high": 0.016576200396825388,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.012,
+        "difference": -0.004,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 3,
+        "discordant_pairs": 5,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.472,
+        "system_b_rate": 0.456,
+        "difference": 0.016,
+        "correct_only_in_a": 50,
+        "correct_only_in_b": 46,
+        "discordant_pairs": 96,
+        "p_value": 0.7596492883236297,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.524354896707238e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.4464969065851096,
+        "p_value": 0.655626407259774,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.14164835695521658,
+        "significant": false,
+        "mde_80_power": 0.02509849415465968,
+        "n_needed_for_observed_diff": 9843
+       },
+       "step_f1": {
+        "t_statistic": -0.44308121000860995,
+        "p_value": 0.6580916966702451,
+        "dof": 249,
+        "mean_difference": -0.005200000000000003,
+        "sd_difference": 0.185562414535205,
+        "significant": false,
+        "mde_80_power": 0.0328795707669863,
+        "n_needed_for_observed_diff": 9996
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.6624601223857982,
+        "p_value": 0.5082890761928074,
+        "dof": 249,
+        "mean_difference": -0.006904761904761904,
+        "sd_difference": 0.16480066937141824,
+        "significant": false,
+        "mde_80_power": 0.029200823262710035,
+        "n_needed_for_observed_diff": 4472
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.1125186976142174,
+        "p_value": 0.2669881083089196,
+        "dof": 249,
+        "mean_difference": -0.009750541769464561,
+        "sd_difference": 0.13857708853900344,
+        "significant": false,
+        "mde_80_power": 0.024554299968093243,
+        "n_needed_for_observed_diff": 1586
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.4075668540174267,
+        "p_value": 0.6839418883531375,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.6207134125844624,
+        "significant": false,
+        "mde_80_power": 0.10998342862808798,
+        "n_needed_for_observed_diff": 11813
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.002079999999999993,
+       "ordered_step_accuracy": -0.002071428571428574,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0009333333333333305,
+       "_sum": -0.003218095238095236,
+       "_total_delta_composite": -0.0032180952380952976,
+       "_residual": 6.158268339717665e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4705506411648915,
+        "system_b": 0.4653570158925172,
+        "difference": 0.005193625272374269,
+        "ci_low": -0.011232176034927321,
+        "ci_high": 0.02234489988666949,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10931475191475193,
+        "system_b": 0.08907388167388168,
+        "difference": 0.02024087024087025,
+        "ci_low": -0.004330305805305822,
+        "ci_high": 0.04599081252081252,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09494603174603175,
+        "system_b": 0.07660952380952381,
+        "difference": 0.018336507936507943,
+        "ci_low": -0.004737142857142849,
+        "ci_high": 0.042705079365079356,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.1303430436230436,
+        "system_b": 0.11821240981240982,
+        "difference": 0.012130633810633784,
+        "ci_low": -0.19278011111111112,
+        "ci_high": 0.21938389782439782,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.004,
+        "difference": 0.012,
+        "ci_low": -0.004,
+        "ci_high": 0.032,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.312,
+        "system_b": 0.308,
+        "difference": 0.0040000000000000036,
+        "ci_low": -0.07200000000000001,
+        "ci_high": 0.08000000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16292880452880454,
+        "system_b": 0.14776551226551232,
+        "difference": 0.015163292263292216,
+        "ci_low": -0.008702218267843261,
+        "ci_high": 0.040256548451548455,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.004,
+        "difference": 0.012,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 5,
+        "p_value": 0.375,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.312,
+        "system_b_rate": 0.308,
+        "difference": 0.004,
+        "correct_only_in_a": 49,
+        "correct_only_in_b": 48,
+        "discordant_pairs": 97,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.262177448353619e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.3438012400514816,
+        "p_value": 0.18023588114803066,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.14119399056577286,
+        "significant": false,
+        "mde_80_power": 0.025017985545773152,
+        "n_needed_for_observed_diff": 1087
+       },
+       "step_f1": {
+        "t_statistic": 1.5876128021862765,
+        "p_value": 0.1136429111239378,
+        "dof": 249,
+        "mean_difference": 0.020240870240870238,
+        "sd_difference": 0.20158331961334508,
+        "significant": false,
+        "mde_80_power": 0.03571829478115318,
+        "n_needed_for_observed_diff": 779
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.509864425314464,
+        "p_value": 0.1323459187773141,
+        "dof": 249,
+        "mean_difference": 0.018336507936507936,
+        "sd_difference": 0.19202098029775916,
+        "significant": false,
+        "mde_80_power": 0.034023955908638166,
+        "n_needed_for_observed_diff": 861
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.5974323585507127,
+        "p_value": 0.5507616583091401,
+        "dof": 249,
+        "mean_difference": 0.0051936252723743,
+        "sd_difference": 0.1374522566366904,
+        "significant": false,
+        "mde_80_power": 0.024354992418524526,
+        "n_needed_for_observed_diff": 5498
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.10133343317462325,
+        "p_value": 0.919367326166501,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.6241331337741161,
+        "significant": false,
+        "mde_80_power": 0.11058936472317607,
+        "n_needed_for_observed_diff": 191094
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0080963480963481,
+       "ordered_step_accuracy": 0.005500952380952382,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.001466666666666683,
+       "_sum": 0.012130633810633798,
+       "_total_delta_composite": 0.012130633810633784,
+       "_residual": 1.3877787807814457e-17,
+       "_share_reference_term": 0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_imbalanced_trial0__biencoder_only__typed",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__typed",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5310403311127952,
+       "system_b": 0.517633339818622,
+       "difference": 0.01340699129417322,
+       "ci_low": 0.0031710590218864535,
+       "ci_high": 0.023823591215203475,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1912138454138454,
+       "system_b": 0.16706542825366355,
+       "difference": 0.024148417160181845,
+       "ci_low": 0.009986224537989237,
+       "ci_high": 0.038535975897740576,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.17263756613756615,
+       "system_b": 0.14791856661856662,
+       "difference": 0.02471899951899953,
+       "ci_low": 0.011074819624819631,
+       "ci_high": 0.038697512025012024,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.22216569689569687,
+       "system_b": 0.18102396350925765,
+       "difference": 0.04114173338643923,
+       "ci_low": 0.007718936189627328,
+       "ci_high": 0.22357995939300354,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.050666666666666665,
+       "system_b": 0.02666666666666667,
+       "difference": 0.023999999999999997,
+       "ci_low": 0.010666666666666672,
+       "ci_high": 0.03733333333333333,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.468,
+       "system_b": 0.47333333333333333,
+       "difference": -0.005333333333333301,
+       "ci_low": -0.04533333333333334,
+       "ci_high": 0.03600000000000003,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.24645712111962115,
+       "system_b": 0.22627995438657206,
+       "difference": 0.02017716673304909,
+       "ci_low": 0.006183920510317557,
+       "ci_high": 0.03445286356005111,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.050666666666666665,
+       "system_b_rate": 0.02666666666666667,
+       "difference": 0.024,
+       "correct_only_in_a": 22,
+       "correct_only_in_b": 4,
+       "discordant_pairs": 26,
+       "p_value": 0.0005335211753845215,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 2.9802322387695312e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.468,
+       "system_b_rate": 0.47333333333333333,
+       "difference": -0.005333333333333333,
+       "correct_only_in_a": 119,
+       "correct_only_in_b": 123,
+       "discordant_pairs": 242,
+       "p_value": 0.8471289384306088,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.8298997121333476e-73,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 3.5574139473064714,
+       "p_value": 0.00039809609572321296,
+       "dof": 749,
+       "mean_difference": 0.024,
+       "sd_difference": 0.18475979426118094,
+       "significant": true,
+       "mde_80_power": 0.0189009210049649,
+       "n_needed_for_observed_diff": 466
+      },
+      "step_f1": {
+       "t_statistic": 3.2849911770159475,
+       "p_value": 0.001067293454098381,
+       "dof": 749,
+       "mean_difference": 0.024148417160181866,
+       "sd_difference": 0.20131915268477812,
+       "significant": true,
+       "mde_80_power": 0.020594942838605093,
+       "n_needed_for_observed_diff": 546
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 3.4980771201895497,
+       "p_value": 0.0004962843354060152,
+       "dof": 749,
+       "mean_difference": 0.02471899951899952,
+       "sd_difference": 0.19352280081780676,
+       "significant": true,
+       "mde_80_power": 0.01979737629360111,
+       "n_needed_for_observed_diff": 482
+      },
+      "rouge_l_f1": {
+       "t_statistic": 2.533665718112272,
+       "p_value": 0.011490438795478045,
+       "dof": 749,
+       "mean_difference": 0.013406991294173177,
+       "sd_difference": 0.14491476731913205,
+       "significant": true,
+       "mde_80_power": 0.014824776031520338,
+       "n_needed_for_observed_diff": 918
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.25696958834234396,
+       "p_value": 0.7972728224121944,
+       "dof": 749,
+       "mean_difference": -0.005333333333333333,
+       "sd_difference": 0.5683915735330473,
+       "significant": false,
+       "mde_80_power": 0.05814643967425664,
+       "n_needed_for_observed_diff": 89148
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.00965936686407274,
+      "ordered_step_accuracy": 0.007415699855699859,
+      "reference_validity_micro": 0.025,
+      "step_count_term": -0.0009333333333333416,
+      "_sum": 0.041141733386439255,
+      "_total_delta_composite": 0.04114173338643923,
+      "_residual": 2.7755575615628914e-17,
+      "_share_reference_term": 0.6076554861016206
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.125,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6888888888888889,
+      "step_count_term_b": 0.6982222222222223
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6067046545547155,
+        "system_b": 0.5812850040425221,
+        "difference": 0.025419650512193304,
+        "ci_low": 0.003262118453866414,
+        "ci_high": 0.0470789865018155,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.29893333333333333,
+        "system_b": 0.2664915750915751,
+        "difference": 0.03244175824175821,
+        "ci_low": 0.0017743772893772526,
+        "ci_high": 0.06503666666666671,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2848333333333333,
+        "system_b": 0.25579999999999997,
+        "difference": 0.029033333333333355,
+        "ci_low": -0.0006341666666666794,
+        "ci_high": 0.06023333333333325,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4835566666666667,
+        "system_b": 0.46666996336996336,
+        "difference": 0.01688670329670333,
+        "ci_low": -0.007445559523809464,
+        "ci_high": 0.0420124056776557,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.08,
+        "difference": 0.036000000000000004,
+        "ci_low": 0.0040000000000000036,
+        "ci_high": 0.068,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.692,
+        "system_b": 0.688,
+        "difference": 0.0040000000000000036,
+        "ci_low": -0.06399999999999995,
+        "ci_high": 0.06799999999999995,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3544458333333334,
+        "system_b": 0.33333745421245425,
+        "difference": 0.02110837912087915,
+        "ci_low": -0.009306949404761912,
+        "ci_high": 0.0525155070970696,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.116,
+        "system_b_rate": 0.08,
+        "difference": 0.036,
+        "correct_only_in_a": 13,
+        "correct_only_in_b": 4,
+        "discordant_pairs": 17,
+        "p_value": 0.049041748046875,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 1.52587890625e-05,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.692,
+        "system_b_rate": 0.688,
+        "difference": 0.004,
+        "correct_only_in_a": 35,
+        "correct_only_in_b": 34,
+        "discordant_pairs": 69,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.3881317890172014e-21,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.1995114920249934,
+        "p_value": 0.028761090347486657,
+        "dof": 249,
+        "mean_difference": 0.036,
+        "sd_difference": 0.258789272478982,
+        "significant": true,
+        "mde_80_power": 0.04585454559600634,
+        "n_needed_for_observed_diff": 406
+       },
+       "step_f1": {
+        "t_statistic": 1.999823170845043,
+        "p_value": 0.04660568846547865,
+        "dof": 249,
+        "mean_difference": 0.03244175824175824,
+        "sd_difference": 0.25649729646132974,
+        "significant": true,
+        "mde_80_power": 0.04544843324907773,
+        "n_needed_for_observed_diff": 491
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.8744838350708435,
+        "p_value": 0.0620345361504724,
+        "dof": 249,
+        "mean_difference": 0.02903333333333333,
+        "sd_difference": 0.24489798120012077,
+        "significant": false,
+        "mde_80_power": 0.04339316517156978,
+        "n_needed_for_observed_diff": 559
+       },
+       "rouge_l_f1": {
+        "t_statistic": 2.3161646755408523,
+        "p_value": 0.021361966213798017,
+        "dof": 249,
+        "mean_difference": 0.025419650512193484,
+        "sd_difference": 0.17352823353379768,
+        "significant": true,
+        "mde_80_power": 0.030747249376096946,
+        "n_needed_for_observed_diff": 366
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.12014832273569348,
+        "p_value": 0.9044625409235157,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.5263956396836049,
+        "significant": false,
+        "mde_80_power": 0.09327138111326143,
+        "n_needed_for_observed_diff": 135931
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.012976703296703286,
+       "ordered_step_accuracy": 0.008710000000000006,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.004800000000000005,
+       "_sum": 0.016886703296703286,
+       "_total_delta_composite": 0.01688670329670333,
+       "_residual": -4.5102810375396984e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5162698827976191,
+        "system_b": 0.527144581146914,
+        "difference": -0.010874698349294887,
+        "ci_low": -0.027203653210514343,
+        "ci_high": 0.005690652566963105,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.15734236874236876,
+        "system_b": 0.15024155844155845,
+        "difference": 0.007100810300810306,
+        "ci_low": -0.017128095238095227,
+        "ci_high": 0.030544420024420007,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.12926666666666664,
+        "system_b": 0.12006666666666665,
+        "difference": 0.009199999999999986,
+        "ci_low": -0.013601666666666692,
+        "ci_high": 0.03166666666666665,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.36878361416361416,
+        "system_b": 0.37118329004329004,
+        "difference": -0.0023996758796758777,
+        "ci_low": -0.021272761183261223,
+        "ci_high": 0.01613834521034524,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.0,
+        "difference": 0.016,
+        "ci_low": 0.004,
+        "ci_high": 0.032,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.428,
+        "system_b": 0.5,
+        "difference": -0.07200000000000001,
+        "ci_low": -0.14800000000000008,
+        "ci_high": 0.004099999999998547,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.21097951770451773,
+        "system_b": 0.21397911255411262,
+        "difference": -0.0029995948495948888,
+        "ci_low": -0.026590951479076474,
+        "ci_high": 0.020172931512931497,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.0,
+        "difference": 0.016,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 4,
+        "p_value": 0.125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.428,
+        "system_b_rate": 0.5,
+        "difference": -0.072,
+        "correct_only_in_a": 40,
+        "correct_only_in_b": 58,
+        "discordant_pairs": 98,
+        "p_value": 0.08541058911280434,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.310887241768095e-30,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.012158166696862,
+        "p_value": 0.04528026312539455,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.12572680269402645,
+        "significant": true,
+        "mde_80_power": 0.02227737398675038,
+        "n_needed_for_observed_diff": 485
+       },
+       "step_f1": {
+        "t_statistic": 0.5925981016480018,
+        "p_value": 0.5539879234871211,
+        "dof": 249,
+        "mean_difference": 0.007100810300810302,
+        "sd_difference": 0.18946005497570637,
+        "significant": false,
+        "mde_80_power": 0.03357018877284017,
+        "n_needed_for_observed_diff": 5588
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.7999379366343946,
+        "p_value": 0.4245092467183613,
+        "dof": 249,
+        "mean_difference": 0.0092,
+        "sd_difference": 0.18184507285623208,
+        "significant": false,
+        "mde_80_power": 0.03222089967184559,
+        "n_needed_for_observed_diff": 3067
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.2764697097949171,
+        "p_value": 0.2029787578771185,
+        "dof": 249,
+        "mean_difference": -0.010874698349295017,
+        "sd_difference": 0.13470282681666856,
+        "significant": false,
+        "mde_80_power": 0.023867824407897465,
+        "n_needed_for_observed_diff": 1205
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.8267535296188289,
+        "p_value": 0.06893399495205348,
+        "dof": 249,
+        "mean_difference": -0.072,
+        "sd_difference": 0.6231929700435064,
+        "significant": false,
+        "mde_80_power": 0.11042277829461206,
+        "n_needed_for_observed_diff": 589
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0028403241203241226,
+       "ordered_step_accuracy": 0.0027599999999999955,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.007999999999999997,
+       "_sum": -0.0023996758796758786,
+       "_total_delta_composite": -0.0023996758796758777,
+       "_residual": -8.673617379884035e-19,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.47014645598605115,
+        "system_b": 0.4444704342664301,
+        "difference": 0.025676021719621023,
+        "ci_low": 0.01104356329823086,
+        "ci_high": 0.040001472921396435,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.11736583416583417,
+        "system_b": 0.08446315122785711,
+        "difference": 0.03290268293797706,
+        "ci_low": 0.016633335161570454,
+        "ci_high": 0.050972553067847176,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.10381269841269841,
+        "system_b": 0.06788903318903318,
+        "difference": 0.03592366522366523,
+        "ci_low": 0.019998044733044743,
+        "ci_high": 0.053759393939393926,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.13915680985680987,
+        "system_b": 0.10521863711451947,
+        "difference": 0.0339381727422904,
+        "ci_low": 0.020418868881118907,
+        "ci_high": 0.24414243358602186,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.0,
+        "difference": 0.02,
+        "ci_low": 0.004,
+        "ci_high": 0.04,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.284,
+        "system_b": 0.232,
+        "difference": 0.05199999999999996,
+        "ci_low": -0.016000000000000014,
+        "ci_high": 0.12,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.17394601232101237,
+        "system_b": 0.13152329639314936,
+        "difference": 0.04242271592786301,
+        "ci_low": 0.02494770393005685,
+        "ci_high": 0.06142736574699811,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.02,
+        "system_b_rate": 0.0,
+        "difference": 0.02,
+        "correct_only_in_a": 5,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 5,
+        "p_value": 0.0625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.284,
+        "system_b_rate": 0.232,
+        "difference": 0.052,
+        "correct_only_in_a": 44,
+        "correct_only_in_b": 31,
+        "discordant_pairs": 75,
+        "p_value": 0.1654279417242567,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.293955920339377e-23,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.2542476911513574,
+        "p_value": 0.02505038250022726,
+        "dof": 249,
+        "mean_difference": 0.02,
+        "sd_difference": 0.14028084280983538,
+        "significant": true,
+        "mde_80_power": 0.02485618604377128,
+        "n_needed_for_observed_diff": 387
+       },
+       "step_f1": {
+        "t_statistic": 3.6981001988779165,
+        "p_value": 0.000267252685314434,
+        "dof": 249,
+        "mean_difference": 0.03290268293797705,
+        "sd_difference": 0.14067685246324366,
+        "significant": true,
+        "mde_80_power": 0.024926354496020948,
+        "n_needed_for_observed_diff": 144
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 4.096559611295128,
+        "p_value": 5.6751833205010025e-05,
+        "dof": 249,
+        "mean_difference": 0.035923665223665226,
+        "sd_difference": 0.1386536689164025,
+        "significant": true,
+        "mde_80_power": 0.024567869148815327,
+        "n_needed_for_observed_diff": 117
+       },
+       "rouge_l_f1": {
+        "t_statistic": 3.428084705414659,
+        "p_value": 0.0007111300936515147,
+        "dof": 249,
+        "mean_difference": 0.02567602171962106,
+        "sd_difference": 0.11842576374747792,
+        "significant": true,
+        "mde_80_power": 0.02098371208158034,
+        "n_needed_for_observed_diff": 167
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.5049029176532525,
+        "p_value": 0.13361643487391045,
+        "dof": 249,
+        "mean_difference": 0.052,
+        "sd_difference": 0.5463423467381578,
+        "significant": false,
+        "mde_80_power": 0.09680571304039903,
+        "n_needed_for_observed_diff": 867
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.013161073175190824,
+       "ordered_step_accuracy": 0.010777099567099569,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.010000000000000009,
+       "_sum": 0.0339381727422904,
+       "_total_delta_composite": 0.0339381727422904,
+       "_residual": 0.0,
+       "_share_reference_term": 0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_2000_vs_4000",
+    "kind": "pool_size",
+    "contrast": "4000 vs 2000",
+    "cell_a": "size4000_imbalanced_trial0__biencoder_only__typed",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_only__typed",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5287493632947979,
+       "system_b": 0.5310403311127952,
+       "difference": -0.0022909678179973136,
+       "ci_low": -0.012715809634123953,
+       "ci_high": 0.007855008838714267,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.18659219766588186,
+       "system_b": 0.1912138454138454,
+       "difference": -0.004621647747963531,
+       "ci_low": -0.018634976319976335,
+       "ci_high": 0.0094752134025818,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1657215784215784,
+       "system_b": 0.17263756613756615,
+       "difference": -0.006915987715987754,
+       "ci_low": -0.020577647167647175,
+       "ci_high": 0.0068330435305435176,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.39164224148171517,
+       "system_b": 0.22216569689569687,
+       "difference": 0.1694765445860183,
+       "ci_low": -0.014133167469956959,
+       "ci_high": 0.20135659815233498,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.04666666666666667,
+       "system_b": 0.050666666666666665,
+       "difference": -0.003999999999999997,
+       "ci_low": -0.017333333333333333,
+       "ci_high": 0.009333333333333332,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4706666666666667,
+       "system_b": 0.468,
+       "difference": 0.0026666666666666505,
+       "ci_low": -0.03866666666666663,
+       "ci_high": 0.042666666666666686,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.23955280185214395,
+       "system_b": 0.24645712111962115,
+       "difference": -0.006904319267477199,
+       "ci_low": -0.021079097380446065,
+       "ci_high": 0.006744990288707413,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.04666666666666667,
+       "system_b_rate": 0.050666666666666665,
+       "difference": -0.004,
+       "correct_only_in_a": 11,
+       "correct_only_in_b": 14,
+       "discordant_pairs": 25,
+       "p_value": 0.6900379657745361,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.960464477539063e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.4706666666666667,
+       "system_b_rate": 0.468,
+       "difference": 0.0026666666666666666,
+       "correct_only_in_a": 119,
+       "correct_only_in_b": 117,
+       "discordant_pairs": 236,
+       "p_value": 0.9481171285953605,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.8111358157653425e-71,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -0.5997438223718417,
+       "p_value": 0.5488583622359041,
+       "dof": 749,
+       "mean_difference": -0.004,
+       "sd_difference": 0.18265217150184423,
+       "significant": false,
+       "mde_80_power": 0.018685311264535247,
+       "n_needed_for_observed_diff": 16366
+      },
+      "step_f1": {
+       "t_statistic": -0.6414738887477993,
+       "p_value": 0.5214110848642073,
+       "dof": 749,
+       "mean_difference": -0.004621647747963537,
+       "sd_difference": 0.19730972443352351,
+       "significant": false,
+       "mde_80_power": 0.020184778457576876,
+       "n_needed_for_observed_diff": 14306
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.9761956191594728,
+       "p_value": 0.3292827097927846,
+       "dof": 749,
+       "mean_difference": -0.006915987715987717,
+       "sd_difference": 0.19402066579322994,
+       "significant": false,
+       "mde_80_power": 0.019848307864559184,
+       "n_needed_for_observed_diff": 6178
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.4375845532624282,
+       "p_value": 0.6618136192662183,
+       "dof": 749,
+       "mean_difference": -0.002290967817997311,
+       "sd_difference": 0.1433796900599208,
+       "significant": false,
+       "mde_80_power": 0.014667737677321619,
+       "n_needed_for_observed_diff": 30744
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 0.13010355952835445,
+       "p_value": 0.8965194263363082,
+       "dof": 749,
+       "mean_difference": 0.0026666666666666666,
+       "sd_difference": 0.5613195718761733,
+       "significant": false,
+       "mde_80_power": 0.05742297413242669,
+       "n_needed_for_observed_diff": 347773
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.0018486590991854124,
+      "ordered_step_accuracy": -0.002074796314796326,
+      "reference_validity_micro": 0.17500000000000002,
+      "step_count_term": -0.0016000000000000016,
+      "_sum": 0.16947654458601827,
+      "_total_delta_composite": 0.1694765445860183,
+      "_residual": -2.7755575615628914e-17,
+      "_share_reference_term": 1.032591267584986
+     },
+     "reference_terms": {
+      "ref_micro_a": 1.0,
+      "ref_micro_b": 0.125,
+      "step_count_term_a": 0.6728888888888889,
+      "step_count_term_b": 0.6888888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.603008418763871,
+        "system_b": 0.6067046545547155,
+        "difference": -0.0036962357908444377,
+        "ci_low": -0.025863815927474706,
+        "ci_high": 0.018086376543924122,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.2981333333333333,
+        "system_b": 0.29893333333333333,
+        "difference": -0.0008000000000000229,
+        "ci_low": -0.03413333333333329,
+        "ci_high": 0.03213333333333335,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2775,
+        "system_b": 0.2848333333333333,
+        "difference": -0.007333333333333303,
+        "ci_low": -0.04099999999999995,
+        "ci_high": 0.025999999999999968,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.48263666666666666,
+        "system_b": 0.4835566666666667,
+        "difference": -0.0009200000000000319,
+        "ci_low": -0.026073916666666724,
+        "ci_high": 0.023947000000000055,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.124,
+        "system_b": 0.116,
+        "difference": 0.007999999999999993,
+        "ci_low": -0.024000000000000007,
+        "ci_high": 0.04000000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.664,
+        "system_b": 0.692,
+        "difference": -0.027999999999999914,
+        "ci_low": -0.09199999999999997,
+        "ci_high": 0.03599999999999992,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.35329583333333336,
+        "system_b": 0.3544458333333334,
+        "difference": -0.0011500000000000399,
+        "ci_low": -0.032592395833333294,
+        "ci_high": 0.029933749999999974,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.124,
+        "system_b_rate": 0.116,
+        "difference": 0.008,
+        "correct_only_in_a": 10,
+        "correct_only_in_b": 8,
+        "discordant_pairs": 18,
+        "p_value": 0.8145294189453125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 7.62939453125e-06,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.664,
+        "system_b_rate": 0.692,
+        "difference": -0.028,
+        "correct_only_in_a": 29,
+        "correct_only_in_b": 36,
+        "discordant_pairs": 65,
+        "p_value": 0.4570207854105899,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.421010862427522e-20,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.4706700002234264,
+        "p_value": 0.6382884447377815,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.26874690621176195,
+        "significant": false,
+        "mde_80_power": 0.04761892618896609,
+        "n_needed_for_observed_diff": 8858
+       },
+       "step_f1": {
+        "t_statistic": -0.047583912433339794,
+        "p_value": 0.9620859962676824,
+        "dof": 249,
+        "mean_difference": -0.000799999999999999,
+        "sd_difference": 0.2658274612957397,
+        "significant": false,
+        "mde_80_power": 0.04710163341738244,
+        "n_needed_for_observed_diff": 866627
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.4338101853250729,
+        "p_value": 0.6648019020248962,
+        "dof": 249,
+        "mean_difference": -0.007333333333333336,
+        "sd_difference": 0.26728321462981347,
+        "significant": false,
+        "mde_80_power": 0.04735957651909754,
+        "n_needed_for_observed_diff": 10427
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.3330719498545413,
+        "p_value": 0.7393602443460214,
+        "dof": 249,
+        "mean_difference": -0.0036962357908446064,
+        "sd_difference": 0.17546544933020172,
+        "significant": false,
+        "mde_80_power": 0.031090502205762552,
+        "n_needed_for_observed_diff": 17688
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.8678143006377194,
+        "p_value": 0.3863315801618297,
+        "dof": 249,
+        "mean_difference": -0.028,
+        "sd_difference": 0.5101539259012419,
+        "significant": false,
+        "mde_80_power": 0.09039353228260275,
+        "n_needed_for_observed_diff": 2606
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0003200000000000092,
+       "ordered_step_accuracy": -0.0021999999999999906,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0016000000000000016,
+       "_sum": -0.0009199999999999982,
+       "_total_delta_composite": -0.0009200000000000319,
+       "_residual": 3.371868756429919e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5234628528795913,
+        "system_b": 0.5162698827976191,
+        "difference": 0.007192970081972172,
+        "ci_low": -0.009069006847842455,
+        "ci_high": 0.023006276064205796,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.15416507936507934,
+        "system_b": 0.15734236874236876,
+        "difference": -0.0031772893772894217,
+        "ci_low": -0.023491800976800953,
+        "ci_high": 0.01697866300366299,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.12729157509157507,
+        "system_b": 0.12926666666666664,
+        "difference": -0.00197509157509157,
+        "ci_low": -0.020381043956043978,
+        "ci_high": 0.01636523809523806,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.37105350427350425,
+        "system_b": 0.36878361416361416,
+        "difference": 0.0022698901098900937,
+        "ci_low": -0.013540534798534782,
+        "ci_high": 0.018329957264957293,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.016,
+        "difference": -0.004,
+        "ci_low": -0.019999999999999997,
+        "ci_high": 0.008,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.488,
+        "system_b": 0.428,
+        "difference": 0.06,
+        "ci_low": -0.016000000000000014,
+        "ci_high": 0.136,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.21381688034188034,
+        "system_b": 0.21097951770451773,
+        "difference": 0.002837362637362617,
+        "ci_low": -0.016925668498168463,
+        "ci_high": 0.022912446581196604,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.016,
+        "difference": -0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 3,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.25,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.488,
+        "system_b_rate": 0.428,
+        "difference": 0.06,
+        "correct_only_in_a": 53,
+        "correct_only_in_b": 38,
+        "discordant_pairs": 91,
+        "p_value": 0.14179337454474722,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.077935669463161e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.5765789258001912,
+        "p_value": 0.5647447828879819,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.10969105940803119,
+        "significant": false,
+        "mde_80_power": 0.019436020809202256,
+        "n_needed_for_observed_diff": 5903
+       },
+       "step_f1": {
+        "t_statistic": -0.3095742115856148,
+        "p_value": 0.7571436771979235,
+        "dof": 249,
+        "mean_difference": -0.0031772893772893766,
+        "sd_difference": 0.16227887921009534,
+        "significant": false,
+        "mde_80_power": 0.028753990436804037,
+        "n_needed_for_observed_diff": 20475
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.2110223323217603,
+        "p_value": 0.8330424424707723,
+        "dof": 249,
+        "mean_difference": -0.001975091575091574,
+        "sd_difference": 0.14798879094880535,
+        "significant": false,
+        "mde_80_power": 0.02622194767679552,
+        "n_needed_for_observed_diff": 44066
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.8649299816077936,
+        "p_value": 0.3879097291077344,
+        "dof": 249,
+        "mean_difference": 0.007192970081972244,
+        "sd_difference": 0.1314913870727324,
+        "significant": false,
+        "mde_80_power": 0.023298793440127703,
+        "n_needed_for_observed_diff": 2623
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.577097461793519,
+        "p_value": 0.11604268063860416,
+        "dof": 249,
+        "mean_difference": 0.06,
+        "sd_difference": 0.6015375213220144,
+        "significant": false,
+        "mde_80_power": 0.10658567658135507,
+        "n_needed_for_observed_diff": 789
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0012709157509157689,
+       "ordered_step_accuracy": -0.000592527472527471,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.004133333333333322,
+       "_sum": 0.0022698901098900824,
+       "_total_delta_composite": 0.0022698901098900937,
+       "_residual": -1.1275702593849246e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.45977681824093164,
+        "system_b": 0.47014645598605115,
+        "difference": -0.010369637745119509,
+        "ci_low": -0.024754823905933098,
+        "ci_high": 0.0045990683282001454,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10747818029923292,
+        "system_b": 0.11736583416583417,
+        "difference": -0.009887653866601245,
+        "ci_low": -0.027405263537631962,
+        "ci_high": 0.007633405979984913,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09237316017316018,
+        "system_b": 0.10381269841269841,
+        "difference": -0.011439538239538236,
+        "ci_low": -0.028953982683982683,
+        "ci_high": 0.005767402597402584,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3212365535049746,
+        "system_b": 0.13915680985680987,
+        "difference": 0.18207974364816473,
+        "ci_low": -0.030626799974878993,
+        "ci_high": 0.19633603069153072,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.02,
+        "difference": -0.016,
+        "ci_low": -0.032,
+        "ci_high": -0.004,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.26,
+        "system_b": 0.284,
+        "difference": -0.023999999999999966,
+        "ci_low": -0.096,
+        "ci_high": 0.04400000000000004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.15154569188121825,
+        "system_b": 0.17394601232101237,
+        "difference": -0.02240032043979412,
+        "ci_low": -0.04257870528594212,
+        "ci_high": -0.0026320648101898136,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.02,
+        "difference": -0.016,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 4,
+        "discordant_pairs": 4,
+        "p_value": 0.125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.26,
+        "system_b_rate": 0.284,
+        "difference": -0.024,
+        "correct_only_in_a": 37,
+        "correct_only_in_b": 43,
+        "discordant_pairs": 80,
+        "p_value": 0.5764306261883931,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.6543612251060553e-24,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -2.012158166696862,
+        "p_value": 0.04528026312539455,
+        "dof": 249,
+        "mean_difference": -0.016,
+        "sd_difference": 0.12572680269402645,
+        "significant": true,
+        "mde_80_power": 0.02227737398675038,
+        "n_needed_for_observed_diff": 485
+       },
+       "step_f1": {
+        "t_statistic": -1.1037415813532256,
+        "p_value": 0.27077076410903966,
+        "dof": 249,
+        "mean_difference": -0.009887653866601235,
+        "sd_difference": 0.1416432408729928,
+        "significant": false,
+        "mde_80_power": 0.02509758764248722,
+        "n_needed_for_observed_diff": 1611
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.2838611532784703,
+        "p_value": 0.20038392500489524,
+        "dof": 249,
+        "mean_difference": -0.011439538239538243,
+        "sd_difference": 0.14088359993273863,
+        "significant": false,
+        "mde_80_power": 0.02496298782002238,
+        "n_needed_for_observed_diff": 1191
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.4058071650110233,
+        "p_value": 0.16102796764331545,
+        "dof": 249,
+        "mean_difference": -0.010369637745119576,
+        "sd_difference": 0.1166293450537838,
+        "significant": false,
+        "mde_80_power": 0.02066540691340068,
+        "n_needed_for_observed_diff": 993
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.6700807524370596,
+        "p_value": 0.5034272641708877,
+        "dof": 249,
+        "mean_difference": -0.024,
+        "sd_difference": 0.566309833314977,
+        "significant": false,
+        "mde_80_power": 0.10034372686494332,
+        "n_needed_for_observed_diff": 4371
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.003955061546640499,
+       "ordered_step_accuracy": -0.0034318614718614705,
+       "reference_validity_micro": 0.2,
+       "step_count_term": -0.010533333333333329,
+       "_sum": 0.1820797436481647,
+       "_total_delta_composite": 0.18207974364816473,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 1.0984198241538765
+      }
+     }
+    }
+   },
+   {
+    "family": "size_4000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 4000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_only__typed",
+    "cell_b": "size4000_imbalanced_trial0__biencoder_only__typed",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5303738748559566,
+       "system_b": 0.5287493632947979,
+       "difference": 0.0016245115611586147,
+       "ci_low": -0.009415918519065185,
+       "ci_high": 0.01265107242372674,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1947480984100179,
+       "system_b": 0.18659219766588186,
+       "difference": 0.008155900744136024,
+       "ci_low": -0.007302439178754958,
+       "ci_high": 0.0236229979955831,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1727852332852333,
+       "system_b": 0.1657215784215784,
+       "difference": 0.0070636548636549,
+       "ci_low": -0.008519163799163822,
+       "ci_high": 0.022299252969252982,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.19800147601624385,
+       "system_b": 0.39164224148171517,
+       "difference": -0.19364076546547132,
+       "ci_low": -0.2043946667799578,
+       "ci_high": 0.01533967623269404,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.048,
+       "system_b": 0.04666666666666667,
+       "difference": 0.0013333333333333322,
+       "ci_low": -0.013333333333333336,
+       "ci_high": 0.016,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.492,
+       "system_b": 0.4706666666666667,
+       "difference": 0.021333333333333315,
+       "ci_low": -0.019999999999999962,
+       "ci_high": 0.061333333333333406,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2475018450203048,
+       "system_b": 0.23955280185214395,
+       "difference": 0.007949043168160863,
+       "ci_low": -0.007317596131329669,
+       "ci_high": 0.023257395296302955,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.048,
+       "system_b_rate": 0.04666666666666667,
+       "difference": 0.0013333333333333333,
+       "correct_only_in_a": 17,
+       "correct_only_in_b": 16,
+       "discordant_pairs": 33,
+       "p_value": 1.0,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.3283064365386963e-10,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.492,
+       "system_b_rate": 0.4706666666666667,
+       "difference": 0.021333333333333333,
+       "correct_only_in_a": 128,
+       "correct_only_in_b": 112,
+       "discordant_pairs": 240,
+       "p_value": 0.3329330313349304,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.131959884853339e-72,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 0.17396507995688623,
+       "p_value": 0.8619399129169586,
+       "dof": 749,
+       "mean_difference": 0.0013333333333333333,
+       "sd_difference": 0.2098975103282828,
+       "significant": false,
+       "mde_80_power": 0.021472508549373395,
+       "n_needed_for_observed_diff": 194514
+      },
+      "step_f1": {
+       "t_statistic": 1.0345740625454292,
+       "p_value": 0.301201784178219,
+       "dof": 749,
+       "mean_difference": 0.008155900744136038,
+       "sd_difference": 0.21589420110463672,
+       "significant": false,
+       "mde_80_power": 0.022085969822743527,
+       "n_needed_for_observed_diff": 5500
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 0.9054993831129352,
+       "p_value": 0.3654920659815079,
+       "dof": 749,
+       "mean_difference": 0.007063654863654864,
+       "sd_difference": 0.21363477322061908,
+       "significant": false,
+       "mde_80_power": 0.021854830422946062,
+       "n_needed_for_observed_diff": 7180
+      },
+      "rouge_l_f1": {
+       "t_statistic": 0.2835507926492413,
+       "p_value": 0.7768330086413837,
+       "dof": 749,
+       "mean_difference": 0.0016245115611586544,
+       "sd_difference": 0.15689986592194227,
+       "significant": false,
+       "mde_80_power": 0.01605085123275272,
+       "n_needed_for_observed_diff": 73217
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 1.03284152536644,
+       "p_value": 0.30201143988451823,
+       "dof": 749,
+       "mean_difference": 0.021333333333333333,
+       "sd_difference": 0.5656602492477213,
+       "significant": false,
+       "mde_80_power": 0.057867025287797046,
+       "n_needed_for_observed_diff": 5519
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.00326236029765441,
+      "ordered_step_accuracy": 0.00211909645909647,
+      "reference_validity_micro": -0.2,
+      "step_count_term": 0.0009777777777777886,
+      "_sum": -0.19364076546547135,
+      "_total_delta_composite": -0.19364076546547132,
+      "_residual": -2.7755575615628914e-17,
+      "_share_reference_term": 1.0328403707723548
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 1.0,
+      "step_count_term_a": 0.6826666666666668,
+      "step_count_term_b": 0.6728888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6122916256366132,
+        "system_b": 0.603008418763871,
+        "difference": 0.0092832068727422,
+        "ci_low": -0.013350654248413142,
+        "ci_high": 0.032437864112631706,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.31763174603174604,
+        "system_b": 0.2981333333333333,
+        "difference": 0.019498412698412737,
+        "ci_low": -0.016355555555555568,
+        "ci_high": 0.0559876190476191,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.30357142857142855,
+        "system_b": 0.2775,
+        "difference": 0.026071428571428523,
+        "ci_low": -0.011597023809523814,
+        "ci_high": 0.06400178571428569,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.5011907936507937,
+        "system_b": 0.48263666666666666,
+        "difference": 0.018554126984127006,
+        "ci_low": -0.008265960317460252,
+        "ci_high": 0.045821357142857094,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.132,
+        "system_b": 0.124,
+        "difference": 0.008000000000000007,
+        "ci_low": -0.032000000000000015,
+        "ci_high": 0.05199999999999999,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.716,
+        "system_b": 0.664,
+        "difference": 0.051999999999999935,
+        "ci_low": -0.008000000000000007,
+        "ci_high": 0.11599999999999999,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3764884920634921,
+        "system_b": 0.35329583333333336,
+        "difference": 0.023192658730158744,
+        "ci_low": -0.01033245039682541,
+        "ci_high": 0.05727669642857135,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.132,
+        "system_b_rate": 0.124,
+        "difference": 0.008,
+        "correct_only_in_a": 16,
+        "correct_only_in_b": 14,
+        "discordant_pairs": 30,
+        "p_value": 0.855535551905632,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.862645149230957e-09,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.716,
+        "system_b_rate": 0.664,
+        "difference": 0.052,
+        "correct_only_in_a": 38,
+        "correct_only_in_b": 25,
+        "discordant_pairs": 63,
+        "p_value": 0.1299179230225525,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.168404344971009e-19,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.3645145600124169,
+        "p_value": 0.7157831744698963,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.34701249355423924,
+        "significant": false,
+        "mde_80_power": 0.0614867071406874,
+        "n_needed_for_observed_diff": 14769
+       },
+       "step_f1": {
+        "t_statistic": 1.0404679816431628,
+        "p_value": 0.2991317487916138,
+        "dof": 249,
+        "mean_difference": 0.0194984126984127,
+        "sd_difference": 0.2963060659856063,
+        "significant": false,
+        "mde_80_power": 0.05250209903586223,
+        "n_needed_for_observed_diff": 1813
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.3518339578610976,
+        "p_value": 0.17765511486118707,
+        "dof": 249,
+        "mean_difference": 0.026071428571428572,
+        "sd_difference": 0.30493795358769754,
+        "significant": false,
+        "mde_80_power": 0.05403157233990671,
+        "n_needed_for_observed_diff": 1074
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.7805081761341169,
+        "p_value": 0.43583316342368994,
+        "dof": 249,
+        "mean_difference": 0.009283206872742249,
+        "sd_difference": 0.18805746439323676,
+        "significant": false,
+        "mde_80_power": 0.03332166551219533,
+        "n_needed_for_observed_diff": 3222
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.6434078687335079,
+        "p_value": 0.10156064020523412,
+        "dof": 249,
+        "mean_difference": 0.052,
+        "sd_difference": 0.500297100486321,
+        "significant": false,
+        "mde_80_power": 0.08864701378865292,
+        "n_needed_for_observed_diff": 727
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.007799365079365095,
+       "ordered_step_accuracy": 0.007821428571428557,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0029333333333333325,
+       "_sum": 0.018554126984126985,
+       "_total_delta_composite": 0.018554126984127006,
+       "_residual": -2.0816681711721685e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5077913385074214,
+        "system_b": 0.5234628528795913,
+        "difference": -0.015671514372169848,
+        "ci_low": -0.03456279483821055,
+        "ci_high": 0.003667483448374824,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.14523492063492063,
+        "system_b": 0.15416507936507934,
+        "difference": -0.008930158730158705,
+        "ci_low": -0.02896587301587301,
+        "ci_high": 0.010549444444444401,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.1214,
+        "system_b": 0.12729157509157507,
+        "difference": -0.005891575091575077,
+        "ci_low": -0.02434523809523808,
+        "ci_high": 0.012057380952380955,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.35971396825396823,
+        "system_b": 0.37105350427350425,
+        "difference": -0.011339536019536023,
+        "ci_low": -0.026927885225885222,
+        "ci_high": 0.003856412698412676,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.012,
+        "difference": -0.004,
+        "ci_low": -0.012,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.436,
+        "system_b": 0.488,
+        "difference": -0.05199999999999999,
+        "ci_low": -0.124,
+        "ci_high": 0.016000000000000014,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19964246031746033,
+        "system_b": 0.21381688034188034,
+        "difference": -0.014174420024420015,
+        "ci_low": -0.033659856532356563,
+        "ci_high": 0.004820515873015884,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.012,
+        "difference": -0.004,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.436,
+        "system_b_rate": 0.488,
+        "difference": -0.052,
+        "correct_only_in_a": 34,
+        "correct_only_in_b": 47,
+        "discordant_pairs": 81,
+        "p_value": 0.1820767469408432,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.271806125530277e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -0.8863262749332762,
+        "p_value": 0.3762969344747574,
+        "dof": 249,
+        "mean_difference": -0.008930158730158731,
+        "sd_difference": 0.15930725655326247,
+        "significant": false,
+        "mde_80_power": 0.028227452356973333,
+        "n_needed_for_observed_diff": 2498
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.6295667894847865,
+        "p_value": 0.5295552803093089,
+        "dof": 249,
+        "mean_difference": -0.005891575091575093,
+        "sd_difference": 0.14796520882668482,
+        "significant": false,
+        "mde_80_power": 0.026217769190246727,
+        "n_needed_for_observed_diff": 4951
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.606695565150232,
+        "p_value": 0.1093885035166442,
+        "dof": 249,
+        "mean_difference": -0.015671514372169862,
+        "sd_difference": 0.15422237066885353,
+        "significant": false,
+        "mde_80_power": 0.02732646782464093,
+        "n_needed_for_observed_diff": 761
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.447605944299627,
+        "p_value": 0.1489851526540314,
+        "dof": 249,
+        "mean_difference": -0.052,
+        "sd_difference": 0.5679668523615847,
+        "significant": false,
+        "mde_80_power": 0.1006373319850408,
+        "n_needed_for_observed_diff": 937
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0035720634920634823,
+       "ordered_step_accuracy": -0.001767472527472523,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.006000000000000005,
+       "_sum": -0.01133953601953601,
+       "_total_delta_composite": -0.011339536019536023,
+       "_residual": 1.214306433183765e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.47103866042383513,
+        "system_b": 0.45977681824093164,
+        "difference": 0.011261842182903492,
+        "ci_low": -0.0038723939091587748,
+        "ci_high": 0.026230954026703845,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.12137762856338707,
+        "system_b": 0.10747818029923292,
+        "difference": 0.013899448264154152,
+        "ci_low": -0.006095325769861372,
+        "ci_high": 0.034156521517697984,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09338427128427128,
+        "system_b": 0.09237316017316018,
+        "difference": 0.0010111111111111015,
+        "ci_low": -0.017277283549783553,
+        "ci_high": 0.019433373015872998,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.13309966614396954,
+        "system_b": 0.3212365535049746,
+        "difference": -0.18813688736100506,
+        "ci_low": -0.20380720074696543,
+        "ci_high": 0.02480151265418451,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.004,
+        "difference": 0.0,
+        "ci_low": -0.012,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.324,
+        "system_b": 0.26,
+        "difference": 0.064,
+        "ci_low": -0.01200000000000001,
+        "ci_high": 0.14,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16637458267996197,
+        "system_b": 0.15154569188121825,
+        "difference": 0.014828890798743721,
+        "ci_low": -0.007802294115413342,
+        "ci_high": 0.03760330739811873,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.004,
+        "difference": 0.0,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 2,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.324,
+        "system_b_rate": 0.26,
+        "difference": 0.064,
+        "correct_only_in_a": 56,
+        "correct_only_in_b": 40,
+        "discordant_pairs": 96,
+        "p_value": 0.1253456971884925,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.524354896707238e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.08962214298964416,
+        "significant": false,
+        "mde_80_power": 0.015880034758644045,
+        "n_needed_for_observed_diff": null
+       },
+       "step_f1": {
+        "t_statistic": 1.3481574246138324,
+        "p_value": 0.1788328621133256,
+        "dof": 249,
+        "mean_difference": 0.013899448264154148,
+        "sd_difference": 0.16301477087140262,
+        "significant": false,
+        "mde_80_power": 0.02888438215441233,
+        "n_needed_for_observed_diff": 1080
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.10818599500488549,
+        "p_value": 0.9139352791327547,
+        "dof": 249,
+        "mean_difference": 0.0010111111111111102,
+        "sd_difference": 0.14777393684230117,
+        "significant": false,
+        "mde_80_power": 0.026183877947981764,
+        "n_needed_for_observed_diff": 167653
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.4814218270711448,
+        "p_value": 0.13975852775264022,
+        "dof": 249,
+        "mean_difference": 0.011261842182903577,
+        "sd_difference": 0.12019895784088368,
+        "significant": false,
+        "mde_80_power": 0.021297902112054835,
+        "n_needed_for_observed_diff": 895
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.6384859226122093,
+        "p_value": 0.1025832998165287,
+        "dof": 249,
+        "mean_difference": 0.064,
+        "sd_difference": 0.6175999667062021,
+        "significant": false,
+        "mde_80_power": 0.10943176107008679,
+        "n_needed_for_observed_diff": 731
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.005559779305661661,
+       "ordered_step_accuracy": 0.0003033333333333304,
+       "reference_validity_micro": -0.2,
+       "step_count_term": 0.005999999999999984,
+       "_sum": -0.18813688736100503,
+       "_total_delta_composite": -0.18813688736100506,
+       "_residual": 2.7755575615628914e-17,
+       "_share_reference_term": 1.0630557505516263
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 1000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_only__typed",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__typed",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5303738748559566,
+       "system_b": 0.517633339818622,
+       "difference": 0.012740535037334522,
+       "ci_low": 0.0011286188376323145,
+       "ci_high": 0.024407298270392074,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1947480984100179,
+       "system_b": 0.16706542825366355,
+       "difference": 0.02768267015635434,
+       "ci_low": 0.012217321781532318,
+       "ci_high": 0.04309449247633459,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1727852332852333,
+       "system_b": 0.14791856661856662,
+       "difference": 0.024866666666666676,
+       "ci_low": 0.00999872895622896,
+       "ci_high": 0.04003486652236651,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.19800147601624385,
+       "system_b": 0.18102396350925765,
+       "difference": 0.016977512506986203,
+       "ci_low": -0.1861483999248086,
+       "ci_high": 0.2254467796793563,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.048,
+       "system_b": 0.02666666666666667,
+       "difference": 0.021333333333333333,
+       "ci_low": 0.008,
+       "ci_high": 0.03599999999999999,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.492,
+       "system_b": 0.47333333333333333,
+       "difference": 0.018666666666666665,
+       "ci_low": -0.026666666666666616,
+       "ci_high": 0.0626666666666667,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2475018450203048,
+       "system_b": 0.22627995438657206,
+       "difference": 0.021221890633732754,
+       "ci_low": 0.006160295243613734,
+       "ci_high": 0.03641980048055805,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.048,
+       "system_b_rate": 0.02666666666666667,
+       "difference": 0.021333333333333333,
+       "correct_only_in_a": 22,
+       "correct_only_in_b": 6,
+       "discordant_pairs": 28,
+       "p_value": 0.0037191659212112427,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 7.450580596923828e-09,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.492,
+       "system_b_rate": 0.47333333333333333,
+       "difference": 0.018666666666666668,
+       "correct_only_in_a": 151,
+       "correct_only_in_b": 137,
+       "discordant_pairs": 288,
+       "p_value": 0.44371221051651655,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 4.021529366771898e-87,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 3.0402873998963282,
+       "p_value": 0.002445868314429381,
+       "dof": 749,
+       "mean_difference": 0.021333333333333333,
+       "sd_difference": 0.19216518632156265,
+       "significant": true,
+       "mde_80_power": 0.01965849237434089,
+       "n_needed_for_observed_diff": 637
+      },
+      "step_f1": {
+       "t_statistic": 3.496305942878755,
+       "p_value": 0.0004995367359300716,
+       "dof": 749,
+       "mean_difference": 0.027682670156354366,
+       "sd_difference": 0.21683489866630573,
+       "significant": true,
+       "mde_80_power": 0.022182203153018484,
+       "n_needed_for_observed_diff": 482
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 3.247458932308291,
+       "p_value": 0.0012162762422929319,
+       "dof": 749,
+       "mean_difference": 0.02486666666666667,
+       "sd_difference": 0.2097029484775351,
+       "significant": true,
+       "mde_80_power": 0.021452604878305418,
+       "n_needed_for_observed_diff": 559
+      },
+      "rouge_l_f1": {
+       "t_statistic": 2.1387184331179223,
+       "p_value": 0.03278130322034449,
+       "dof": 749,
+       "mean_difference": 0.01274053503733452,
+       "sd_difference": 0.1631415881252724,
+       "significant": true,
+       "mde_80_power": 0.016689379213214246,
+       "n_needed_for_observed_diff": 1287
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 0.8247820475948391,
+       "p_value": 0.40975792715944076,
+       "dof": 749,
+       "mean_difference": 0.018666666666666668,
+       "sd_difference": 0.6198094658205723,
+       "significant": false,
+       "mde_80_power": 0.0634064883999793,
+       "n_needed_for_observed_diff": 8654
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.011073068062541736,
+      "ordered_step_accuracy": 0.007460000000000002,
+      "reference_validity_micro": 0.0,
+      "step_count_term": -0.0015555555555555546,
+      "_sum": 0.016977512506986182,
+      "_total_delta_composite": 0.016977512506986203,
+      "_residual": -2.0816681711721685e-17,
+      "_share_reference_term": 0.0
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6826666666666668,
+      "step_count_term_b": 0.6982222222222223
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6122916256366132,
+        "system_b": 0.5812850040425221,
+        "difference": 0.031006621594091066,
+        "ci_low": 0.006984832469517322,
+        "ci_high": 0.055257794767673056,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.31763174603174604,
+        "system_b": 0.2664915750915751,
+        "difference": 0.051140170940170926,
+        "ci_low": 0.016691758241758215,
+        "ci_high": 0.087004126984127,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.30357142857142855,
+        "system_b": 0.25579999999999997,
+        "difference": 0.047771428571428576,
+        "ci_low": 0.01334261904761906,
+        "ci_high": 0.08333333333333331,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.5011907936507937,
+        "system_b": 0.46666996336996336,
+        "difference": 0.034520830280830306,
+        "ci_low": 0.008430750915750842,
+        "ci_high": 0.06167768131868124,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.132,
+        "system_b": 0.08,
+        "difference": 0.052000000000000005,
+        "ci_low": 0.016,
+        "ci_high": 0.092,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.716,
+        "system_b": 0.688,
+        "difference": 0.028000000000000025,
+        "ci_low": -0.039999999999999925,
+        "ci_high": 0.09599999999999997,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3764884920634921,
+        "system_b": 0.33333745421245425,
+        "difference": 0.043151037851037854,
+        "ci_low": 0.010538438644688685,
+        "ci_high": 0.07709710164835168,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.132,
+        "system_b_rate": 0.08,
+        "difference": 0.052,
+        "correct_only_in_a": 19,
+        "correct_only_in_b": 6,
+        "discordant_pairs": 25,
+        "p_value": 0.01463329792022705,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 5.960464477539063e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.716,
+        "system_b_rate": 0.688,
+        "difference": 0.028,
+        "correct_only_in_a": 39,
+        "correct_only_in_b": 32,
+        "discordant_pairs": 71,
+        "p_value": 0.4766877934342755,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.470329472543003e-22,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.630604290725952,
+        "p_value": 0.009054711373319146,
+        "dof": 249,
+        "mean_difference": 0.052,
+        "sd_difference": 0.31254879137176617,
+        "significant": true,
+        "mde_80_power": 0.05538012711132493,
+        "n_needed_for_observed_diff": 284
+       },
+       "step_f1": {
+        "t_statistic": 2.8542202049130907,
+        "p_value": 0.004677459767056112,
+        "dof": 249,
+        "mean_difference": 0.05114017094017094,
+        "sd_difference": 0.2832987795106351,
+        "significant": true,
+        "mde_80_power": 0.050197354310420314,
+        "n_needed_for_observed_diff": 241
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.6675802552273162,
+        "p_value": 0.00814114982001143,
+        "dof": 249,
+        "mean_difference": 0.04777142857142857,
+        "sd_difference": 0.2831527206533566,
+        "significant": true,
+        "mde_80_power": 0.05017147432526243,
+        "n_needed_for_observed_diff": 276
+       },
+       "rouge_l_f1": {
+        "t_statistic": 2.537312433509928,
+        "p_value": 0.011781810451854287,
+        "dof": 249,
+        "mean_difference": 0.03100662159409113,
+        "sd_difference": 0.19321930064531245,
+        "significant": true,
+        "mde_80_power": 0.034236284783359855,
+        "n_needed_for_observed_diff": 305
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.8302307458476655,
+        "p_value": 0.40720362812735666,
+        "dof": 249,
+        "mean_difference": 0.028,
+        "sd_difference": 0.5332479851388268,
+        "significant": false,
+        "mde_80_power": 0.09448553958322496,
+        "n_needed_for_observed_diff": 2847
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.020456068376068372,
+       "ordered_step_accuracy": 0.014331428571428571,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.00026666666666667064,
+       "_sum": 0.03452083028083027,
+       "_total_delta_composite": 0.034520830280830306,
+       "_residual": -3.469446951953614e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5077913385074214,
+        "system_b": 0.527144581146914,
+        "difference": -0.019353242639492563,
+        "ci_low": -0.038103823872285156,
+        "ci_high": 7.573233806335223e-05,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.14523492063492063,
+        "system_b": 0.15024155844155845,
+        "difference": -0.00500663780663782,
+        "ci_low": -0.027057503607503582,
+        "ci_high": 0.016504639249639217,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.1214,
+        "system_b": 0.12006666666666665,
+        "difference": 0.0013333333333333391,
+        "ci_low": -0.019666666666666652,
+        "ci_high": 0.021533333333333335,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.35971396825396823,
+        "system_b": 0.37118329004329004,
+        "difference": -0.011469321789321807,
+        "ci_low": -0.028702759740259754,
+        "ci_high": 0.0050394336219336386,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.0,
+        "difference": 0.008,
+        "ci_low": 0.0,
+        "ci_high": 0.02,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.436,
+        "system_b": 0.5,
+        "difference": -0.064,
+        "ci_low": -0.14800000000000002,
+        "ci_high": 0.020000000000000018,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19964246031746033,
+        "system_b": 0.21397911255411262,
+        "difference": -0.014336652236652286,
+        "ci_low": -0.03587844967532469,
+        "ci_high": 0.006299292027416981,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.0,
+        "difference": 0.008,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.436,
+        "system_b_rate": 0.5,
+        "difference": -0.064,
+        "correct_only_in_a": 51,
+        "correct_only_in_b": 67,
+        "discordant_pairs": 118,
+        "p_value": 0.1670511141738021,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.018531076210112e-36,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.4170619309433983,
+        "p_value": 0.15771479274702116,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.08926293455821276,
+        "significant": false,
+        "mde_80_power": 0.015816387068615163,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": -0.4448053343078316,
+        "p_value": 0.6568468350573387,
+        "dof": 249,
+        "mean_difference": -0.0050066378066378064,
+        "sd_difference": 0.17796975066769552,
+        "significant": false,
+        "mde_80_power": 0.03153423620897776,
+        "n_needed_for_observed_diff": 9918
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.12472441742398495,
+        "p_value": 0.9008423581663809,
+        "dof": 249,
+        "mean_difference": 0.0013333333333333344,
+        "sd_difference": 0.1690274567178303,
+        "significant": false,
+        "mde_80_power": 0.02994976239470754,
+        "n_needed_for_observed_diff": 126139
+       },
+       "rouge_l_f1": {
+        "t_statistic": -2.011165002116897,
+        "p_value": 0.04538578470223929,
+        "dof": 249,
+        "mean_difference": -0.019353242639492643,
+        "sd_difference": 0.15215143159876968,
+        "significant": true,
+        "mde_80_power": 0.026959520736355328,
+        "n_needed_for_observed_diff": 486
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.4763905903301566,
+        "p_value": 0.14110258409712165,
+        "dof": 249,
+        "mean_difference": -0.064,
+        "sd_difference": 0.6854072749322992,
+        "significant": false,
+        "mde_80_power": 0.12144645270321294,
+        "n_needed_for_observed_diff": 901
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.002002655122655128,
+       "ordered_step_accuracy": 0.00040000000000000175,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.00986666666666668,
+       "_sum": -0.011469321789321807,
+       "_total_delta_composite": -0.011469321789321807,
+       "_residual": 0.0,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.47103866042383513,
+        "system_b": 0.4444704342664301,
+        "difference": 0.026568226157405006,
+        "ci_low": 0.010194960606815275,
+        "ci_high": 0.043157770798003085,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.12137762856338707,
+        "system_b": 0.08446315122785711,
+        "difference": 0.036914477335529966,
+        "ci_low": 0.016679777166418035,
+        "ci_high": 0.05784610926397306,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09338427128427128,
+        "system_b": 0.06788903318903318,
+        "difference": 0.0254952380952381,
+        "ci_low": 0.007293311688311686,
+        "ci_high": 0.04454475468975468,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.13309966614396954,
+        "system_b": 0.10521863711451947,
+        "difference": 0.02788102902945007,
+        "ci_low": -0.17511684051620893,
+        "ci_high": 0.23908950663861422,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.324,
+        "system_b": 0.232,
+        "difference": 0.092,
+        "ci_low": 0.01599999999999996,
+        "ci_high": 0.172,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16637458267996197,
+        "system_b": 0.13152329639314936,
+        "difference": 0.03485128628681261,
+        "ci_low": 0.012396444512981839,
+        "ci_high": 0.05743994938863169,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.0,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.324,
+        "system_b_rate": 0.232,
+        "difference": 0.092,
+        "correct_only_in_a": 61,
+        "correct_only_in_b": 38,
+        "discordant_pairs": 99,
+        "p_value": 0.026525106848394427,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 3.1554436208840472e-30,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.06324555320336758,
+        "significant": false,
+        "mde_80_power": 0.0112064,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 3.501406927341175,
+        "p_value": 0.0005483308590836139,
+        "dof": 249,
+        "mean_difference": 0.036914477335529966,
+        "sd_difference": 0.1666956018499416,
+        "significant": true,
+        "mde_80_power": 0.029536583964478922,
+        "n_needed_for_observed_diff": 161
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.690408473657973,
+        "p_value": 0.007619437644559529,
+        "dof": 249,
+        "mean_difference": 0.0254952380952381,
+        "sd_difference": 0.1498341658127983,
+        "significant": true,
+        "mde_80_power": 0.02654892732719645,
+        "n_needed_for_observed_diff": 272
+       },
+       "rouge_l_f1": {
+        "t_statistic": 3.1298400041960353,
+        "p_value": 0.001957565862202991,
+        "dof": 249,
+        "mean_difference": 0.026568226157405065,
+        "sd_difference": 0.13421789601900833,
+        "significant": true,
+        "mde_80_power": 0.023781900129973523,
+        "n_needed_for_observed_diff": 201
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 2.3320157257786427,
+        "p_value": 0.020497866657081126,
+        "dof": 249,
+        "mean_difference": 0.092,
+        "sd_difference": 0.6237726905515435,
+        "significant": true,
+        "mde_80_power": 0.11052549824205844,
+        "n_needed_for_observed_diff": 361
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.014765790934211986,
+       "ordered_step_accuracy": 0.007648571428571429,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.005466666666666665,
+       "_sum": 0.02788102902945008,
+       "_total_delta_composite": 0.02788102902945007,
+       "_residual": 1.0408340855860843e-17,
+       "_share_reference_term": 0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_imbalanced_trial0__biencoder_only__uniform",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__uniform",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5235959820198607,
+       "system_b": 0.5193862670378518,
+       "difference": 0.004209714982008839,
+       "ci_low": -0.006038877317702168,
+       "ci_high": 0.014514995691820399,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.17253788433788433,
+       "system_b": 0.16287219914588333,
+       "difference": 0.009665685192001006,
+       "ci_low": -0.003956811891811891,
+       "ci_high": 0.023321206571206572,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.15658306878306877,
+       "system_b": 0.14818973544973546,
+       "difference": 0.008393333333333308,
+       "ci_low": -0.004951275132275094,
+       "ci_high": 0.021849767195767172,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.1835011854811855,
+       "system_b": 0.25302802251549616,
+       "difference": -0.06952683703431067,
+       "ci_low": -0.19196096453595138,
+       "ci_high": 0.13008944968082603,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.037333333333333336,
+       "system_b": 0.032,
+       "difference": 0.005333333333333336,
+       "ci_low": -0.006666666666666668,
+       "ci_high": 0.017333333333333336,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.472,
+       "system_b": 0.444,
+       "difference": 0.02799999999999997,
+       "ci_low": -0.01200000000000001,
+       "ci_high": 0.068,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.22937648185148188,
+       "system_b": 0.21906280592214805,
+       "difference": 0.010313675929333826,
+       "ci_low": -0.0031527573196783896,
+       "ci_high": 0.023959564928127394,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.037333333333333336,
+       "system_b_rate": 0.032,
+       "difference": 0.005333333333333333,
+       "correct_only_in_a": 13,
+       "correct_only_in_b": 9,
+       "discordant_pairs": 22,
+       "p_value": 0.5234670639038086,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 4.76837158203125e-07,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.472,
+       "system_b_rate": 0.444,
+       "difference": 0.028,
+       "correct_only_in_a": 127,
+       "correct_only_in_b": 106,
+       "discordant_pairs": 233,
+       "p_value": 0.1900004175149027,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.448908652612274e-70,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 0.8526476457277679,
+       "p_value": 0.3941272944760845,
+       "dof": 749,
+       "mean_difference": 0.005333333333333333,
+       "sd_difference": 0.17130094641072627,
+       "significant": false,
+       "mde_80_power": 0.017524081303142754,
+       "n_needed_for_observed_diff": 8098
+      },
+      "step_f1": {
+       "t_statistic": 1.387454659056794,
+       "p_value": 0.16571582599998794,
+       "dof": 749,
+       "mean_difference": 0.009665685192000981,
+       "sd_difference": 0.19078511066450216,
+       "significant": false,
+       "mde_80_power": 0.01951731067905224,
+       "n_needed_for_observed_diff": 3058
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 1.236736835003809,
+       "p_value": 0.21657243755734867,
+       "dof": 749,
+       "mean_difference": 0.008393333333333333,
+       "sd_difference": 0.18586080195923552,
+       "significant": false,
+       "mde_80_power": 0.019013554057031253,
+       "n_needed_for_observed_diff": 3849
+      },
+      "rouge_l_f1": {
+       "t_statistic": 0.802703292782754,
+       "p_value": 0.4224008769116191,
+       "dof": 749,
+       "mean_difference": 0.00420971498200888,
+       "sd_difference": 0.14362441745568835,
+       "significant": false,
+       "mde_80_power": 0.014692773282030155,
+       "n_needed_for_observed_diff": 9137
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 1.3765763307454555,
+       "p_value": 0.16905462343246902,
+       "dof": 749,
+       "mean_difference": 0.028,
+       "sd_difference": 0.5570425434323589,
+       "significant": false,
+       "mde_80_power": 0.05698543426031444,
+       "n_needed_for_observed_diff": 3107
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0038662740768004022,
+      "ordered_step_accuracy": 0.0025179999999999925,
+      "reference_validity_micro": -0.07777777777777778,
+      "step_count_term": 0.001866666666666672,
+      "_sum": -0.06952683703431072,
+      "_total_delta_composite": -0.06952683703431067,
+      "_residual": -4.163336342344337e-17,
+      "_share_reference_term": 1.1186727470342908
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.3888888888888889,
+      "step_count_term_a": 0.6751111111111111,
+      "step_count_term_b": 0.6564444444444444
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5954771911864707,
+        "system_b": 0.5917252890778902,
+        "difference": 0.0037519021085804516,
+        "ci_low": -0.017015552605380714,
+        "ci_high": 0.023793849570395993,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.28566060606060606,
+        "system_b": 0.27620346320346323,
+        "difference": 0.00945714285714283,
+        "ci_low": -0.022530800865800837,
+        "ci_high": 0.040299177489177405,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2674444444444445,
+        "system_b": 0.2627866666666666,
+        "difference": 0.004657777777777872,
+        "ci_low": -0.027336555555555586,
+        "ci_high": 0.035324611111111154,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.27049757575757577,
+        "system_b": 0.4674507186147186,
+        "difference": -0.19695314285714283,
+        "ci_low": -0.22032788354978353,
+        "ci_high": 0.014097589393939416,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.104,
+        "system_b": 0.088,
+        "difference": 0.016,
+        "ci_low": -0.016,
+        "ci_high": 0.048000000000000015,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.632,
+        "system_b": 0.648,
+        "difference": -0.016000000000000014,
+        "ci_low": -0.07600000000000007,
+        "ci_high": 0.040000000000000036,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3381219696969698,
+        "system_b": 0.3343133982683983,
+        "difference": 0.0038085714285714944,
+        "ci_low": -0.0260913636363636,
+        "ci_high": 0.03380970643939387,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.104,
+        "system_b_rate": 0.088,
+        "difference": 0.016,
+        "correct_only_in_a": 11,
+        "correct_only_in_b": 7,
+        "discordant_pairs": 18,
+        "p_value": 0.480682373046875,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 7.62939453125e-06,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.632,
+        "system_b_rate": 0.648,
+        "difference": -0.016,
+        "correct_only_in_a": 26,
+        "correct_only_in_b": 30,
+        "discordant_pairs": 56,
+        "p_value": 0.6888797607233396,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.7755575615628914e-17,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.9425987574171679,
+        "p_value": 0.34679980599354626,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.2683880185739599,
+        "significant": false,
+        "mde_80_power": 0.047555335339956796,
+        "n_needed_for_observed_diff": 2209
+       },
+       "step_f1": {
+        "t_statistic": 0.5985204259029302,
+        "p_value": 0.5500367930469842,
+        "dof": 249,
+        "mean_difference": 0.009457142857142858,
+        "sd_difference": 0.24983367560971162,
+        "significant": false,
+        "mde_80_power": 0.044267714654183735,
+        "n_needed_for_observed_diff": 5478
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.2937344043137916,
+        "p_value": 0.7692055478240865,
+        "dof": 249,
+        "mean_difference": 0.004657777777777778,
+        "sd_difference": 0.2507228706678915,
+        "significant": false,
+        "mde_80_power": 0.04442527000780592,
+        "n_needed_for_observed_diff": 22743
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.3615114919642303,
+        "p_value": 0.7180236819890292,
+        "dof": 249,
+        "mean_difference": 0.0037519021085802478,
+        "sd_difference": 0.1640965292228648,
+        "significant": false,
+        "mde_80_power": 0.029076057555698573,
+        "n_needed_for_observed_diff": 15015
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.5337574591250456,
+        "p_value": 0.5939855053598134,
+        "dof": 249,
+        "mean_difference": -0.016,
+        "sd_difference": 0.4739647352716492,
+        "significant": false,
+        "mde_80_power": 0.08398121512621057,
+        "n_needed_for_observed_diff": 6888
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0037828571428571325,
+       "ordered_step_accuracy": 0.0013973333333333615,
+       "reference_validity_micro": -0.2,
+       "step_count_term": -0.0021333333333333317,
+       "_sum": -0.19695314285714285,
+       "_total_delta_composite": -0.19695314285714283,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 1.0154699594972556
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.497639707522638,
+        "system_b": 0.5112249003003103,
+        "difference": -0.013585192777672339,
+        "ci_low": -0.029479565297911743,
+        "ci_high": 0.0024031027732158844,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.12493313353313353,
+        "system_b": 0.13114314574314573,
+        "difference": -0.006210012210012203,
+        "ci_low": -0.025886801531801534,
+        "ci_high": 0.012225541125541119,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.10526666666666666,
+        "system_b": 0.10979999999999998,
+        "difference": -0.00453333333333332,
+        "ci_low": -0.02260000000000001,
+        "ci_high": 0.012466666666666668,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.1487532534132534,
+        "system_b": 0.3537972582972583,
+        "difference": -0.20504400488400487,
+        "ci_low": -0.21883587662337664,
+        "ci_high": 0.005574722222222312,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.008,
+        "difference": -0.008,
+        "ci_low": -0.02,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.432,
+        "system_b": 0.42,
+        "difference": 0.01200000000000001,
+        "ci_low": -0.06,
+        "ci_high": 0.08400000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.18594156676656676,
+        "system_b": 0.19224657287157287,
+        "difference": -0.006305006105006117,
+        "ci_low": -0.025649841547341533,
+        "ci_high": 0.01233142676767678,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.0,
+        "system_b_rate": 0.008,
+        "difference": -0.008,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.432,
+        "system_b_rate": 0.42,
+        "difference": 0.012,
+        "correct_only_in_a": 43,
+        "correct_only_in_b": 40,
+        "discordant_pairs": 83,
+        "p_value": 0.8264047244491933,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.0679515313825692e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.4170619309433985,
+        "p_value": 0.15771479274702108,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.08926293455821276,
+        "significant": false,
+        "mde_80_power": 0.015816387068615163,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": -0.6382964193597989,
+        "p_value": 0.5238673483324656,
+        "dof": 249,
+        "mean_difference": -0.0062100122100122125,
+        "sd_difference": 0.1538296494032574,
+        "significant": false,
+        "mde_80_power": 0.027256882037690423,
+        "n_needed_for_observed_diff": 4817
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.5018629259703884,
+        "p_value": 0.6162074118341091,
+        "dof": 249,
+        "mean_difference": -0.004533333333333335,
+        "sd_difference": 0.14282444452713478,
+        "significant": false,
+        "mde_80_power": 0.025306883631838643,
+        "n_needed_for_observed_diff": 7791
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.6733328792565192,
+        "p_value": 0.09551755720558186,
+        "dof": 249,
+        "mean_difference": -0.013585192777672346,
+        "sd_difference": 0.12836702177573225,
+        "significant": false,
+        "mde_80_power": 0.022745191084058217,
+        "n_needed_for_observed_diff": 701
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.3287048276188198,
+        "p_value": 0.7426550818589363,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.5772250471177427,
+        "significant": false,
+        "mde_80_power": 0.10227777986572885,
+        "n_needed_for_observed_diff": 18162
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.002484004884004881,
+       "ordered_step_accuracy": -0.001359999999999996,
+       "reference_validity_micro": -0.2,
+       "step_count_term": -0.0012000000000000012,
+       "_sum": -0.2050440048840049,
+       "_total_delta_composite": -0.20504400488400487,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 0.9754003786316099
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4776710473504735,
+        "system_b": 0.45520861173535476,
+        "difference": 0.022462435615118737,
+        "ci_low": 0.005687781279974261,
+        "ci_high": 0.03890816141606174,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10701991341991342,
+        "system_b": 0.08126998849104111,
+        "difference": 0.025749924928872306,
+        "ci_low": 0.007132365120259862,
+        "ci_high": 0.04489811104100576,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09703809523809523,
+        "system_b": 0.07198253968253968,
+        "difference": 0.025055555555555553,
+        "ci_low": 0.008159484126984133,
+        "ci_high": 0.04357349206349206,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3312527272727273,
+        "system_b": 0.18228053507895614,
+        "difference": 0.14897219219377117,
+        "ci_low": 0.026070056304806296,
+        "ci_high": 0.2336040017745413,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.0,
+        "difference": 0.008,
+        "ci_low": 0.0,
+        "ci_high": 0.02,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.352,
+        "system_b": 0.264,
+        "difference": 0.08799999999999997,
+        "ci_low": 0.01200000000000001,
+        "ci_high": 0.164,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16406590909090912,
+        "system_b": 0.13062844662647294,
+        "difference": 0.033437462464436185,
+        "ci_low": 0.013455339377362402,
+        "ci_high": 0.05415456220862472,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.0,
+        "difference": 0.008,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.352,
+        "system_b_rate": 0.264,
+        "difference": 0.088,
+        "correct_only_in_a": 58,
+        "correct_only_in_b": 36,
+        "discordant_pairs": 94,
+        "p_value": 0.029766410087911834,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 1.0097419586828951e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.4170619309433985,
+        "p_value": 0.15771479274702108,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.08926293455821276,
+        "significant": false,
+        "mde_80_power": 0.015816387068615163,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": 2.6907069736307996,
+        "p_value": 0.007612820181888768,
+        "dof": 249,
+        "mean_difference": 0.025749924928872295,
+        "sd_difference": 0.15131415860514055,
+        "significant": true,
+        "mde_80_power": 0.026811165388025388,
+        "n_needed_for_observed_diff": 272
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.7881620496497055,
+        "p_value": 0.0057099050427796465,
+        "dof": 249,
+        "mean_difference": 0.025055555555555553,
+        "sd_difference": 0.1420875511995358,
+        "significant": true,
+        "mde_80_power": 0.025176314430240366,
+        "n_needed_for_observed_diff": 253
+       },
+       "rouge_l_f1": {
+        "t_statistic": 2.647870575941611,
+        "p_value": 0.00861723231699798,
+        "dof": 249,
+        "mean_difference": 0.022462435615118737,
+        "sd_difference": 0.13413128833421295,
+        "significant": true,
+        "mde_80_power": 0.023766554223269697,
+        "n_needed_for_observed_diff": 280
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 2.2882708590778087,
+        "p_value": 0.022960235917819434,
+        "dof": 249,
+        "mean_difference": 0.088,
+        "sd_difference": 0.6080583358190529,
+        "significant": true,
+        "mde_80_power": 0.10774109149795225,
+        "n_needed_for_observed_diff": 375
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.010299969971548924,
+       "ordered_step_accuracy": 0.007516666666666665,
+       "reference_validity_micro": 0.12222222222222223,
+       "step_count_term": 0.008933333333333326,
+       "_sum": 0.14897219219377114,
+       "_total_delta_composite": 0.14897219219377117,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 0.8204364883296159
+      }
+     }
+    }
+   },
+   {
+    "family": "size_2000_vs_4000",
+    "kind": "pool_size",
+    "contrast": "4000 vs 2000",
+    "cell_a": "size4000_imbalanced_trial0__biencoder_only__uniform",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_only__uniform",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5226512379903042,
+       "system_b": 0.5235959820198607,
+       "difference": -0.0009447440295564657,
+       "ci_low": -0.010997400156639223,
+       "ci_high": 0.00885179973553779,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.17242183742183745,
+       "system_b": 0.17253788433788433,
+       "difference": -0.00011604691604688577,
+       "ci_low": -0.013868586413586407,
+       "ci_high": 0.01345430828430829,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1576,
+       "system_b": 0.15658306878306877,
+       "difference": 0.0010169312169312217,
+       "ci_low": -0.012295833333333357,
+       "ci_high": 0.014180621693121676,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.38167095719095717,
+       "system_b": 0.1835011854811855,
+       "difference": 0.19816977170977168,
+       "ci_low": -0.0014751876919376513,
+       "ci_high": 0.2087140190642691,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.04666666666666667,
+       "system_b": 0.037333333333333336,
+       "difference": 0.009333333333333332,
+       "ci_low": -0.0013333333333333322,
+       "ci_high": 0.02,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.448,
+       "system_b": 0.472,
+       "difference": -0.023999999999999966,
+       "ci_low": -0.0626666666666667,
+       "ci_high": 0.014666666666666661,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2270886964886965,
+       "system_b": 0.22937648185148188,
+       "difference": -0.0022877853627853717,
+       "ci_low": -0.01599093591593588,
+       "ci_high": 0.01097386116198619,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.04666666666666667,
+       "system_b_rate": 0.037333333333333336,
+       "difference": 0.009333333333333334,
+       "correct_only_in_a": 12,
+       "correct_only_in_b": 5,
+       "discordant_pairs": 17,
+       "p_value": 0.143463134765625,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.52587890625e-05,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.448,
+       "system_b_rate": 0.472,
+       "difference": -0.024,
+       "correct_only_in_a": 104,
+       "correct_only_in_b": 122,
+       "discordant_pairs": 226,
+       "p_value": 0.2580814800066526,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.8546030753437107e-68,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.6998867582711485,
+       "p_value": 0.08956740265136842,
+       "dof": 749,
+       "mean_difference": 0.009333333333333334,
+       "sd_difference": 0.15036522811027522,
+       "significant": false,
+       "mde_80_power": 0.015382357994988136,
+       "n_needed_for_observed_diff": 2038
+      },
+      "step_f1": {
+       "t_statistic": -0.016678958722203922,
+       "p_value": 0.9866971750930438,
+       "dof": 749,
+       "mean_difference": -0.00011604691604691789,
+       "sd_difference": 0.19054401029000892,
+       "significant": false,
+       "mde_80_power": 0.019492646118503307,
+       "n_needed_for_observed_diff": 21160974
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 0.1507400876105511,
+       "p_value": 0.8802213352564245,
+       "dof": 749,
+       "mean_difference": 0.0010169312169312176,
+       "sd_difference": 0.18475382884991115,
+       "significant": false,
+       "mde_80_power": 0.01890031074358405,
+       "n_needed_for_observed_diff": 259070
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.18692639382651408,
+       "p_value": 0.8517689647218839,
+       "dof": 749,
+       "mean_difference": -0.0009447440295564652,
+       "sd_difference": 0.13841213256824889,
+       "significant": false,
+       "mde_80_power": 0.014159556705843672,
+       "n_needed_for_observed_diff": 168474
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -1.1976889364441152,
+       "p_value": 0.23141701643700902,
+       "dof": 749,
+       "mean_difference": -0.024,
+       "sd_difference": 0.5487794443168156,
+       "significant": false,
+       "mde_80_power": 0.056140119486807485,
+       "n_needed_for_observed_diff": 4104
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -4.641876641875431e-05,
+      "ordered_step_accuracy": 0.0003050793650793665,
+      "reference_validity_micro": 0.2,
+      "step_count_term": -0.0020888888888888845,
+      "_sum": 0.19816977170977174,
+      "_total_delta_composite": 0.19816977170977168,
+      "_residual": 5.551115123125783e-17,
+      "_share_reference_term": 1.0092356582663313
+     },
+     "reference_terms": {
+      "ref_micro_a": 1.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6542222222222223,
+      "step_count_term_b": 0.6751111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5965575732642396,
+        "system_b": 0.5954771911864707,
+        "difference": 0.0010803820777689488,
+        "ci_low": -0.019651625115617476,
+        "ci_high": 0.02139960973971465,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.29431746031746037,
+        "system_b": 0.28566060606060606,
+        "difference": 0.008656854256854307,
+        "ci_low": -0.02231430014430011,
+        "ci_high": 0.04031062049062049,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2779,
+        "system_b": 0.2674444444444445,
+        "difference": 0.010455555555555496,
+        "ci_low": -0.02057777777777775,
+        "ci_high": 0.04230027777777783,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4796303174603175,
+        "system_b": 0.27049757575757577,
+        "difference": 0.2091327417027417,
+        "ci_low": -0.001355234487734498,
+        "ci_high": 0.2321834852092352,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.136,
+        "system_b": 0.104,
+        "difference": 0.032000000000000015,
+        "ci_low": 0.0,
+        "ci_high": 0.064,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.628,
+        "system_b": 0.632,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.06799999999999995,
+        "ci_high": 0.06000000000000005,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3495378968253969,
+        "system_b": 0.3381219696969698,
+        "difference": 0.011415927128427095,
+        "ci_low": -0.01819690386002891,
+        "ci_high": 0.04108284316378064,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.136,
+        "system_b_rate": 0.104,
+        "difference": 0.032,
+        "correct_only_in_a": 12,
+        "correct_only_in_b": 4,
+        "discordant_pairs": 16,
+        "p_value": 0.076812744140625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.0517578125e-05,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.628,
+        "system_b_rate": 0.632,
+        "difference": -0.004,
+        "correct_only_in_a": 32,
+        "correct_only_in_b": 33,
+        "discordant_pairs": 65,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.421010862427522e-20,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.012158166696862,
+        "p_value": 0.04528026312539455,
+        "dof": 249,
+        "mean_difference": 0.032,
+        "sd_difference": 0.2514536053880529,
+        "significant": true,
+        "mde_80_power": 0.04455474797350076,
+        "n_needed_for_observed_diff": 485
+       },
+       "step_f1": {
+        "t_statistic": 0.5348551661642864,
+        "p_value": 0.5932273027933194,
+        "dof": 249,
+        "mean_difference": 0.008656854256854257,
+        "sd_difference": 0.2559139235777253,
+        "significant": false,
+        "mde_80_power": 0.04534506614179979,
+        "n_needed_for_observed_diff": 6860
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.6476300816226396,
+        "p_value": 0.517820899862466,
+        "dof": 249,
+        "mean_difference": 0.010455555555555556,
+        "sd_difference": 0.2552643144304101,
+        "significant": false,
+        "mde_80_power": 0.045229962714289806,
+        "n_needed_for_observed_diff": 4679
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.10184532791618334,
+        "p_value": 0.9189614115526779,
+        "dof": 249,
+        "mean_difference": 0.00108038207776897,
+        "sd_difference": 0.1677282688797858,
+        "significant": false,
+        "mde_80_power": 0.029719560936251697,
+        "n_needed_for_observed_diff": 189178
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.1237902255417955,
+        "p_value": 0.9015812383332797,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.5109091039018576,
+        "significant": false,
+        "mde_80_power": 0.09052734132240808,
+        "n_needed_for_observed_diff": 128050
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.003462741702741723,
+       "ordered_step_accuracy": 0.0031366666666666487,
+       "reference_validity_micro": 0.2,
+       "step_count_term": 0.002533333333333332,
+       "_sum": 0.2091327417027417,
+       "_total_delta_composite": 0.2091327417027417,
+       "_residual": 0.0,
+       "_share_reference_term": 0.9563304070496869
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5043402833514118,
+        "system_b": 0.497639707522638,
+        "difference": 0.006700575828773814,
+        "ci_low": -0.009181592564512297,
+        "ci_high": 0.022805023989890524,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1286989898989899,
+        "system_b": 0.12493313353313353,
+        "difference": 0.003765856365856371,
+        "ci_low": -0.01325586802086803,
+        "ci_high": 0.021000704850704856,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.10977619047619046,
+        "system_b": 0.10526666666666666,
+        "difference": 0.004509523809523797,
+        "ci_low": -0.010825357142857144,
+        "ci_high": 0.020009642857142858,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.34974578643578647,
+        "system_b": 0.1487532534132534,
+        "difference": 0.20099253302253306,
+        "ci_low": -0.009347915556665533,
+        "ci_high": 0.21291357378732378,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.0,
+        "difference": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.416,
+        "system_b": 0.432,
+        "difference": -0.016000000000000014,
+        "ci_low": -0.08799999999999997,
+        "ci_high": 0.055999999999999994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.18718223304473308,
+        "system_b": 0.18594156676656676,
+        "difference": 0.0012406662781663247,
+        "ci_low": -0.015345581259018784,
+        "ci_high": 0.018276255896880887,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.0,
+        "system_b_rate": 0.0,
+        "difference": 0.0,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 0,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.416,
+        "system_b_rate": 0.432,
+        "difference": -0.016,
+        "correct_only_in_a": 39,
+        "correct_only_in_b": 43,
+        "discordant_pairs": 82,
+        "p_value": 0.7406528413457828,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.1359030627651384e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.0,
+        "significant": false,
+        "degenerate_all_zero_differences": true
+       },
+       "step_f1": {
+        "t_statistic": 0.4339783611245056,
+        "p_value": 0.6646799363026109,
+        "dof": 249,
+        "mean_difference": 0.0037658563658563658,
+        "sd_difference": 0.1372036548814693,
+        "significant": false,
+        "mde_80_power": 0.02431094298629407,
+        "n_needed_for_observed_diff": 10419
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.5750628135342521,
+        "p_value": 0.5657680637473396,
+        "dof": 249,
+        "mean_difference": 0.00450952380952381,
+        "sd_difference": 0.1239896413507632,
+        "significant": false,
+        "mde_80_power": 0.021969568553939195,
+        "n_needed_for_observed_diff": 5934
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.8149449049166335,
+        "p_value": 0.41588261774919044,
+        "dof": 249,
+        "mean_difference": 0.006700575828773843,
+        "sd_difference": 0.13000315190487222,
+        "significant": false,
+        "mde_80_power": 0.023035094923150857,
+        "n_needed_for_observed_diff": 2955
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.44101390344813796,
+        "p_value": 0.6595856026308605,
+        "dof": 249,
+        "mean_difference": -0.016,
+        "sd_difference": 0.5736377262383076,
+        "significant": false,
+        "mde_80_power": 0.10164214699247316,
+        "n_needed_for_observed_diff": 10089
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0015063425463425484,
+       "ordered_step_accuracy": 0.001352857142857139,
+       "reference_validity_micro": 0.2,
+       "step_count_term": -0.001866666666666661,
+       "_sum": 0.20099253302253303,
+       "_total_delta_composite": 0.20099253302253306,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 0.9950618413151608
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4670558573552613,
+        "system_b": 0.4776710473504735,
+        "difference": -0.010615189995212215,
+        "ci_low": -0.02428239358462317,
+        "ci_high": 0.0032429448867197464,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.09424906204906204,
+        "system_b": 0.10701991341991342,
+        "difference": -0.012770851370851377,
+        "ci_low": -0.03269067099567103,
+        "ci_high": 0.006330238095238091,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08512380952380952,
+        "system_b": 0.09703809523809523,
+        "difference": -0.01191428571428571,
+        "ci_low": -0.030833333333333324,
+        "ci_high": 0.006200238095238102,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3156367676767677,
+        "system_b": 0.3312527272727273,
+        "difference": -0.015615959595959628,
+        "ci_low": -0.032304531024531034,
+        "ci_high": 0.00035519480519482155,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.008,
+        "difference": -0.004,
+        "ci_low": -0.012,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.3,
+        "system_b": 0.352,
+        "difference": -0.05199999999999999,
+        "ci_low": -0.124,
+        "ci_high": 0.019999999999999962,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14454595959595962,
+        "system_b": 0.16406590909090912,
+        "difference": -0.019519949494949507,
+        "ci_low": -0.04038066378066382,
+        "ci_high": 0.00044399350649351483,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.008,
+        "difference": -0.004,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.3,
+        "system_b_rate": 0.352,
+        "difference": -0.052,
+        "correct_only_in_a": 33,
+        "correct_only_in_b": 46,
+        "discordant_pairs": 79,
+        "p_value": 0.17661055306016413,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.308722450212111e-24,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -1.2863098442734842,
+        "p_value": 0.19952968493059786,
+        "dof": 249,
+        "mean_difference": -0.012770851370851372,
+        "sd_difference": 0.15697997714611173,
+        "significant": false,
+        "mde_80_power": 0.02781508464687628,
+        "n_needed_for_observed_diff": 1186
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.273742589176175,
+        "p_value": 0.2039423296869458,
+        "dof": 249,
+        "mean_difference": -0.011914285714285714,
+        "sd_difference": 0.1478959715695659,
+        "significant": false,
+        "mde_80_power": 0.026205501127768368,
+        "n_needed_for_observed_diff": 1210
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.5049910438970375,
+        "p_value": 0.13359378545637604,
+        "dof": 249,
+        "mean_difference": -0.01061518999521221,
+        "sd_difference": 0.11152285030673907,
+        "significant": false,
+        "mde_80_power": 0.01976059353388493,
+        "n_needed_for_observed_diff": 867
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.4659717190477972,
+        "p_value": 0.14391766364234101,
+        "dof": 249,
+        "mean_difference": -0.052,
+        "sd_difference": 0.5608513322329456,
+        "significant": false,
+        "mde_80_power": 0.09937654192580644,
+        "n_needed_for_observed_diff": 914
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.005108340548340551,
+       "ordered_step_accuracy": -0.003574285714285713,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.006933333333333325,
+       "_sum": -0.01561595959595959,
+       "_total_delta_composite": -0.015615959595959628,
+       "_residual": 3.8163916471489756e-17,
+       "_share_reference_term": -0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_4000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 4000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_only__uniform",
+    "cell_b": "size4000_imbalanced_trial0__biencoder_only__uniform",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5222343296012064,
+       "system_b": 0.5226512379903042,
+       "difference": -0.00041690838909780314,
+       "ci_low": -0.010842067397569145,
+       "ci_high": 0.010204151629760278,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1816171236171236,
+       "system_b": 0.17242183742183745,
+       "difference": 0.009195286195286145,
+       "ci_low": -0.004428054353054339,
+       "ci_high": 0.023440711880711895,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1649904761904762,
+       "system_b": 0.1576,
+       "difference": 0.007390476190476197,
+       "ci_low": -0.005974603174603161,
+       "ci_high": 0.021363928571428558,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.20818843674843676,
+       "system_b": 0.38167095719095717,
+       "difference": -0.1734825204425204,
+       "ci_low": -0.19830039754689757,
+       "ci_high": 0.010423573352573382,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.048,
+       "system_b": 0.04666666666666667,
+       "difference": 0.0013333333333333322,
+       "ci_low": -0.010666666666666665,
+       "ci_high": 0.013333333333333329,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.48933333333333334,
+       "system_b": 0.448,
+       "difference": 0.04133333333333333,
+       "ci_low": 0.0,
+       "ci_high": 0.08266666666666661,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.23940221260221262,
+       "system_b": 0.2270886964886965,
+       "difference": 0.01231351611351611,
+       "ci_low": -0.0013373770442520554,
+       "ci_high": 0.026255841901154434,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.048,
+       "system_b_rate": 0.04666666666666667,
+       "difference": 0.0013333333333333333,
+       "correct_only_in_a": 10,
+       "correct_only_in_b": 9,
+       "discordant_pairs": 19,
+       "p_value": 1.0,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 3.814697265625e-06,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.48933333333333334,
+       "system_b_rate": 0.448,
+       "difference": 0.04133333333333333,
+       "correct_only_in_a": 138,
+       "correct_only_in_b": 107,
+       "discordant_pairs": 245,
+       "p_value": 0.05506292243218664,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 3.5373746401666845e-74,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 0.22927078376273333,
+       "p_value": 0.8187210500611513,
+       "dof": 749,
+       "mean_difference": 0.0013333333333333333,
+       "sd_difference": 0.15926511249160893,
+       "significant": false,
+       "mde_80_power": 0.01629281588068547,
+       "n_needed_for_observed_diff": 111990
+      },
+      "step_f1": {
+       "t_statistic": 1.2777611653942695,
+       "p_value": 0.20172952834317964,
+       "dof": 749,
+       "mean_difference": 0.009195286195286196,
+       "sd_difference": 0.1970816537658678,
+       "significant": false,
+       "mde_80_power": 0.020161446835617956,
+       "n_needed_for_observed_diff": 3606
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 1.0652340500757127,
+       "p_value": 0.2871132956913694,
+       "dof": 749,
+       "mean_difference": 0.0073904761904761895,
+       "sd_difference": 0.19000193055887318,
+       "significant": false,
+       "mde_80_power": 0.019437191379459238,
+       "n_needed_for_observed_diff": 5188
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.07845082512669975,
+       "p_value": 0.9374903987034906,
+       "dof": 749,
+       "mean_difference": -0.0004169083890977863,
+       "sd_difference": 0.14553711114778467,
+       "significant": false,
+       "mde_80_power": 0.014888441785156447,
+       "n_needed_for_observed_diff": 956486
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 1.9843924875333312,
+       "p_value": 0.04757662843781157,
+       "dof": 749,
+       "mean_difference": 0.04133333333333333,
+       "sd_difference": 0.5704314843402823,
+       "significant": true,
+       "mde_80_power": 0.05835512248416613,
+       "n_needed_for_observed_diff": 1495
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0036781144781144583,
+      "ordered_step_accuracy": 0.002217142857142859,
+      "reference_validity_micro": -0.18333333333333335,
+      "step_count_term": 0.003955555555555557,
+      "_sum": -0.17348252044252047,
+      "_total_delta_composite": -0.1734825204425204,
+      "_residual": -5.551115123125783e-17,
+      "_share_reference_term": 1.0567827402189305
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.08333333333333333,
+      "ref_micro_b": 1.0,
+      "step_count_term_a": 0.6937777777777778,
+      "step_count_term_b": 0.6542222222222223
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6104274306537968,
+        "system_b": 0.5965575732642396,
+        "difference": 0.01386985738955715,
+        "ci_low": -0.006988269723519077,
+        "ci_high": 0.035421856550711124,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.3146285714285714,
+        "system_b": 0.29431746031746037,
+        "difference": 0.020311111111111058,
+        "ci_low": -0.01060023809523804,
+        "ci_high": 0.05207325396825392,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2969,
+        "system_b": 0.2779,
+        "difference": 0.019000000000000017,
+        "ci_low": -0.012200833333333376,
+        "ci_high": 0.0503333333333334,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4945214285714286,
+        "system_b": 0.4796303174603175,
+        "difference": 0.014891111111111133,
+        "ci_low": -0.00905015476190471,
+        "ci_high": 0.03909548809523812,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.128,
+        "system_b": 0.136,
+        "difference": -0.008000000000000007,
+        "ci_low": -0.039999999999999994,
+        "ci_high": 0.023999999999999994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.664,
+        "system_b": 0.628,
+        "difference": 0.03600000000000003,
+        "ci_low": -0.028000000000000025,
+        "ci_high": 0.09999999999999998,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.36815178571428575,
+        "system_b": 0.3495378968253969,
+        "difference": 0.018613888888888874,
+        "ci_low": -0.011312693452381008,
+        "ci_high": 0.04886936011904756,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.128,
+        "system_b_rate": 0.136,
+        "difference": -0.008,
+        "correct_only_in_a": 7,
+        "correct_only_in_b": 9,
+        "discordant_pairs": 16,
+        "p_value": 0.803619384765625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.0517578125e-05,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.664,
+        "system_b_rate": 0.628,
+        "difference": 0.036,
+        "correct_only_in_a": 38,
+        "correct_only_in_b": 29,
+        "discordant_pairs": 67,
+        "p_value": 0.3284320626971899,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.3552527156068805e-20,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.49924868477468143,
+        "p_value": 0.6180450118145276,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.25336292365762075,
+        "significant": false,
+        "mde_80_power": 0.0448930576754854,
+        "n_needed_for_observed_diff": 7873
+       },
+       "step_f1": {
+        "t_statistic": 1.2573224826849252,
+        "p_value": 0.20981488819778155,
+        "dof": 249,
+        "mean_difference": 0.02031111111111111,
+        "sd_difference": 0.2554212376076622,
+        "significant": false,
+        "mde_80_power": 0.04525776773463492,
+        "n_needed_for_observed_diff": 1242
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.1888581184208151,
+        "p_value": 0.23562804750438465,
+        "dof": 249,
+        "mean_difference": 0.019,
+        "sd_difference": 0.2526932129756958,
+        "significant": false,
+        "mde_80_power": 0.04477439248234856,
+        "n_needed_for_observed_diff": 1389
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.2730228286896115,
+        "p_value": 0.2041971998721562,
+        "dof": 249,
+        "mean_difference": 0.013869857389557228,
+        "sd_difference": 0.17226847462690775,
+        "significant": false,
+        "mde_80_power": 0.03052403428034505,
+        "n_needed_for_observed_diff": 1211
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.0999866381531294,
+        "p_value": 0.2724002569161166,
+        "dof": 249,
+        "mean_difference": 0.036,
+        "sd_difference": 0.5174699028944644,
+        "significant": false,
+        "mde_80_power": 0.09168984104146871,
+        "n_needed_for_observed_diff": 1622
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.008124444444444424,
+       "ordered_step_accuracy": 0.0057000000000000045,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0010666666666666713,
+       "_sum": 0.0148911111111111,
+       "_total_delta_composite": 0.014891111111111133,
+       "_residual": -3.2959746043559335e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5070847103170837,
+        "system_b": 0.5043402833514118,
+        "difference": 0.002744426965671898,
+        "ci_low": -0.014351613754881221,
+        "ci_high": 0.01996441892450437,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1422126984126984,
+        "system_b": 0.1286989898989899,
+        "difference": 0.013513708513708506,
+        "ci_low": -0.007811002886002914,
+        "ci_high": 0.0354124531024531,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11886666666666668,
+        "system_b": 0.10977619047619046,
+        "difference": 0.009090476190476218,
+        "ci_low": -0.010867499999999997,
+        "ci_high": 0.028923928571428576,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.362011746031746,
+        "system_b": 0.34974578643578647,
+        "difference": 0.012265959595959552,
+        "ci_low": -0.003930149350649346,
+        "ci_high": 0.0285336432178932,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.476,
+        "system_b": 0.416,
+        "difference": 0.06,
+        "ci_low": -0.01200000000000001,
+        "ci_high": 0.136,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20251468253968258,
+        "system_b": 0.18718223304473308,
+        "difference": 0.015332449494949496,
+        "ci_low": -0.0049126866883116285,
+        "ci_high": 0.03566705402236657,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.0,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.476,
+        "system_b_rate": 0.416,
+        "difference": 0.06,
+        "correct_only_in_a": 53,
+        "correct_only_in_b": 38,
+        "discordant_pairs": 91,
+        "p_value": 0.14179337454474722,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.077935669463161e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 1.2217885844608238,
+        "p_value": 0.2229430039487727,
+        "dof": 249,
+        "mean_difference": 0.01351370851370851,
+        "sd_difference": 0.17488335986453105,
+        "significant": false,
+        "mde_80_power": 0.030987362505693575,
+        "n_needed_for_observed_diff": 1315
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.8921278311260704,
+        "p_value": 0.3731857319644892,
+        "dof": 249,
+        "mean_difference": 0.009090476190476189,
+        "sd_difference": 0.16111261623320605,
+        "significant": false,
+        "mde_80_power": 0.028547341767257477,
+        "n_needed_for_observed_diff": 2466
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.31154519473981246,
+        "p_value": 0.7556468779264214,
+        "dof": 249,
+        "mean_difference": 0.0027444269656718844,
+        "sd_difference": 0.13928380584967576,
+        "significant": false,
+        "mde_80_power": 0.024679522319218106,
+        "n_needed_for_observed_diff": 20217
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.577097461793519,
+        "p_value": 0.11604268063860416,
+        "dof": 249,
+        "mean_difference": 0.06,
+        "sd_difference": 0.6015375213220144,
+        "significant": false,
+        "mde_80_power": 0.10658567658135507,
+        "n_needed_for_observed_diff": 789
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.005405483405483403,
+       "ordered_step_accuracy": 0.0027271428571428655,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0041333333333333335,
+       "_sum": 0.012265959595959601,
+       "_total_delta_composite": 0.012265959595959552,
+       "_residual": 4.85722573273506e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.44919084783273877,
+        "system_b": 0.4670558573552613,
+        "difference": -0.017865009522522513,
+        "ci_low": -0.03255283518006823,
+        "ci_high": -0.003189469827844872,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.08801010101010101,
+        "system_b": 0.09424906204906204,
+        "difference": -0.00623896103896103,
+        "ci_low": -0.023804906204906207,
+        "ci_high": 0.011562467532467523,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.0792047619047619,
+        "system_b": 0.08512380952380952,
+        "difference": -0.0059190476190476154,
+        "ci_low": -0.02285833333333334,
+        "ci_high": 0.011038095238095222,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.11803213564213565,
+        "system_b": 0.3156367676767677,
+        "difference": -0.19760463203463202,
+        "ci_low": -0.21373535064935067,
+        "ci_high": 0.004160104978354927,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.004,
+        "difference": 0.008,
+        "ci_low": 0.0,
+        "ci_high": 0.02,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.328,
+        "system_b": 0.3,
+        "difference": 0.028000000000000025,
+        "ci_low": -0.04799999999999999,
+        "ci_high": 0.09999999999999998,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14754016955266958,
+        "system_b": 0.14454595959595962,
+        "difference": 0.002994209956709959,
+        "ci_low": -0.01729579725829725,
+        "ci_high": 0.022745623647186144,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.004,
+        "difference": 0.008,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.328,
+        "system_b_rate": 0.3,
+        "difference": 0.028,
+        "correct_only_in_a": 47,
+        "correct_only_in_b": 40,
+        "discordant_pairs": 87,
+        "p_value": 0.5202915935750737,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.2924697071141057e-26,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.4170619309433983,
+        "p_value": 0.15771479274702116,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.08926293455821276,
+        "significant": false,
+        "mde_80_power": 0.015816387068615163,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": -0.6868144170397497,
+        "p_value": 0.49283880785097367,
+        "dof": 249,
+        "mean_difference": -0.00623896103896104,
+        "sd_difference": 0.14362924413557812,
+        "significant": false,
+        "mde_80_power": 0.02544948506190376,
+        "n_needed_for_observed_diff": 4160
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.6887279965603208,
+        "p_value": 0.4916356604771753,
+        "dof": 249,
+        "mean_difference": -0.005919047619047618,
+        "sd_difference": 0.13588580795806066,
+        "significant": false,
+        "mde_80_power": 0.024077435347978397,
+        "n_needed_for_observed_diff": 4137
+       },
+       "rouge_l_f1": {
+        "t_statistic": -2.377461948832671,
+        "p_value": 0.018188157185702103,
+        "dof": 249,
+        "mean_difference": -0.01786500952252247,
+        "sd_difference": 0.11881182901687802,
+        "significant": true,
+        "mde_80_power": 0.021052118500939083,
+        "n_needed_for_observed_diff": 348
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.7498214155385409,
+        "p_value": 0.4540701295094425,
+        "dof": 249,
+        "mean_difference": 0.028,
+        "sd_difference": 0.5904324193056038,
+        "significant": false,
+        "mde_80_power": 0.10461797752690079,
+        "n_needed_for_observed_diff": 3491
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0024955844155844123,
+       "ordered_step_accuracy": -0.0017757142857142845,
+       "reference_validity_micro": -0.2,
+       "step_count_term": 0.006666666666666665,
+       "_sum": -0.19760463203463205,
+       "_total_delta_composite": -0.19760463203463202,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 1.0121220233589878
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 1000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_only__uniform",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__uniform",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_only",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5222343296012064,
+       "system_b": 0.5193862670378518,
+       "difference": 0.0028480625633545698,
+       "ci_low": -0.008529844346237941,
+       "ci_high": 0.01408301100728675,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1816171236171236,
+       "system_b": 0.16287219914588333,
+       "difference": 0.018744924471240265,
+       "ci_low": 0.004039122427280315,
+       "ci_high": 0.03376803746935323,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1649904761904762,
+       "system_b": 0.14818973544973546,
+       "difference": 0.016800740740740727,
+       "ci_low": 0.0019820132275132026,
+       "ci_high": 0.03188550264550263,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.20818843674843676,
+       "system_b": 0.25302802251549616,
+       "difference": -0.0448395857670594,
+       "ci_low": -0.17060183195130574,
+       "ci_high": 0.13466935434838062,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.048,
+       "system_b": 0.032,
+       "difference": 0.016,
+       "ci_low": 0.0013333333333333322,
+       "ci_high": 0.03066666666666667,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.48933333333333334,
+       "system_b": 0.444,
+       "difference": 0.04533333333333334,
+       "ci_low": 0.0040000000000000036,
+       "ci_high": 0.08666666666666661,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.23940221260221262,
+       "system_b": 0.21906280592214805,
+       "difference": 0.020339406680064565,
+       "ci_low": 0.005518640043314411,
+       "ci_high": 0.03549024188360378,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.048,
+       "system_b_rate": 0.032,
+       "difference": 0.016,
+       "correct_only_in_a": 22,
+       "correct_only_in_b": 10,
+       "discordant_pairs": 32,
+       "p_value": 0.050102459732443094,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 4.656612873077393e-10,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.48933333333333334,
+       "system_b_rate": 0.444,
+       "difference": 0.04533333333333334,
+       "correct_only_in_a": 143,
+       "correct_only_in_b": 109,
+       "discordant_pairs": 252,
+       "p_value": 0.03742479437018304,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 2.7635739376302223e-76,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 2.126294137828391,
+       "p_value": 0.03380519224507209,
+       "dof": 749,
+       "mean_difference": 0.016,
+       "sd_difference": 0.2060759319271083,
+       "significant": true,
+       "mde_80_power": 0.021081561201960943,
+       "n_needed_for_observed_diff": 1303
+      },
+      "step_f1": {
+       "t_statistic": 2.444043821766076,
+       "p_value": 0.014753320938374328,
+       "dof": 749,
+       "mean_difference": 0.01874492447124026,
+       "sd_difference": 0.2100416097328791,
+       "significant": true,
+       "mde_80_power": 0.021487249913824624,
+       "n_needed_for_observed_diff": 986
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 2.1888745455587513,
+       "p_value": 0.028913985267422775,
+       "dof": 749,
+       "mean_difference": 0.01680074074074074,
+       "sd_difference": 0.21020265197863905,
+       "significant": true,
+       "mde_80_power": 0.021503724530381445,
+       "n_needed_for_observed_diff": 1229
+      },
+      "rouge_l_f1": {
+       "t_statistic": 0.4969095208607975,
+       "p_value": 0.6193986736859863,
+       "dof": 749,
+       "mean_difference": 0.002848062563354631,
+       "sd_difference": 0.1569650052622272,
+       "significant": false,
+       "mde_80_power": 0.016057514985166846,
+       "n_needed_for_observed_diff": 23841
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 2.146946202052134,
+       "p_value": 0.03211799299827292,
+       "dof": 749,
+       "mean_difference": 0.04533333333333334,
+       "sd_difference": 0.5782652879199762,
+       "significant": true,
+       "mde_80_power": 0.05915652033817596,
+       "n_needed_for_observed_diff": 1278
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.007497969788496106,
+      "ordered_step_accuracy": 0.005040222222222218,
+      "reference_validity_micro": -0.061111111111111116,
+      "step_count_term": 0.003733333333333344,
+      "_sum": -0.044839585767059445,
+      "_total_delta_composite": -0.0448395857670594,
+      "_residual": -4.163336342344337e-17,
+      "_share_reference_term": 1.3628830433131542
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.08333333333333333,
+      "ref_micro_b": 0.3888888888888889,
+      "step_count_term_a": 0.6937777777777778,
+      "step_count_term_b": 0.6564444444444444
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6104274306537968,
+        "system_b": 0.5917252890778902,
+        "difference": 0.01870214157590655,
+        "ci_low": -0.0034431521428966144,
+        "ci_high": 0.04099337413985062,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.3146285714285714,
+        "system_b": 0.27620346320346323,
+        "difference": 0.038425108225108195,
+        "ci_low": 0.004986536796536792,
+        "ci_high": 0.07216867965367961,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2969,
+        "system_b": 0.2627866666666666,
+        "difference": 0.034113333333333384,
+        "ci_low": -0.0009030000000000365,
+        "ci_high": 0.06923366666666658,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4945214285714286,
+        "system_b": 0.4674507186147186,
+        "difference": 0.027070709956710015,
+        "ci_low": 0.001216449783549748,
+        "ci_high": 0.05296436904761907,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.128,
+        "system_b": 0.088,
+        "difference": 0.04000000000000001,
+        "ci_low": 0.0,
+        "ci_high": 0.08,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.664,
+        "system_b": 0.648,
+        "difference": 0.016000000000000014,
+        "ci_low": -0.052000000000000046,
+        "ci_high": 0.08400000000000007,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.36815178571428575,
+        "system_b": 0.3343133982683983,
+        "difference": 0.03383838744588746,
+        "ci_low": 0.0015205622294372648,
+        "ci_high": 0.06620546130952386,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.128,
+        "system_b_rate": 0.088,
+        "difference": 0.04,
+        "correct_only_in_a": 18,
+        "correct_only_in_b": 8,
+        "discordant_pairs": 26,
+        "p_value": 0.07551869750022888,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.9802322387695312e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.664,
+        "system_b_rate": 0.648,
+        "difference": 0.016,
+        "correct_only_in_a": 41,
+        "correct_only_in_b": 37,
+        "discordant_pairs": 78,
+        "p_value": 0.7343420330298468,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.617444900424222e-24,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.9724667297574376,
+        "p_value": 0.049662775646749154,
+        "dof": 249,
+        "mean_difference": 0.04,
+        "sd_difference": 0.32064192642248096,
+        "significant": true,
+        "mde_80_power": 0.056814139528620085,
+        "n_needed_for_observed_diff": 505
+       },
+       "step_f1": {
+        "t_statistic": 2.2397332250059057,
+        "p_value": 0.025991317307331313,
+        "dof": 249,
+        "mean_difference": 0.03842510822510822,
+        "sd_difference": 0.27126190738517886,
+        "significant": true,
+        "mde_80_power": 0.048064556082646565,
+        "n_needed_for_observed_diff": 392
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.9157497266043697,
+        "p_value": 0.056542190272771305,
+        "dof": 249,
+        "mean_difference": 0.03411333333333333,
+        "sd_difference": 0.28154990815289105,
+        "significant": false,
+        "mde_80_power": 0.04988747399487618,
+        "n_needed_for_observed_diff": 535
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.6313039149620299,
+        "p_value": 0.10409031336750584,
+        "dof": 249,
+        "mean_difference": 0.018702141575906453,
+        "sd_difference": 0.18127022181569333,
+        "significant": false,
+        "mde_80_power": 0.032119042539218746,
+        "n_needed_for_observed_diff": 738
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.4521896361593077,
+        "p_value": 0.6515260490080794,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.5594604400096069,
+        "significant": false,
+        "mde_80_power": 0.09913009148269779,
+        "n_needed_for_observed_diff": 9597
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.01537004329004328,
+       "ordered_step_accuracy": 0.010234000000000016,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0014666666666666717,
+       "_sum": 0.027070709956709967,
+       "_total_delta_composite": 0.027070709956710015,
+       "_residual": -4.85722573273506e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5070847103170837,
+        "system_b": 0.5112249003003103,
+        "difference": -0.004140189983226628,
+        "ci_low": -0.02223063558921797,
+        "ci_high": 0.014724247258042486,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1422126984126984,
+        "system_b": 0.13114314574314573,
+        "difference": 0.011069552669552674,
+        "ci_low": -0.011442388167388181,
+        "ci_high": 0.03372998556998558,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11886666666666668,
+        "system_b": 0.10979999999999998,
+        "difference": 0.009066666666666695,
+        "ci_low": -0.012333333333333307,
+        "ci_high": 0.03106666666666666,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.362011746031746,
+        "system_b": 0.3537972582972583,
+        "difference": 0.008214487734487741,
+        "ci_low": -0.008971264069264117,
+        "ci_high": 0.02612981601731603,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.008,
+        "difference": -0.004,
+        "ci_low": -0.02,
+        "ci_high": 0.008,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.476,
+        "system_b": 0.42,
+        "difference": 0.055999999999999994,
+        "ci_low": -0.016000000000000014,
+        "ci_high": 0.128,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20251468253968258,
+        "system_b": 0.19224657287157287,
+        "difference": 0.010268109668109704,
+        "ci_low": -0.011214080086580093,
+        "ci_high": 0.032662270021645026,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.008,
+        "difference": -0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 3,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.25,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.476,
+        "system_b_rate": 0.42,
+        "difference": 0.056,
+        "correct_only_in_a": 51,
+        "correct_only_in_b": 37,
+        "discordant_pairs": 88,
+        "p_value": 0.1654405129339897,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.462348535570529e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.5765789258001912,
+        "p_value": 0.5647447828879819,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.10969105940803119,
+        "significant": false,
+        "mde_80_power": 0.019436020809202256,
+        "n_needed_for_observed_diff": 5903
+       },
+       "step_f1": {
+        "t_statistic": 0.9671088258587464,
+        "p_value": 0.3344280165147085,
+        "dof": 249,
+        "mean_difference": 0.011069552669552667,
+        "sd_difference": 0.1809775600170998,
+        "significant": false,
+        "mde_80_power": 0.032067186163337064,
+        "n_needed_for_observed_diff": 2098
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.8292744839977074,
+        "p_value": 0.40774336737240074,
+        "dof": 249,
+        "mean_difference": 0.009066666666666666,
+        "sd_difference": 0.17286988810976464,
+        "significant": false,
+        "mde_80_power": 0.030630597978706833,
+        "n_needed_for_observed_diff": 2854
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.4295538811227076,
+        "p_value": 0.6678916556312484,
+        "dof": 249,
+        "mean_difference": -0.004140189983226615,
+        "sd_difference": 0.15239566988186987,
+        "significant": false,
+        "mde_80_power": 0.02700279701045057,
+        "n_needed_for_observed_diff": 10635
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.496096553763767,
+        "p_value": 0.13589487704011236,
+        "dof": 249,
+        "mean_difference": 0.056,
+        "sd_difference": 0.5918319527036064,
+        "significant": false,
+        "mde_80_power": 0.1048659590888763,
+        "n_needed_for_observed_diff": 877
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.004427821067821069,
+       "ordered_step_accuracy": 0.0027200000000000084,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0010666666666666713,
+       "_sum": 0.00821448773448775,
+       "_total_delta_composite": 0.008214487734487741,
+       "_residual": 8.673617379884035e-18,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.44919084783273877,
+        "system_b": 0.45520861173535476,
+        "difference": -0.006017763902615991,
+        "ci_low": -0.02235195533550756,
+        "ci_high": 0.010380475003911465,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.08801010101010101,
+        "system_b": 0.08126998849104111,
+        "difference": 0.006740112519059899,
+        "ci_low": -0.012773164613164628,
+        "ci_high": 0.027379115592010308,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.0792047619047619,
+        "system_b": 0.07198253968253968,
+        "difference": 0.007222222222222227,
+        "ci_low": -0.010860476190476176,
+        "ci_high": 0.02714936507936509,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.11803213564213565,
+        "system_b": 0.18228053507895614,
+        "difference": -0.0642483994368205,
+        "ci_low": -0.1862501101150312,
+        "ci_high": 0.13834162911494277,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.0,
+        "difference": 0.012,
+        "ci_low": 0.0,
+        "ci_high": 0.028,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.328,
+        "system_b": 0.264,
+        "difference": 0.064,
+        "ci_low": -0.008000000000000007,
+        "ci_high": 0.136,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14754016955266958,
+        "system_b": 0.13062844662647294,
+        "difference": 0.016911722926196637,
+        "ci_low": -0.004897589738477877,
+        "ci_high": 0.03962711930065549,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.0,
+        "difference": 0.012,
+        "correct_only_in_a": 3,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 3,
+        "p_value": 0.25,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.25,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.328,
+        "system_b_rate": 0.264,
+        "difference": 0.064,
+        "correct_only_in_a": 51,
+        "correct_only_in_b": 35,
+        "discordant_pairs": 86,
+        "p_value": 0.10522535125694397,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.5849394142282115e-26,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.7390490211537188,
+        "p_value": 0.0832620199015193,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.10910368672886965,
+        "significant": false,
+        "mde_80_power": 0.019331944983181883,
+        "n_needed_for_observed_diff": 649
+       },
+       "step_f1": {
+        "t_statistic": 0.6637598718847258,
+        "p_value": 0.5074581128290646,
+        "dof": 249,
+        "mean_difference": 0.00674011251905989,
+        "sd_difference": 0.1605558587439427,
+        "significant": false,
+        "mde_80_power": 0.028448690608216802,
+        "n_needed_for_observed_diff": 4454
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.7480587927629682,
+        "p_value": 0.45513063131905046,
+        "dof": 249,
+        "mean_difference": 0.007222222222222222,
+        "sd_difference": 0.15265292120790352,
+        "significant": false,
+        "mde_80_power": 0.02704837904925089,
+        "n_needed_for_observed_diff": 3507
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.7162322026737863,
+        "p_value": 0.47451916191568466,
+        "dof": 249,
+        "mean_difference": -0.006017763902615938,
+        "sd_difference": 0.13284686364540185,
+        "significant": false,
+        "mde_80_power": 0.02353896862865233,
+        "n_needed_for_observed_diff": 3826
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.732213862481695,
+        "p_value": 0.08447381825187156,
+        "dof": 249,
+        "mean_difference": 0.064,
+        "sd_difference": 0.5841823998591714,
+        "significant": false,
+        "mde_80_power": 0.10351054444462095,
+        "n_needed_for_observed_diff": 654
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.00269604500762396,
+       "ordered_step_accuracy": 0.002166666666666668,
+       "reference_validity_micro": -0.07777777777777778,
+       "step_count_term": 0.008666666666666668,
+       "_sum": -0.06424839943682048,
+       "_total_delta_composite": -0.0642483994368205,
+       "_residual": 1.3877787807814457e-17,
+       "_share_reference_term": 1.2105792278025787
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5400628557221581,
+       "system_b": 0.5302035628451818,
+       "difference": 0.009859292876976289,
+       "ci_low": -0.0003703413030950172,
+       "ci_high": 0.02031968987992996,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.17911729751729755,
+       "system_b": 0.17549110149110148,
+       "difference": 0.0036261960261960713,
+       "ci_low": -0.010675261405261406,
+       "ci_high": 0.018466863876863845,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1601707045391256,
+       "system_b": 0.16043398692810457,
+       "difference": -0.0002632823889789637,
+       "ci_low": -0.014284361393680285,
+       "ci_high": 0.014151050993496804,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.19160924147976782,
+       "system_b": 0.21960917635741162,
+       "difference": -0.027999934877643795,
+       "ci_low": -0.19601389571631217,
+       "ci_high": 0.1949774363683272,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.037333333333333336,
+       "system_b": 0.034666666666666665,
+       "difference": 0.0026666666666666713,
+       "ci_low": -0.010666666666666668,
+       "ci_high": 0.016,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.47333333333333333,
+       "system_b": 0.4786666666666667,
+       "difference": -0.005333333333333357,
+       "ci_low": -0.04400000000000004,
+       "ci_high": 0.03333333333333338,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2395115518497098,
+       "system_b": 0.23879718473247885,
+       "difference": 0.0007143671172309407,
+       "ci_low": -0.012993411851413998,
+       "ci_high": 0.014495447006160084,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.037333333333333336,
+       "system_b_rate": 0.034666666666666665,
+       "difference": 0.0026666666666666666,
+       "correct_only_in_a": 14,
+       "correct_only_in_b": 12,
+       "discordant_pairs": 26,
+       "p_value": 0.8450189828872681,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.9802322387695312e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.47333333333333333,
+       "system_b_rate": 0.4786666666666667,
+       "difference": -0.005333333333333333,
+       "correct_only_in_a": 111,
+       "correct_only_in_b": 115,
+       "discordant_pairs": 226,
+       "p_value": 0.8418826617051988,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.8546030753437107e-68,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 0.3920109031838509,
+       "p_value": 0.695161671121033,
+       "dof": 749,
+       "mean_difference": 0.0026666666666666666,
+       "sd_difference": 0.18629500797270335,
+       "significant": false,
+       "mde_80_power": 0.01905797331823066,
+       "n_needed_for_observed_diff": 38307
+      },
+      "step_f1": {
+       "t_statistic": 0.48793042407129783,
+       "p_value": 0.6257419200756261,
+       "dof": 749,
+       "mean_difference": 0.003626196026196027,
+       "sd_difference": 0.20352792770234557,
+       "significant": false,
+       "mde_80_power": 0.02082090045179537,
+       "n_needed_for_observed_diff": 24727
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.03571412148560818,
+       "p_value": 0.9715198261500206,
+       "dof": 749,
+       "mean_difference": -0.0002632823889789832,
+       "sd_difference": 0.2018889131792722,
+       "significant": false,
+       "mde_80_power": 0.020653229318849595,
+       "n_needed_for_observed_diff": 4615233
+      },
+      "rouge_l_f1": {
+       "t_statistic": 1.8235689492594014,
+       "p_value": 0.06861566350899469,
+       "dof": 749,
+       "mean_difference": 0.009859292876976244,
+       "sd_difference": 0.1480656136408508,
+       "significant": false,
+       "mde_80_power": 0.01514710750879728,
+       "n_needed_for_observed_diff": 1771
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.26591114957450046,
+       "p_value": 0.7903808151609323,
+       "dof": 749,
+       "mean_difference": -0.005333333333333333,
+       "sd_difference": 0.5492787681214653,
+       "significant": false,
+       "mde_80_power": 0.056191200295948464,
+       "n_needed_for_observed_diff": 83254
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0014504784104784286,
+      "ordered_step_accuracy": -7.898471669368911e-05,
+      "reference_validity_micro": -0.02857142857142857,
+      "step_count_term": -0.0008000000000000008,
+      "_sum": -0.027999934877643833,
+      "_total_delta_composite": -0.027999934877643795,
+      "_residual": -3.8163916471489756e-17,
+      "_share_reference_term": 1.020410536534536
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.14285714285714285,
+      "step_count_term_a": 0.719111111111111,
+      "step_count_term_b": 0.727111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6083134087436441,
+        "system_b": 0.5957691572119477,
+        "difference": 0.012544251531696471,
+        "ci_low": -0.010581643193051776,
+        "ci_high": 0.03663093768002171,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.29572380952380956,
+        "system_b": 0.2812761904761905,
+        "difference": 0.014447619047619042,
+        "ci_low": -0.01889619047619051,
+        "ci_high": 0.04672499999999999,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2740105263157894,
+        "system_b": 0.26713333333333333,
+        "difference": 0.006877192982456093,
+        "ci_low": -0.029112543859649103,
+        "ci_high": 0.0410771929824561,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4808926817042607,
+        "system_b": 0.4757171428571429,
+        "difference": 0.0051755388471178,
+        "ci_low": -0.02059201754385969,
+        "ci_high": 0.029946253132832123,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.092,
+        "system_b": 0.096,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.04000000000000001,
+        "ci_high": 0.032,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.64,
+        "system_b": 0.66,
+        "difference": -0.020000000000000018,
+        "ci_low": -0.08400000000000007,
+        "ci_high": 0.04399999999999993,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.35111585213032587,
+        "system_b": 0.3446464285714287,
+        "difference": 0.0064694235588971805,
+        "ci_low": -0.025740021929824573,
+        "ci_high": 0.03743281641604011,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.092,
+        "system_b_rate": 0.096,
+        "difference": -0.004,
+        "correct_only_in_a": 10,
+        "correct_only_in_b": 11,
+        "discordant_pairs": 21,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 9.5367431640625e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.64,
+        "system_b_rate": 0.66,
+        "difference": -0.02,
+        "correct_only_in_a": 31,
+        "correct_only_in_b": 36,
+        "discordant_pairs": 67,
+        "p_value": 0.6254068289416487,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.3552527156068805e-20,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.21780176115740937,
+        "p_value": 0.8277619508153277,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.2903812754647969,
+        "significant": false,
+        "mde_80_power": 0.051452292857728225,
+        "n_needed_for_observed_diff": 41365
+       },
+       "step_f1": {
+        "t_statistic": 0.8580097455443408,
+        "p_value": 0.3917122061951977,
+        "dof": 249,
+        "mean_difference": 0.01444761904761905,
+        "sd_difference": 0.26624046634763904,
+        "significant": false,
+        "mde_80_power": 0.04717481326290805,
+        "n_needed_for_observed_diff": 2666
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.3903317101750384,
+        "p_value": 0.6966249886363971,
+        "dof": 249,
+        "mean_difference": 0.006877192982456141,
+        "sd_difference": 0.27857836253343876,
+        "significant": false,
+        "mde_80_power": 0.04936094956520202,
+        "n_needed_for_observed_diff": 12880
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.0359294391835445,
+        "p_value": 0.30124005678897325,
+        "dof": 249,
+        "mean_difference": 0.012544251531696422,
+        "sd_difference": 0.19146287807729817,
+        "significant": false,
+        "mde_80_power": 0.03392506647836845,
+        "n_needed_for_observed_diff": 1829
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.610079756603217,
+        "p_value": 0.5423653419958157,
+        "dof": 249,
+        "mean_difference": -0.02,
+        "sd_difference": 0.5183384018140859,
+        "significant": false,
+        "mde_80_power": 0.09184372927233847,
+        "n_needed_for_observed_diff": 5273
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.005779047619047618,
+       "ordered_step_accuracy": 0.002063157894736828,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.002666666666666662,
+       "_sum": 0.005175538847117784,
+       "_total_delta_composite": 0.0051755388471178,
+       "_residual": -1.5612511283791264e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5304393935125665,
+        "system_b": 0.5271035505673597,
+        "difference": 0.003335842945206835,
+        "ci_low": -0.013112910098791425,
+        "ci_high": 0.019825233189564893,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13943290043290044,
+        "system_b": 0.15237806637806636,
+        "difference": -0.012945165945165926,
+        "ci_low": -0.033702518037518045,
+        "ci_high": 0.008128340548340515,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.12123333333333332,
+        "system_b": 0.13369999999999999,
+        "difference": -0.012466666666666668,
+        "ci_low": -0.03180083333333333,
+        "ci_high": 0.007000833333333354,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3626764935064935,
+        "system_b": 0.37386122655122656,
+        "difference": -0.011184733044733053,
+        "ci_low": -0.027427864718614733,
+        "ci_high": 0.004704345959595897,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.008,
+        "difference": 0.008,
+        "ci_low": -0.008,
+        "ci_high": 0.024,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.484,
+        "system_b": 0.488,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.07600000000000001,
+        "ci_high": 0.068,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20334561688311692,
+        "system_b": 0.21732653318903322,
+        "difference": -0.013980916305916302,
+        "ci_low": -0.03428483089826843,
+        "ci_high": 0.0058804324494949505,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.008,
+        "difference": 0.008,
+        "correct_only_in_a": 3,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 4,
+        "p_value": 0.625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.484,
+        "system_b_rate": 0.488,
+        "difference": -0.004,
+        "correct_only_in_a": 41,
+        "correct_only_in_b": 42,
+        "discordant_pairs": 83,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.0679515313825692e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0000000000000002,
+        "p_value": 0.31828130151580053,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.12649110640673517,
+        "significant": false,
+        "mde_80_power": 0.0224128,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -1.2217332808895751,
+        "p_value": 0.22296388687695165,
+        "dof": 249,
+        "mean_difference": -0.012945165945165944,
+        "sd_difference": 0.16753333037536658,
+        "significant": false,
+        "mde_80_power": 0.02968502002791465,
+        "n_needed_for_observed_diff": 1315
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.2511516058453327,
+        "p_value": 0.21205341169371528,
+        "dof": 249,
+        "mean_difference": -0.012466666666666666,
+        "sd_difference": 0.1575471002578055,
+        "significant": false,
+        "mde_80_power": 0.027915572477513938,
+        "n_needed_for_observed_diff": 1254
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.3896155800248615,
+        "p_value": 0.697153859740561,
+        "dof": 249,
+        "mean_difference": 0.0033358429452069087,
+        "sd_difference": 0.13537525402327305,
+        "significant": false,
+        "mde_80_power": 0.023986970938624487,
+        "n_needed_for_observed_diff": 12927
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.1095471512232284,
+        "p_value": 0.912856759453351,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.5773363569673273,
+        "significant": false,
+        "mde_80_power": 0.10229750271793277,
+        "n_needed_for_observed_diff": 163513
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.005178066378066371,
+       "ordered_step_accuracy": -0.0037400000000000003,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.002266666666666661,
+       "_sum": -0.011184733044733032,
+       "_total_delta_composite": -0.011184733044733053,
+       "_residual": 2.0816681711721685e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4814357649102635,
+        "system_b": 0.467737980756238,
+        "difference": 0.013697784154025505,
+        "ci_low": 0.0006141127320988445,
+        "ci_high": 0.026430791414289275,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1021951825951826,
+        "system_b": 0.09281904761904762,
+        "difference": 0.009376134976134973,
+        "ci_low": -0.009945149295149303,
+        "ci_high": 0.029815974025974024,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08526825396825397,
+        "system_b": 0.08046862745098039,
+        "difference": 0.0047996265172735725,
+        "ci_low": -0.012421619981325863,
+        "ci_high": 0.023015483193277318,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.13125854922854924,
+        "system_b": 0.1521063025210084,
+        "difference": -0.020847753292459165,
+        "ci_low": -0.1857770295178678,
+        "ci_high": 0.19705179027345202,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.296,
+        "system_b": 0.288,
+        "difference": 0.008000000000000007,
+        "ci_low": -0.06,
+        "ci_high": 0.07600000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16407318653568653,
+        "system_b": 0.1544185924369748,
+        "difference": 0.009654594098711722,
+        "ci_low": -0.008022321808093855,
+        "ci_high": 0.028115719454156994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.0,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.296,
+        "system_b_rate": 0.288,
+        "difference": 0.008,
+        "correct_only_in_a": 39,
+        "correct_only_in_b": 37,
+        "discordant_pairs": 76,
+        "p_value": 0.9087769252754921,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.6469779601696886e-23,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 0.9334097718255628,
+        "p_value": 0.35151266886219734,
+        "dof": 249,
+        "mean_difference": 0.009376134976134978,
+        "sd_difference": 0.1588259683406017,
+        "significant": false,
+        "mde_80_power": 0.028142173504102544,
+        "n_needed_for_observed_diff": 2253
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.5372685202168122,
+        "p_value": 0.5915619333954292,
+        "dof": 249,
+        "mean_difference": 0.004799626517273575,
+        "sd_difference": 0.14124921842248525,
+        "significant": false,
+        "mde_80_power": 0.025027771300219343,
+        "n_needed_for_observed_diff": 6798
+       },
+       "rouge_l_f1": {
+        "t_statistic": 2.07474379567118,
+        "p_value": 0.03903763911210664,
+        "dof": 249,
+        "mean_difference": 0.0136977841540254,
+        "sd_difference": 0.1043892670373552,
+        "significant": true,
+        "mde_80_power": 0.0184966028894681,
+        "n_needed_for_observed_diff": 456
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.22898054713560115,
+        "p_value": 0.8190719933686823,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.5524098356347614,
+        "significant": false,
+        "mde_80_power": 0.0978808037642047,
+        "n_needed_for_observed_diff": 37425
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.003750453990453989,
+       "ordered_step_accuracy": 0.0014398879551820716,
+       "reference_validity_micro": -0.02857142857142857,
+       "step_count_term": 0.002533333333333321,
+       "_sum": -0.02084775329245919,
+       "_total_delta_composite": -0.020847753292459165,
+       "_residual": -2.42861286636753e-17,
+       "_share_reference_term": 1.370479982692578
+      }
+     }
+    }
+   },
+   {
+    "family": "size_2000_vs_4000",
+    "kind": "pool_size",
+    "contrast": "4000 vs 2000",
+    "cell_a": "size4000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5461039107256193,
+       "system_b": 0.5400628557221581,
+       "difference": 0.006041055003461193,
+       "ci_low": -0.00357613542463642,
+       "ci_high": 0.015472297035575785,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.18857699816523343,
+       "system_b": 0.17911729751729755,
+       "difference": 0.009459700647935887,
+       "ci_low": -0.0044364439917381066,
+       "ci_high": 0.023301628741628725,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.17118095238095235,
+       "system_b": 0.1601707045391256,
+       "difference": 0.011010247841826748,
+       "ci_low": -0.002306979253689776,
+       "ci_high": 0.02438802561960457,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.20087397386926797,
+       "system_b": 0.19160924147976782,
+       "difference": 0.009264732389500152,
+       "ci_low": -0.0009366414305222431,
+       "ci_high": 0.019687902366152435,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.04,
+       "system_b": 0.037333333333333336,
+       "difference": 0.0026666666666666644,
+       "ci_low": -0.009333333333333336,
+       "ci_high": 0.014666666666666672,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.52,
+       "system_b": 0.47333333333333333,
+       "difference": 0.04666666666666669,
+       "ci_low": 0.008000000000000007,
+       "ci_high": 0.08400000000000002,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.251092467336585,
+       "system_b": 0.2395115518497098,
+       "difference": 0.011580915486875232,
+       "ci_low": -0.0011708017881528166,
+       "ci_high": 0.024609877957690488,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.04,
+       "system_b_rate": 0.037333333333333336,
+       "difference": 0.0026666666666666666,
+       "correct_only_in_a": 12,
+       "correct_only_in_b": 10,
+       "discordant_pairs": 22,
+       "p_value": 0.8318119049072266,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 4.76837158203125e-07,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.52,
+       "system_b_rate": 0.47333333333333333,
+       "difference": 0.04666666666666667,
+       "correct_only_in_a": 127,
+       "correct_only_in_b": 92,
+       "discordant_pairs": 219,
+       "p_value": 0.021375972466109734,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 2.3738919364399497e-66,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 0.4261687302171958,
+       "p_value": 0.6701073444572928,
+       "dof": 749,
+       "mean_difference": 0.0026666666666666666,
+       "sd_difference": 0.17136328678268525,
+       "significant": false,
+       "mde_80_power": 0.01753045872118724,
+       "n_needed_for_observed_diff": 32413
+      },
+      "step_f1": {
+       "t_statistic": 1.3380863562739422,
+       "p_value": 0.1812743710702979,
+       "dof": 749,
+       "mean_difference": 0.00945970064793594,
+       "sd_difference": 0.1936082603274075,
+       "significant": false,
+       "mde_80_power": 0.01980611879868208,
+       "n_needed_for_observed_diff": 3288
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 1.605111485360803,
+       "p_value": 0.10889079212838512,
+       "dof": 749,
+       "mean_difference": 0.01101024784182679,
+       "sd_difference": 0.1878548986064832,
+       "significant": false,
+       "mde_80_power": 0.019217550079848933,
+       "n_needed_for_observed_diff": 2285
+      },
+      "rouge_l_f1": {
+       "t_statistic": 1.2321445168090985,
+       "p_value": 0.21828175851131368,
+       "dof": 749,
+       "mean_difference": 0.006041055003461135,
+       "sd_difference": 0.1342708607385607,
+       "significant": false,
+       "mde_80_power": 0.01373590473098613,
+       "n_needed_for_observed_diff": 3878
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 2.3723668604958683,
+       "p_value": 0.017926219625819372,
+       "dof": 749,
+       "mean_difference": 0.04666666666666667,
+       "sd_difference": 0.538710653114695,
+       "significant": true,
+       "mde_80_power": 0.05511008247097415,
+       "n_needed_for_observed_diff": 1046
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.003783880259174355,
+      "ordered_step_accuracy": 0.0033030743525480242,
+      "reference_validity_micro": 0.0,
+      "step_count_term": 0.0021777777777777898,
+      "_sum": 0.00926473238950017,
+      "_total_delta_composite": 0.009264732389500152,
+      "_residual": 1.734723475976807e-17,
+      "_share_reference_term": 0.0
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.7408888888888889,
+      "step_count_term_b": 0.719111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6235746052382365,
+        "system_b": 0.6083134087436441,
+        "difference": 0.015261196494592344,
+        "ci_low": -0.0047974246806328485,
+        "ci_high": 0.03601577971623006,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.310622969187675,
+        "system_b": 0.29572380952380956,
+        "difference": 0.014899159663865458,
+        "ci_low": -0.014649187675070053,
+        "ci_high": 0.045647815126050414,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2934,
+        "system_b": 0.2740105263157894,
+        "difference": 0.019389473684210567,
+        "ci_low": -0.010333596491228097,
+        "ci_high": 0.05016868421052632,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.49600252100840336,
+        "system_b": 0.4808926817042607,
+        "difference": 0.01510983930414267,
+        "ci_low": -0.006640754017396413,
+        "ci_high": 0.03771769032876317,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.108,
+        "system_b": 0.092,
+        "difference": 0.016,
+        "ci_low": -0.016,
+        "ci_high": 0.048,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.68,
+        "system_b": 0.64,
+        "difference": 0.040000000000000036,
+        "ci_low": -0.02400000000000002,
+        "ci_high": 0.10399999999999998,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3700031512605042,
+        "system_b": 0.35111585213032587,
+        "difference": 0.018887299130178337,
+        "ci_low": -0.008300942521745514,
+        "ci_high": 0.047147112910953866,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.108,
+        "system_b_rate": 0.092,
+        "difference": 0.016,
+        "correct_only_in_a": 10,
+        "correct_only_in_b": 6,
+        "discordant_pairs": 16,
+        "p_value": 0.454498291015625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.0517578125e-05,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.68,
+        "system_b_rate": 0.64,
+        "difference": 0.04,
+        "correct_only_in_a": 38,
+        "correct_only_in_b": 28,
+        "discordant_pairs": 66,
+        "p_value": 0.267811664846587,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.710505431213761e-20,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.25298221281347033,
+        "significant": false,
+        "mde_80_power": 0.0448256,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 0.9697539665146,
+        "p_value": 0.33311016817245487,
+        "dof": 249,
+        "mean_difference": 0.014899159663865546,
+        "sd_difference": 0.24292388269192244,
+        "significant": false,
+        "mde_80_power": 0.04304337714060516,
+        "n_needed_for_observed_diff": 2087
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.2543125897242993,
+        "p_value": 0.21090458594518005,
+        "dof": 249,
+        "mean_difference": 0.019389473684210526,
+        "sd_difference": 0.2444163439652582,
+        "significant": false,
+        "mde_80_power": 0.043307824475894166,
+        "n_needed_for_observed_diff": 1248
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.4602471172504097,
+        "p_value": 0.14548273145575147,
+        "dof": 249,
+        "mean_difference": 0.01526119649459232,
+        "sd_difference": 0.16524648524272148,
+        "significant": false,
+        "mde_80_power": 0.02927981681604505,
+        "n_needed_for_observed_diff": 921
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.2321901975453422,
+        "p_value": 0.2190403029437473,
+        "dof": 249,
+        "mean_difference": 0.04,
+        "sd_difference": 0.5132775226532369,
+        "significant": false,
+        "mde_80_power": 0.0909469984611497,
+        "n_needed_for_observed_diff": 1293
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.005959663865546184,
+       "ordered_step_accuracy": 0.00581684210526317,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0033333333333333327,
+       "_sum": 0.015109839304142687,
+       "_total_delta_composite": 0.01510983930414267,
+       "_residual": 1.734723475976807e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.533015929943775,
+        "system_b": 0.5304393935125665,
+        "difference": 0.002576536431208476,
+        "ci_low": -0.013301039220950047,
+        "ci_high": 0.0186204889110449,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.15714554334554334,
+        "system_b": 0.13943290043290044,
+        "difference": 0.017712642912642906,
+        "ci_low": -0.005574016539016535,
+        "ci_high": 0.041671976356976344,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13119999999999998,
+        "system_b": 0.12123333333333332,
+        "difference": 0.009966666666666665,
+        "ci_low": -0.01210083333333336,
+        "ci_high": 0.03233333333333334,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3750182173382174,
+        "system_b": 0.3626764935064935,
+        "difference": 0.012341723831723883,
+        "ci_low": -0.0048942004107003926,
+        "ci_high": 0.029811229242979298,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.016,
+        "difference": -0.004,
+        "ci_low": -0.02,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.508,
+        "system_b": 0.484,
+        "difference": 0.02400000000000002,
+        "ci_low": -0.043999999999999984,
+        "ci_high": 0.09200000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2187727716727717,
+        "system_b": 0.20334561688311692,
+        "difference": 0.015427154789654784,
+        "ci_low": -0.006117750513375518,
+        "ci_high": 0.03726403655372404,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.016,
+        "difference": -0.004,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 3,
+        "discordant_pairs": 5,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.508,
+        "system_b_rate": 0.484,
+        "difference": 0.024,
+        "correct_only_in_a": 41,
+        "correct_only_in_b": 35,
+        "discordant_pairs": 76,
+        "p_value": 0.5665734423986847,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.6469779601696886e-23,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.4464969065851096,
+        "p_value": 0.655626407259774,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.14164835695521658,
+        "significant": false,
+        "mde_80_power": 0.02509849415465968,
+        "n_needed_for_observed_diff": 9843
+       },
+       "step_f1": {
+        "t_statistic": 1.471594207127449,
+        "p_value": 0.14239318671514462,
+        "dof": 249,
+        "mean_difference": 0.017712642912642913,
+        "sd_difference": 0.1903116182229557,
+        "significant": false,
+        "mde_80_power": 0.03372107619322986,
+        "n_needed_for_observed_diff": 907
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.8785964216622191,
+        "p_value": 0.38046716483279003,
+        "dof": 249,
+        "mean_difference": 0.009966666666666664,
+        "sd_difference": 0.17936202885232014,
+        "significant": false,
+        "mde_80_power": 0.03178093222882294,
+        "n_needed_for_observed_diff": 2542
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.3121116367460496,
+        "p_value": 0.7552168822652471,
+        "dof": 249,
+        "mean_difference": 0.0025765364312084196,
+        "sd_difference": 0.13052579009813983,
+        "significant": false,
+        "mde_80_power": 0.023127700527061083,
+        "n_needed_for_observed_diff": 20144
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.6875209724323147,
+        "p_value": 0.49239438219072396,
+        "dof": 249,
+        "mean_difference": 0.024,
+        "sd_difference": 0.5519443543339532,
+        "significant": false,
+        "mde_80_power": 0.09779832571815766,
+        "n_needed_for_observed_diff": 4152
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.007085057165057163,
+       "ordered_step_accuracy": 0.0029899999999999996,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.002266666666666661,
+       "_sum": 0.012341723831723824,
+       "_total_delta_composite": 0.012341723831723883,
+       "_residual": -5.898059818321144e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.48172119699484617,
+        "system_b": 0.4814357649102635,
+        "difference": 0.00028543208458264857,
+        "ci_low": -0.011556623750854148,
+        "ci_high": 0.012353273984775821,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.09796248196248197,
+        "system_b": 0.1021951825951826,
+        "difference": -0.00423270063270062,
+        "ci_low": -0.02054305194805194,
+        "ci_high": 0.012471099456099458,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08894285714285713,
+        "system_b": 0.08526825396825397,
+        "difference": 0.0036746031746031638,
+        "ci_low": -0.010901706349206348,
+        "ci_high": 0.018719087301587303,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.13160118326118325,
+        "system_b": 0.13125854922854924,
+        "difference": 0.00034263403263401493,
+        "ci_low": -0.0124847316017316,
+        "ci_high": 0.013503771117771096,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.004,
+        "difference": -0.004,
+        "ci_low": -0.012,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.372,
+        "system_b": 0.296,
+        "difference": 0.07600000000000001,
+        "ci_low": 0.008000000000000007,
+        "ci_high": 0.144,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1645014790764791,
+        "system_b": 0.16407318653568653,
+        "difference": 0.00042829254079257417,
+        "ci_low": -0.015605914502164505,
+        "ci_high": 0.016879713897213884,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.0,
+        "system_b_rate": 0.004,
+        "difference": -0.004,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.372,
+        "system_b_rate": 0.296,
+        "difference": 0.076,
+        "correct_only_in_a": 48,
+        "correct_only_in_b": 29,
+        "discordant_pairs": 77,
+        "p_value": 0.039539532877977755,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 1.3234889800848443e-23,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -0.5097537950992609,
+        "p_value": 0.6106754631458396,
+        "dof": 249,
+        "mean_difference": -0.004232700632700635,
+        "sd_difference": 0.13128862189602156,
+        "significant": false,
+        "mde_80_power": 0.023262865733574393,
+        "n_needed_for_observed_diff": 7552
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.48901537829865493,
+        "p_value": 0.6252612631372019,
+        "dof": 249,
+        "mean_difference": 0.0036746031746031733,
+        "sd_difference": 0.11881135077448118,
+        "significant": false,
+        "mde_80_power": 0.021052033761770485,
+        "n_needed_for_observed_diff": 8206
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.04568988999558527,
+        "p_value": 0.9635940433076606,
+        "dof": 249,
+        "mean_difference": 0.0002854320845826743,
+        "sd_difference": 0.09877628340299094,
+        "significant": false,
+        "mde_80_power": 0.01750204538124489,
+        "n_needed_for_observed_diff": 939966
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 2.1814677212407205,
+        "p_value": 0.03008450148938957,
+        "dof": 249,
+        "mean_difference": 0.076,
+        "sd_difference": 0.5508518412459162,
+        "significant": true,
+        "mde_80_power": 0.09760474469862877,
+        "n_needed_for_observed_diff": 413
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0016930802530802482,
+       "ordered_step_accuracy": 0.001102380952380949,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0009333333333333416,
+       "_sum": 0.00034263403263404247,
+       "_total_delta_composite": 0.00034263403263401493,
+       "_residual": 2.7538735181131813e-17,
+       "_share_reference_term": 0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_4000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 4000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "cell_b": "size4000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5421902806691635,
+       "system_b": 0.5461039107256193,
+       "difference": -0.00391363005645573,
+       "ci_low": -0.014116577305037653,
+       "ci_high": 0.006455938605649958,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1907283605283605,
+       "system_b": 0.18857699816523343,
+       "difference": 0.002151362363127074,
+       "ci_low": -0.012094120117355407,
+       "ci_high": 0.016095864669099944,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.17273968253968253,
+       "system_b": 0.17118095238095235,
+       "difference": 0.001558730158730176,
+       "ci_low": -0.011790634920634887,
+       "ci_high": 0.014921031746031765,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.20006880452880452,
+       "system_b": 0.20087397386926797,
+       "difference": -0.0008051693404634575,
+       "ci_low": -0.011463011924894328,
+       "ci_high": 0.009924061031561062,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.048,
+       "system_b": 0.04,
+       "difference": 0.008,
+       "ci_low": -0.0040000000000000036,
+       "ci_high": 0.02133333333333333,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5013333333333333,
+       "system_b": 0.52,
+       "difference": -0.01866666666666672,
+       "ci_low": -0.05733333333333329,
+       "ci_high": 0.020000000000000018,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2500860056610057,
+       "system_b": 0.251092467336585,
+       "difference": -0.0010064616755793288,
+       "ci_low": -0.014328764906117843,
+       "ci_high": 0.012405076289451285,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.048,
+       "system_b_rate": 0.04,
+       "difference": 0.008,
+       "correct_only_in_a": 15,
+       "correct_only_in_b": 9,
+       "discordant_pairs": 24,
+       "p_value": 0.30745625495910645,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.1920928955078125e-07,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.5013333333333333,
+       "system_b_rate": 0.52,
+       "difference": -0.018666666666666668,
+       "correct_only_in_a": 103,
+       "correct_only_in_b": 117,
+       "discordant_pairs": 220,
+       "p_value": 0.3808230775762083,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.1869459682199748e-66,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.2251538695233413,
+       "p_value": 0.22090238271097676,
+       "dof": 749,
+       "mean_difference": 0.008,
+       "sd_difference": 0.17882572014183434,
+       "significant": false,
+       "mde_80_power": 0.018293865413590807,
+       "n_needed_for_observed_diff": 3922
+      },
+      "step_f1": {
+       "t_statistic": 0.3016546549671696,
+       "p_value": 0.7629990714000593,
+       "dof": 749,
+       "mean_difference": 0.0021513623631270705,
+       "sd_difference": 0.1953143563755981,
+       "significant": false,
+       "mde_80_power": 0.019980652369487796,
+       "n_needed_for_observed_diff": 64693
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 0.2322036786448897,
+       "p_value": 0.8164432500928998,
+       "dof": 749,
+       "mean_difference": 0.0015587301587301585,
+       "sd_difference": 0.18383680955928414,
+       "significant": false,
+       "mde_80_power": 0.018806499699674413,
+       "n_needed_for_observed_diff": 109179
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.7610959447893489,
+       "p_value": 0.4468393088647468,
+       "dof": 749,
+       "mean_difference": -0.003913630056455641,
+       "sd_difference": 0.14082215772705622,
+       "significant": false,
+       "mde_80_power": 0.014406102202003961,
+       "n_needed_for_observed_diff": 10163
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.9438110775021538,
+       "p_value": 0.34557053579344865,
+       "dof": 749,
+       "mean_difference": -0.018666666666666668,
+       "sd_difference": 0.5416420007392724,
+       "significant": false,
+       "mde_80_power": 0.055409959238599836,
+       "n_needed_for_observed_diff": 6609
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0008605449452508296,
+      "ordered_step_accuracy": 0.0004676190476190528,
+      "reference_validity_micro": 0.0,
+      "step_count_term": -0.0021333333333333425,
+      "_sum": -0.00080516934046346,
+      "_total_delta_composite": -0.0008051693404634575,
+      "_residual": -2.6020852139652106e-18,
+      "_share_reference_term": -0.0
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.7195555555555555,
+      "step_count_term_b": 0.7408888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.620586646506496,
+        "system_b": 0.6235746052382365,
+        "difference": -0.0029879587317405143,
+        "ci_low": -0.02369276705413275,
+        "ci_high": 0.017748768060693917,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.31439999999999996,
+        "system_b": 0.310622969187675,
+        "difference": 0.003777030812324944,
+        "ci_low": -0.02597098039215693,
+        "ci_high": 0.033243837535014045,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.297,
+        "system_b": 0.2934,
+        "difference": 0.003599999999999992,
+        "ci_low": -0.024533333333333296,
+        "ci_high": 0.0325333333333333,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.5001933333333334,
+        "system_b": 0.49600252100840336,
+        "difference": 0.0041908123249300155,
+        "ci_low": -0.017531415966386587,
+        "ci_high": 0.02600254201680673,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.108,
+        "difference": 0.008000000000000007,
+        "ci_low": -0.023999999999999994,
+        "ci_high": 0.039999999999999994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.676,
+        "system_b": 0.68,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.06000000000000005,
+        "ci_high": 0.05599999999999994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3752416666666667,
+        "system_b": 0.3700031512605042,
+        "difference": 0.005238515406162492,
+        "ci_low": -0.021914269957983196,
+        "ci_high": 0.03250317752100855,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.116,
+        "system_b_rate": 0.108,
+        "difference": 0.008,
+        "correct_only_in_a": 9,
+        "correct_only_in_b": 7,
+        "discordant_pairs": 16,
+        "p_value": 0.803619384765625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.0517578125e-05,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.676,
+        "system_b_rate": 0.68,
+        "difference": -0.004,
+        "correct_only_in_a": 27,
+        "correct_only_in_b": 28,
+        "discordant_pairs": 55,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.551115123125783e-17,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.49924868477468143,
+        "p_value": 0.6180450118145276,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.25336292365762075,
+        "significant": false,
+        "mde_80_power": 0.0448930576754854,
+        "n_needed_for_observed_diff": 7873
+       },
+       "step_f1": {
+        "t_statistic": 0.2492838514711868,
+        "p_value": 0.803346732335498,
+        "dof": 249,
+        "mean_difference": 0.0037770308123249293,
+        "sd_difference": 0.2395666644488459,
+        "significant": false,
+        "mde_80_power": 0.042448515863983266,
+        "n_needed_for_observed_diff": 31577
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.24616553785153275,
+        "p_value": 0.8057568929908516,
+        "dof": 249,
+        "mean_difference": 0.0035999999999999995,
+        "sd_difference": 0.23123057102071284,
+        "significant": false,
+        "mde_80_power": 0.04097145395747035,
+        "n_needed_for_observed_diff": 32382
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.2827928323846926,
+        "p_value": 0.7775705924077194,
+        "dof": 249,
+        "mean_difference": -0.0029879587317405178,
+        "sd_difference": 0.16706143269633195,
+        "significant": false,
+        "mde_80_power": 0.029601405071882417,
+        "n_needed_for_observed_diff": 24537
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.13457491604929533,
+        "p_value": 0.8930566891864592,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.46996539221470135,
+        "significant": false,
+        "mde_80_power": 0.08327257656170524,
+        "n_needed_for_observed_diff": 108349
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0015108123249299777,
+       "ordered_step_accuracy": 0.0010799999999999976,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0015999999999999903,
+       "_sum": 0.004190812324929965,
+       "_total_delta_composite": 0.0041908123249300155,
+       "_residual": -5.0306980803327406e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5284846334084438,
+        "system_b": 0.533015929943775,
+        "difference": -0.004531296535331242,
+        "ci_low": -0.021952645791864536,
+        "ci_high": 0.012705531145224463,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.15921538461538462,
+        "system_b": 0.15714554334554334,
+        "difference": 0.002069841269841277,
+        "ci_low": -0.02094824175824176,
+        "ci_high": 0.02566807081807084,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13473333333333332,
+        "system_b": 0.13119999999999998,
+        "difference": 0.0035333333333333328,
+        "ci_low": -0.01766666666666665,
+        "ci_high": 0.024800000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.37557282051282054,
+        "system_b": 0.3750182173382174,
+        "difference": 0.0005546031746031521,
+        "ci_low": -0.016751264957264953,
+        "ci_high": 0.01788881440781434,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.012,
+        "difference": 0.008,
+        "ci_low": -0.012,
+        "ci_high": 0.028,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.496,
+        "system_b": 0.508,
+        "difference": -0.01200000000000001,
+        "ci_low": -0.07999999999999996,
+        "ci_high": 0.052000000000000046,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.21946602564102566,
+        "system_b": 0.2187727716727717,
+        "difference": 0.000693253968253954,
+        "ci_low": -0.020939081196581204,
+        "ci_high": 0.02236101800976801,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.02,
+        "system_b_rate": 0.012,
+        "difference": 0.008,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 6,
+        "p_value": 0.6875,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.03125,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.496,
+        "system_b_rate": 0.508,
+        "difference": -0.012,
+        "correct_only_in_a": 34,
+        "correct_only_in_b": 37,
+        "discordant_pairs": 71,
+        "p_value": 0.8125886494061618,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.470329472543003e-22,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.8159506119058424,
+        "p_value": 0.41530824255993326,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.15502299350114557,
+        "significant": false,
+        "mde_80_power": 0.027468329176994783,
+        "n_needed_for_observed_diff": 2948
+       },
+       "step_f1": {
+        "t_statistic": 0.17571371903522529,
+        "p_value": 0.860661668567764,
+        "dof": 249,
+        "mean_difference": 0.0020698412698412706,
+        "sd_difference": 0.18625218462314383,
+        "significant": false,
+        "mde_80_power": 0.033001790261037084,
+        "n_needed_for_observed_diff": 63554
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.32809859517036455,
+        "p_value": 0.7431128392952763,
+        "dof": 249,
+        "mean_difference": 0.003533333333333336,
+        "sd_difference": 0.17027474714005597,
+        "significant": false,
+        "mde_80_power": 0.030170768215348944,
+        "n_needed_for_observed_diff": 18229
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.5130625271160982,
+        "p_value": 0.608362466552124,
+        "dof": 249,
+        "mean_difference": -0.004531296535331206,
+        "sd_difference": 0.13964397171841947,
+        "significant": false,
+        "mde_80_power": 0.024743339656359754,
+        "n_needed_for_observed_diff": 7455
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.3554118307989267,
+        "p_value": 0.7225819728341514,
+        "dof": 249,
+        "mean_difference": -0.012,
+        "sd_difference": 0.5338501511995131,
+        "significant": false,
+        "mde_80_power": 0.09459223662990549,
+        "n_needed_for_observed_diff": 15535
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0008279365079365109,
+       "ordered_step_accuracy": 0.0010599999999999997,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.001333333333333331,
+       "_sum": 0.0005546031746031798,
+       "_total_delta_composite": 0.0005546031746031521,
+       "_residual": 2.7647155398380363e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.47749956209255096,
+        "system_b": 0.48172119699484617,
+        "difference": -0.004221634902295213,
+        "ci_low": -0.018235458423208874,
+        "ci_high": 0.009373973944841513,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.09856969696969696,
+        "system_b": 0.09796248196248197,
+        "difference": 0.0006072150072149868,
+        "ci_low": -0.018250202020202028,
+        "ci_high": 0.019169264069264065,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08648571428571428,
+        "system_b": 0.08894285714285713,
+        "difference": -0.002457142857142852,
+        "ci_low": -0.019799999999999998,
+        "ci_high": 0.014828571428571413,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.12444025974025974,
+        "system_b": 0.13160118326118325,
+        "difference": -0.007160923520923512,
+        "ci_low": -0.022625876623376655,
+        "ci_high": 0.008351146464646493,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.0,
+        "difference": 0.008,
+        "ci_low": 0.0,
+        "ci_high": 0.02,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.332,
+        "system_b": 0.372,
+        "difference": -0.03999999999999998,
+        "ci_low": -0.11599999999999999,
+        "ci_high": 0.03600000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1555503246753247,
+        "system_b": 0.1645014790764791,
+        "difference": -0.008951154401154404,
+        "ci_low": -0.0282823457792208,
+        "ci_high": 0.010438933080808132,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.0,
+        "difference": 0.008,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.332,
+        "system_b_rate": 0.372,
+        "difference": -0.04,
+        "correct_only_in_a": 42,
+        "correct_only_in_b": 52,
+        "discordant_pairs": 94,
+        "p_value": 0.3533280324715825,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0097419586828951e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.4170619309433983,
+        "p_value": 0.15771479274702116,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.08926293455821276,
+        "significant": false,
+        "mde_80_power": 0.015816387068615163,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": 0.06377635695420424,
+        "p_value": 0.9491994725626073,
+        "dof": 249,
+        "mean_difference": 0.0006072150072150099,
+        "sd_difference": 0.15054030552527706,
+        "significant": false,
+        "mde_80_power": 0.0266740473344241,
+        "n_needed_for_observed_diff": 482429
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.2805717140427661,
+        "p_value": 0.7792718875972894,
+        "dof": 249,
+        "mean_difference": -0.002457142857142857,
+        "sd_difference": 0.13847026581946878,
+        "significant": false,
+        "mde_80_power": 0.024535372184817415,
+        "n_needed_for_observed_diff": 24927
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.6033216131475383,
+        "p_value": 0.5468439223278082,
+        "dof": 249,
+        "mean_difference": -0.004221634902295199,
+        "sd_difference": 0.11063735700821459,
+        "significant": false,
+        "mde_80_power": 0.01960369409039874,
+        "n_needed_for_observed_diff": 5391
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.0315534712764842,
+        "p_value": 0.30328224883180516,
+        "dof": 249,
+        "mean_difference": -0.04,
+        "sd_difference": 0.6131097898890796,
+        "significant": false,
+        "mde_80_power": 0.10863615228915637,
+        "n_needed_for_observed_diff": 1845
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0002428860028859947,
+       "ordered_step_accuracy": -0.0007371428571428556,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.006666666666666665,
+       "_sum": -0.007160923520923526,
+       "_total_delta_composite": -0.007160923520923512,
+       "_residual": -1.3877787807814457e-17,
+       "_share_reference_term": -0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 1000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "raw"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5421902806691635,
+       "system_b": 0.5302035628451818,
+       "difference": 0.011986717823981752,
+       "ci_low": 0.00021952933816465366,
+       "ci_high": 0.023706232831207912,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1907283605283605,
+       "system_b": 0.17549110149110148,
+       "difference": 0.015237259037259032,
+       "ci_low": -0.001123748658748651,
+       "ci_high": 0.031513827838827835,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.17273968253968253,
+       "system_b": 0.16043398692810457,
+       "difference": 0.01230569561157796,
+       "ci_low": -0.003927065826330572,
+       "ci_high": 0.028395665266106426,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.20006880452880452,
+       "system_b": 0.21960917635741162,
+       "difference": -0.0195403718286071,
+       "ci_low": -0.1881556397105074,
+       "ci_high": 0.20427464259433373,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.048,
+       "system_b": 0.034666666666666665,
+       "difference": 0.013333333333333336,
+       "ci_low": -0.0013333333333333322,
+       "ci_high": 0.028000000000000004,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5013333333333333,
+       "system_b": 0.4786666666666667,
+       "difference": 0.022666666666666613,
+       "ci_low": -0.019999999999999962,
+       "ci_high": 0.0653333333333333,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2500860056610057,
+       "system_b": 0.23879718473247885,
+       "difference": 0.011288820928526844,
+       "ci_low": -0.004573446306552904,
+       "ci_high": 0.027002653637212506,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.048,
+       "system_b_rate": 0.034666666666666665,
+       "difference": 0.013333333333333334,
+       "correct_only_in_a": 21,
+       "correct_only_in_b": 11,
+       "discordant_pairs": 32,
+       "p_value": 0.11018416518345475,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 4.656612873077393e-10,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.5013333333333333,
+       "system_b_rate": 0.4786666666666667,
+       "difference": 0.02266666666666667,
+       "correct_only_in_a": 142,
+       "correct_only_in_b": 125,
+       "discordant_pairs": 267,
+       "p_value": 0.3274959920566324,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 8.433758354584419e-81,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.7702799816382495,
+       "p_value": 0.07708724620214075,
+       "dof": 749,
+       "mean_difference": 0.013333333333333334,
+       "sd_difference": 0.20626588757570188,
+       "significant": false,
+       "mde_80_power": 0.021100993658696842,
+       "n_needed_for_observed_diff": 1879
+      },
+      "step_f1": {
+       "t_statistic": 1.8041444188872426,
+       "p_value": 0.0716102926415137,
+       "dof": 749,
+       "mean_difference": 0.015237259037259039,
+       "sd_difference": 0.23129496735088786,
+       "significant": false,
+       "mde_80_power": 0.023661467713939663,
+       "n_needed_for_observed_diff": 1809
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 1.5000921598646155,
+       "p_value": 0.13401191715267843,
+       "dof": 749,
+       "mean_difference": 0.012305695611577964,
+       "sd_difference": 0.2246564328708271,
+       "significant": false,
+       "mde_80_power": 0.022982345850343134,
+       "n_needed_for_observed_diff": 2616
+      },
+      "rouge_l_f1": {
+       "t_statistic": 1.9886991238921614,
+       "p_value": 0.04709788732997347,
+       "dof": 749,
+       "mean_difference": 0.011986717823981738,
+       "sd_difference": 0.16506759780219146,
+       "significant": true,
+       "mde_80_power": 0.016886409941159225,
+       "n_needed_for_observed_diff": 1489
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 1.0404403349724936,
+       "p_value": 0.29847110020699,
+       "dof": 749,
+       "mean_difference": 0.02266666666666667,
+       "sd_difference": 0.5966245357602359,
+       "significant": false,
+       "mde_80_power": 0.06103467080119705,
+       "n_needed_for_observed_diff": 5438
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.006094903614903613,
+      "ordered_step_accuracy": 0.003691708683473388,
+      "reference_validity_micro": -0.02857142857142857,
+      "step_count_term": -0.0007555555555555538,
+      "_sum": -0.019540371828607125,
+      "_total_delta_composite": -0.0195403718286071,
+      "_residual": -2.42861286636753e-17,
+      "_share_reference_term": 1.462174252467397
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.14285714285714285,
+      "step_count_term_a": 0.7195555555555555,
+      "step_count_term_b": 0.727111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.620586646506496,
+        "system_b": 0.5957691572119477,
+        "difference": 0.0248174892945483,
+        "ci_low": -0.0008480085812829604,
+        "ci_high": 0.051070067475060876,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.31439999999999996,
+        "system_b": 0.2812761904761905,
+        "difference": 0.033123809523809444,
+        "ci_low": -0.00514428571428574,
+        "ci_high": 0.07139047619047617,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.297,
+        "system_b": 0.26713333333333333,
+        "difference": 0.029866666666666652,
+        "ci_low": -0.0076666666666665995,
+        "ci_high": 0.06800000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.5001933333333334,
+        "system_b": 0.4757171428571429,
+        "difference": 0.024476190476190485,
+        "ci_low": -0.0033203571428571314,
+        "ci_high": 0.05259623809523813,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.096,
+        "difference": 0.020000000000000004,
+        "ci_low": -0.020000000000000004,
+        "ci_high": 0.06,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.676,
+        "system_b": 0.66,
+        "difference": 0.016000000000000014,
+        "ci_low": -0.051999999999999935,
+        "ci_high": 0.08399999999999996,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3752416666666667,
+        "system_b": 0.3446464285714287,
+        "difference": 0.03059523809523801,
+        "ci_low": -0.0041504464285714165,
+        "ci_high": 0.06574529761904765,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.116,
+        "system_b_rate": 0.096,
+        "difference": 0.02,
+        "correct_only_in_a": 15,
+        "correct_only_in_b": 10,
+        "discordant_pairs": 25,
+        "p_value": 0.42435622215270996,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.960464477539063e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.676,
+        "system_b_rate": 0.66,
+        "difference": 0.016,
+        "correct_only_in_a": 38,
+        "correct_only_in_b": 34,
+        "discordant_pairs": 72,
+        "p_value": 0.723948145746914,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.235164736271502e-22,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.02,
+        "sd_difference": 0.3162277660168379,
+        "significant": false,
+        "mde_80_power": 0.05603199999999999,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 1.7258561610271825,
+        "p_value": 0.08561381867563207,
+        "dof": 249,
+        "mean_difference": 0.03312380952380953,
+        "sd_difference": 0.30346295723298605,
+        "significant": false,
+        "mde_80_power": 0.053770219591575324,
+        "n_needed_for_observed_diff": 659
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.5575462703888587,
+        "p_value": 0.12061090961993248,
+        "dof": 249,
+        "mean_difference": 0.02986666666666667,
+        "sd_difference": 0.3031906485838008,
+        "significant": false,
+        "mde_80_power": 0.05372196956463007,
+        "n_needed_for_observed_diff": 809
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.8977518450994086,
+        "p_value": 0.05888544361029281,
+        "dof": 249,
+        "mean_difference": 0.02481748929454822,
+        "sd_difference": 0.20677042728288533,
+        "significant": false,
+        "mde_80_power": 0.03663739186298313,
+        "n_needed_for_observed_diff": 545
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.4706700002234264,
+        "p_value": 0.6382884447377815,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.5374938124235239,
+        "significant": false,
+        "mde_80_power": 0.09523785237793218,
+        "n_needed_for_observed_diff": 8858
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.013249523809523779,
+       "ordered_step_accuracy": 0.008959999999999996,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.002266666666666661,
+       "_sum": 0.024476190476190436,
+       "_total_delta_composite": 0.024476190476190485,
+       "_residual": -4.85722573273506e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5284846334084438,
+        "system_b": 0.5271035505673597,
+        "difference": 0.0013810828410840692,
+        "ci_low": -0.01767944001269567,
+        "ci_high": 0.02014705004755315,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.15921538461538462,
+        "system_b": 0.15237806637806636,
+        "difference": 0.006837318237318257,
+        "ci_low": -0.019228709068709042,
+        "ci_high": 0.03408132256632257,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13473333333333332,
+        "system_b": 0.13369999999999999,
+        "difference": 0.0010333333333333306,
+        "ci_low": -0.023499999999999965,
+        "ci_high": 0.026268333333333317,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.37557282051282054,
+        "system_b": 0.37386122655122656,
+        "difference": 0.0017115939615939824,
+        "ci_low": -0.018164484126984147,
+        "ci_high": 0.02187421428571426,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.008,
+        "difference": 0.012,
+        "ci_low": -0.004,
+        "ci_high": 0.032,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.496,
+        "system_b": 0.488,
+        "difference": 0.008000000000000007,
+        "ci_low": -0.07200000000000001,
+        "ci_high": 0.08800000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.21946602564102566,
+        "system_b": 0.21732653318903322,
+        "difference": 0.0021394924519924363,
+        "ci_low": -0.02270560515873017,
+        "ci_high": 0.027342767857142854,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.02,
+        "system_b_rate": 0.008,
+        "difference": 0.012,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 5,
+        "p_value": 0.375,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.496,
+        "system_b_rate": 0.488,
+        "difference": 0.008,
+        "correct_only_in_a": 53,
+        "correct_only_in_b": 51,
+        "discordant_pairs": 104,
+        "p_value": 0.9219488276264309,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 9.860761315262648e-32,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.3438012400514816,
+        "p_value": 0.18023588114803066,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.14119399056577284,
+        "significant": false,
+        "mde_80_power": 0.02501798554577315,
+        "n_needed_for_observed_diff": 1087
+       },
+       "step_f1": {
+        "t_statistic": 0.5144302838195742,
+        "p_value": 0.60740747326775,
+        "dof": 249,
+        "mean_difference": 0.00683731823731824,
+        "sd_difference": 0.2101499405983319,
+        "significant": false,
+        "mde_80_power": 0.037236203575427826,
+        "n_needed_for_observed_diff": 7415
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.08237936379105107,
+        "p_value": 0.9344112279995935,
+        "dof": 249,
+        "mean_difference": 0.0010333333333333349,
+        "sd_difference": 0.19833164309180434,
+        "significant": false,
+        "mde_80_power": 0.035142134309383385,
+        "n_needed_for_observed_diff": 289145
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.14172310015431752,
+        "p_value": 0.8874133250807589,
+        "dof": 249,
+        "mean_difference": 0.001381082841084118,
+        "sd_difference": 0.15408100057247912,
+        "significant": false,
+        "mde_80_power": 0.027301418635128485,
+        "n_needed_for_observed_diff": 97695
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.19573856724122363,
+        "p_value": 0.8449744356262114,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.6462247485997509,
+        "significant": false,
+        "mde_80_power": 0.11450375015966573,
+        "n_needed_for_observed_diff": 51216
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.002734927294927303,
+       "ordered_step_accuracy": 0.00030999999999999913,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.001333333333333331,
+       "_sum": 0.001711593961593971,
+       "_total_delta_composite": 0.0017115939615939824,
+       "_residual": -1.1275702593849246e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.47749956209255096,
+        "system_b": 0.467737980756238,
+        "difference": 0.009761581336312941,
+        "ci_low": -0.005617584460861397,
+        "ci_high": 0.02479465819726246,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.09856969696969696,
+        "system_b": 0.09281904761904762,
+        "difference": 0.0057506493506493395,
+        "ci_low": -0.013355,
+        "ci_high": 0.025448073593073592,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08648571428571428,
+        "system_b": 0.08046862745098039,
+        "difference": 0.006017086834733884,
+        "ci_low": -0.011761078431372553,
+        "ci_high": 0.023653389355742283,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.12444025974025974,
+        "system_b": 0.1521063025210084,
+        "difference": -0.027666042780748662,
+        "ci_low": -0.1950217062006621,
+        "ci_high": 0.1936743937271878,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.0,
+        "difference": 0.008,
+        "ci_low": 0.0,
+        "ci_high": 0.02,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.332,
+        "system_b": 0.288,
+        "difference": 0.04400000000000004,
+        "ci_low": -0.028000000000000025,
+        "ci_high": 0.11999999999999997,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1555503246753247,
+        "system_b": 0.1544185924369748,
+        "difference": 0.0011317322383498918,
+        "ci_low": -0.019506973755411265,
+        "ci_high": 0.021354767316017337,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.0,
+        "difference": 0.008,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.332,
+        "system_b_rate": 0.288,
+        "difference": 0.044,
+        "correct_only_in_a": 51,
+        "correct_only_in_b": 40,
+        "discordant_pairs": 91,
+        "p_value": 0.29446978456853307,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.077935669463161e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.4170619309433983,
+        "p_value": 0.15771479274702116,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.08926293455821276,
+        "significant": false,
+        "mde_80_power": 0.015816387068615163,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": 0.5846546697326812,
+        "p_value": 0.5593093051527667,
+        "dof": 249,
+        "mean_difference": 0.0057506493506493525,
+        "sd_difference": 0.15552043722950976,
+        "significant": false,
+        "mde_80_power": 0.027556470605367072,
+        "n_needed_for_observed_diff": 5741
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.6713892204769103,
+        "p_value": 0.5025949794651867,
+        "dof": 249,
+        "mean_difference": 0.006017086834733896,
+        "sd_difference": 0.14170393786823274,
+        "significant": false,
+        "mde_80_power": 0.02510834246670814,
+        "n_needed_for_observed_diff": 4354
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.2526121955635412,
+        "p_value": 0.21152201189586325,
+        "dof": 249,
+        "mean_difference": 0.009761581336312875,
+        "sd_difference": 0.12321782710191136,
+        "significant": false,
+        "mde_80_power": 0.021832811758239718,
+        "n_needed_for_observed_diff": 1251
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.1538774271113161,
+        "p_value": 0.24965673977218616,
+        "dof": 249,
+        "mean_difference": 0.044,
+        "sd_difference": 0.6029245991740233,
+        "significant": false,
+        "mde_80_power": 0.10683145116080685,
+        "n_needed_for_observed_diff": 1474
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0023002597402597357,
+       "ordered_step_accuracy": 0.0018051260504201652,
+       "reference_validity_micro": -0.02857142857142857,
+       "step_count_term": -0.003200000000000003,
+       "_sum": -0.027666042780748672,
+       "_total_delta_composite": -0.027666042780748662,
+       "_residual": -1.0408340855860843e-17,
+       "_share_reference_term": 1.0327255255785954
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5471138456044016,
+       "system_b": 0.5375348919863999,
+       "difference": 0.009578953618001651,
+       "ci_low": -0.0008034362626759186,
+       "ci_high": 0.019886613444723766,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.19266641007945357,
+       "system_b": 0.1817014541014541,
+       "difference": 0.010964955977999458,
+       "ci_low": -0.0034789812482203973,
+       "ci_high": 0.02582522280859238,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1740328042328042,
+       "system_b": 0.16300634920634918,
+       "difference": 0.011026455026455023,
+       "ci_low": -0.0031768518518518305,
+       "ci_high": 0.02589433862433867,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.20225418307940046,
+       "system_b": 0.1950935975135975,
+       "difference": 0.007160585565802957,
+       "ci_low": -0.19765440392538225,
+       "ci_high": 0.20265596085798263,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.04666666666666667,
+       "system_b": 0.032,
+       "difference": 0.014666666666666668,
+       "ci_low": 0.0013333333333333322,
+       "ci_high": 0.02933333333333333,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.52,
+       "system_b": 0.5093333333333333,
+       "difference": 0.010666666666666713,
+       "ci_low": -0.03199999999999997,
+       "ci_high": 0.053333333333333344,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.25281772884925063,
+       "system_b": 0.24386699689199692,
+       "difference": 0.00895073195725371,
+       "ci_low": -0.005299625991962955,
+       "ci_high": 0.02331144600769599,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.04666666666666667,
+       "system_b_rate": 0.032,
+       "difference": 0.014666666666666666,
+       "correct_only_in_a": 20,
+       "correct_only_in_b": 9,
+       "discordant_pairs": 29,
+       "p_value": 0.06142834573984146,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 3.725290298461914e-09,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.52,
+       "system_b_rate": 0.5093333333333333,
+       "difference": 0.010666666666666666,
+       "correct_only_in_a": 133,
+       "correct_only_in_b": 125,
+       "discordant_pairs": 258,
+       "p_value": 0.663064461563114,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 4.3180842775472223e-78,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 2.0469883627995484,
+       "p_value": 0.04100768851084752,
+       "dof": 749,
+       "mean_difference": 0.014666666666666666,
+       "sd_difference": 0.1962215399641013,
+       "significant": true,
+       "mde_80_power": 0.0200734572213868,
+       "n_needed_for_observed_diff": 1405
+      },
+      "step_f1": {
+       "t_statistic": 1.4516353255495966,
+       "p_value": 0.1470217474041488,
+       "dof": 749,
+       "mean_difference": 0.010964955977999456,
+       "sd_difference": 0.2068616554549474,
+       "significant": false,
+       "mde_80_power": 0.02116194069356416,
+       "n_needed_for_observed_diff": 2794
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 1.4788864152542196,
+       "p_value": 0.1395910952281897,
+       "dof": 749,
+       "mean_difference": 0.011026455026455025,
+       "sd_difference": 0.2041887086462778,
+       "significant": false,
+       "mde_80_power": 0.02088849832108718,
+       "n_needed_for_observed_diff": 2692
+      },
+      "rouge_l_f1": {
+       "t_statistic": 1.8100420632198475,
+       "p_value": 0.07068993040609621,
+       "dof": 749,
+       "mean_difference": 0.009578953618001559,
+       "sd_difference": 0.14493058146234708,
+       "significant": false,
+       "mde_80_power": 0.014826393817862132,
+       "n_needed_for_observed_diff": 1797
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 0.497808427224448,
+       "p_value": 0.618765195187742,
+       "dof": 749,
+       "mean_difference": 0.010666666666666666,
+       "sd_difference": 0.5868094659722993,
+       "significant": false,
+       "mde_80_power": 0.06003058947786672,
+       "n_needed_for_observed_diff": 23755
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.004385982391199784,
+      "ordered_step_accuracy": 0.0033079365079365067,
+      "reference_validity_micro": 0.0,
+      "step_count_term": -0.000533333333333319,
+      "_sum": 0.007160585565802971,
+      "_total_delta_composite": 0.007160585565802957,
+      "_residual": 1.3877787807814457e-17,
+      "_share_reference_term": 0.0
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.7297777777777779,
+      "step_count_term_b": 0.735111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6318814281966165,
+        "system_b": 0.6194803222315687,
+        "difference": 0.012401105965047843,
+        "ci_low": -0.009059528981153921,
+        "ci_high": 0.03307899853836035,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.31527619047619043,
+        "system_b": 0.2948,
+        "difference": 0.020476190476190426,
+        "ci_low": -0.012934285714285785,
+        "ci_high": 0.05420952380952382,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.3,
+        "system_b": 0.2843333333333333,
+        "difference": 0.015666666666666662,
+        "ci_low": -0.017333333333333367,
+        "ci_high": 0.04933333333333334,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.5037104761904763,
+        "system_b": 0.49108666666666667,
+        "difference": 0.012623809523809593,
+        "ci_low": -0.011647166666666691,
+        "ci_high": 0.036925309523809555,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.112,
+        "system_b": 0.096,
+        "difference": 0.016,
+        "ci_low": -0.020000000000000004,
+        "ci_high": 0.052000000000000005,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.748,
+        "system_b": 0.724,
+        "difference": 0.02400000000000002,
+        "ci_low": -0.03600000000000003,
+        "ci_high": 0.08400000000000007,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3796380952380953,
+        "system_b": 0.3638583333333334,
+        "difference": 0.01577976190476188,
+        "ci_low": -0.014558958333333392,
+        "ci_high": 0.04615663690476189,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.112,
+        "system_b_rate": 0.096,
+        "difference": 0.016,
+        "correct_only_in_a": 13,
+        "correct_only_in_b": 9,
+        "discordant_pairs": 22,
+        "p_value": 0.5234670639038086,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.76837158203125e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.748,
+        "system_b_rate": 0.724,
+        "difference": 0.024,
+        "correct_only_in_a": 33,
+        "correct_only_in_b": 27,
+        "discordant_pairs": 60,
+        "p_value": 0.5189580031896518,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.734723475976807e-18,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.8523362153927414,
+        "p_value": 0.39484656604994506,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.2968103528217449,
+        "significant": false,
+        "mde_80_power": 0.05259145298589144,
+        "n_needed_for_observed_diff": 2702
+       },
+       "step_f1": {
+        "t_statistic": 1.214453898921006,
+        "p_value": 0.22572492496240723,
+        "dof": 249,
+        "mean_difference": 0.02047619047619048,
+        "sd_difference": 0.26658648700349485,
+        "significant": false,
+        "mde_80_power": 0.04723612422757484,
+        "n_needed_for_observed_diff": 1331
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.9263063215157855,
+        "p_value": 0.3551837369498133,
+        "dof": 249,
+        "mean_difference": 0.01566666666666667,
+        "sd_difference": 0.2674188271123677,
+        "significant": false,
+        "mde_80_power": 0.047383605524261095,
+        "n_needed_for_observed_diff": 2287
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.158047929724301,
+        "p_value": 0.24795401993983765,
+        "dof": 249,
+        "mean_difference": 0.012401105965047777,
+        "sd_difference": 0.16931829567705195,
+        "significant": false,
+        "mde_80_power": 0.030001295783974313,
+        "n_needed_for_observed_diff": 1464
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.7739752518376133,
+        "p_value": 0.43967965129296077,
+        "dof": 249,
+        "mean_difference": 0.024,
+        "sd_difference": 0.49029128298254976,
+        "significant": false,
+        "mde_80_power": 0.0868740955739334,
+        "n_needed_for_observed_diff": 3276
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.00819047619047617,
+       "ordered_step_accuracy": 0.0046999999999999984,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.00026666666666667064,
+       "_sum": 0.012623809523809497,
+       "_total_delta_composite": 0.012623809523809593,
+       "_residual": -9.540979117872439e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.534047389962992,
+        "system_b": 0.5202871082354069,
+        "difference": 0.013760281727585033,
+        "ci_low": -0.0034128877518562165,
+        "ci_high": 0.031186849200490946,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.15070020703933748,
+        "system_b": 0.14674285714285712,
+        "difference": 0.003957349896480361,
+        "ci_low": -0.01730038302277433,
+        "ci_high": 0.025324292615596922,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13027619047619046,
+        "system_b": 0.11846666666666665,
+        "difference": 0.011809523809523811,
+        "ci_low": -0.008134999999999991,
+        "ci_high": 0.032420476190476145,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.36549627329192547,
+        "system_b": 0.36383714285714286,
+        "difference": 0.0016591304347826075,
+        "ci_low": -0.017294583160800528,
+        "ci_high": 0.020794455831608,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.0,
+        "difference": 0.016,
+        "ci_low": 0.004,
+        "ci_high": 0.032,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.464,
+        "system_b": 0.48,
+        "difference": -0.01599999999999996,
+        "ci_low": -0.09599999999999997,
+        "ci_high": 0.06,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20687034161490686,
+        "system_b": 0.20479642857142857,
+        "difference": 0.002073913043478287,
+        "ci_low": -0.02161822895100066,
+        "ci_high": 0.025993069789510003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.0,
+        "difference": 0.016,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 4,
+        "p_value": 0.125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.464,
+        "system_b_rate": 0.48,
+        "difference": -0.016,
+        "correct_only_in_a": 47,
+        "correct_only_in_b": 51,
+        "discordant_pairs": 98,
+        "p_value": 0.7620362195292433,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.310887241768095e-30,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.012158166696862,
+        "p_value": 0.04528026312539455,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.12572680269402645,
+        "significant": true,
+        "mde_80_power": 0.02227737398675038,
+        "n_needed_for_observed_diff": 485
+       },
+       "step_f1": {
+        "t_statistic": 0.36722004240335593,
+        "p_value": 0.7137667932675417,
+        "dof": 249,
+        "mean_difference": 0.003957349896480328,
+        "sd_difference": 0.1703915599106067,
+        "significant": false,
+        "mde_80_power": 0.03019146612319537,
+        "n_needed_for_observed_diff": 14552
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.1335755380932282,
+        "p_value": 0.2580628685214177,
+        "dof": 249,
+        "mean_difference": 0.01180952380952381,
+        "sd_difference": 0.16472212069299422,
+        "significant": false,
+        "mde_80_power": 0.029186905321205745,
+        "n_needed_for_observed_diff": 1528
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.5729170669576191,
+        "p_value": 0.11700777296624203,
+        "dof": 249,
+        "mean_difference": 0.01376028172758504,
+        "sd_difference": 0.13832207819109946,
+        "significant": false,
+        "mde_80_power": 0.024509115005388243,
+        "n_needed_for_observed_diff": 794
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.40338382472203554,
+        "p_value": 0.6870120545311943,
+        "dof": 249,
+        "mean_difference": -0.016,
+        "sd_difference": 0.6271501168590382,
+        "significant": false,
+        "mde_80_power": 0.1111239401601899,
+        "n_needed_for_observed_diff": 12060
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0015829399585921445,
+       "ordered_step_accuracy": 0.003542857142857143,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0034666666666666626,
+       "_sum": 0.001659130434782625,
+       "_total_delta_composite": 0.0016591304347826075,
+       "_residual": 1.7564075194265172e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4754127186535961,
+        "system_b": 0.47283724549222417,
+        "difference": 0.0025754731613719106,
+        "ci_low": -0.013031433697286859,
+        "ci_high": 0.01835787490792231,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.11202283272283273,
+        "system_b": 0.10356150516150515,
+        "difference": 0.008461327561327572,
+        "ci_low": -0.011609985014984997,
+        "ci_high": 0.02945845154845155,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09182222222222222,
+        "system_b": 0.08621904761904761,
+        "difference": 0.00560317460317461,
+        "ci_low": -0.01388626984126986,
+        "ci_high": 0.02599999999999998,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.13755579975579973,
+        "system_b": 0.130356983016983,
+        "difference": 0.007198816738816727,
+        "ci_low": -0.1990052025752026,
+        "ci_high": 0.19958848884448882,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.0,
+        "difference": 0.012,
+        "ci_low": 0.0,
+        "ci_high": 0.028,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.348,
+        "system_b": 0.324,
+        "difference": 0.023999999999999966,
+        "ci_low": -0.05199999999999999,
+        "ci_high": 0.10399999999999998,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1719447496947497,
+        "system_b": 0.16294622877122877,
+        "difference": 0.008998520923520936,
+        "ci_low": -0.012386922591297594,
+        "ci_high": 0.030337465312465322,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.0,
+        "difference": 0.012,
+        "correct_only_in_a": 3,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 3,
+        "p_value": 0.25,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.25,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.348,
+        "system_b_rate": 0.324,
+        "difference": 0.024,
+        "correct_only_in_a": 53,
+        "correct_only_in_b": 47,
+        "discordant_pairs": 100,
+        "p_value": 0.617299413589252,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.5777218104420236e-30,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.7390490211537188,
+        "p_value": 0.0832620199015193,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.10910368672886965,
+        "significant": false,
+        "mde_80_power": 0.019331944983181883,
+        "n_needed_for_observed_diff": 649
+       },
+       "step_f1": {
+        "t_statistic": 0.7928811085406202,
+        "p_value": 0.4286019132052583,
+        "dof": 249,
+        "mean_difference": 0.008461327561327562,
+        "sd_difference": 0.16873316083796153,
+        "significant": false,
+        "mde_80_power": 0.029897616478020615,
+        "n_needed_for_observed_diff": 3122
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.5420239071011844,
+        "p_value": 0.5882867506934517,
+        "dof": 249,
+        "mean_difference": 0.005603174603174604,
+        "sd_difference": 0.163450298423222,
+        "significant": false,
+        "mde_80_power": 0.028961552733362206,
+        "n_needed_for_observed_diff": 6680
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.329142557791332,
+        "p_value": 0.74232461497627,
+        "dof": 249,
+        "mean_difference": 0.002575473161371856,
+        "sd_difference": 0.123720877926287,
+        "significant": false,
+        "mde_80_power": 0.021921946700899735,
+        "n_needed_for_observed_diff": 18113
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.5992303989136518,
+        "p_value": 0.5495640674652218,
+        "dof": 249,
+        "mean_difference": 0.024,
+        "sd_difference": 0.6332678046843998,
+        "significant": false,
+        "mde_80_power": 0.11220792556902465,
+        "n_needed_for_observed_diff": 5465
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.003384531024531029,
+       "ordered_step_accuracy": 0.001680952380952383,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0021333333333333204,
+       "_sum": 0.007198816738816733,
+       "_total_delta_composite": 0.007198816738816727,
+       "_residual": 6.071532165918825e-18,
+       "_share_reference_term": 0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "size_2000_vs_4000",
+    "kind": "pool_size",
+    "contrast": "4000 vs 2000",
+    "cell_a": "size4000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5459401505709149,
+       "system_b": 0.5471138456044016,
+       "difference": -0.0011736950334866325,
+       "ci_low": -0.01111415329115186,
+       "ci_high": 0.00876421293385373,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.19801275761275763,
+       "system_b": 0.19266641007945357,
+       "difference": 0.005346347533304069,
+       "ci_low": -0.007894309772353239,
+       "ci_high": 0.01839536765971546,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.18347809042809043,
+       "system_b": 0.1740328042328042,
+       "difference": 0.009445286195286229,
+       "ci_low": -0.003664079485329458,
+       "ci_high": 0.022431841630591632,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.3052707523957524,
+       "system_b": 0.20225418307940046,
+       "difference": 0.10301656931635195,
+       "ci_low": -0.004627723071815462,
+       "ci_high": 0.20579553441626808,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.05333333333333334,
+       "system_b": 0.04666666666666667,
+       "difference": 0.006666666666666668,
+       "ci_low": -0.006666666666666661,
+       "ci_high": 0.02,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.488,
+       "system_b": 0.52,
+       "difference": -0.03200000000000003,
+       "ci_low": -0.07200000000000001,
+       "ci_high": 0.008000000000000007,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.25658844049469054,
+       "system_b": 0.25281772884925063,
+       "difference": 0.003770711645439906,
+       "ci_low": -0.009467256476162781,
+       "ci_high": 0.01685680085262963,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.05333333333333334,
+       "system_b_rate": 0.04666666666666667,
+       "difference": 0.006666666666666667,
+       "correct_only_in_a": 15,
+       "correct_only_in_b": 10,
+       "discordant_pairs": 25,
+       "p_value": 0.42435622215270996,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.960464477539063e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.488,
+       "system_b_rate": 0.52,
+       "difference": -0.032,
+       "correct_only_in_a": 106,
+       "correct_only_in_b": 130,
+       "discordant_pairs": 236,
+       "p_value": 0.1341778192187235,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.8111358157653425e-71,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.0,
+       "p_value": 0.31763345838622353,
+       "dof": 749,
+       "mean_difference": 0.006666666666666667,
+       "sd_difference": 0.18257418583505536,
+       "significant": false,
+       "mde_80_power": 0.018677333333333334,
+       "n_needed_for_observed_diff": 5887
+      },
+      "step_f1": {
+       "t_statistic": 0.7911911961984184,
+       "p_value": 0.4290828915250632,
+       "dof": 749,
+       "mean_difference": 0.005346347533304055,
+       "sd_difference": 0.18505736403052425,
+       "significant": false,
+       "mde_80_power": 0.01893136238278909,
+       "n_needed_for_observed_diff": 9404
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 1.4075915207165148,
+       "p_value": 0.1596669253344939,
+       "dof": 749,
+       "mean_difference": 0.009445286195286196,
+       "sd_difference": 0.1837676710576144,
+       "significant": false,
+       "mde_80_power": 0.018799426833179367,
+       "n_needed_for_observed_diff": 2972
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.22974764540423068,
+       "p_value": 0.8183505958785265,
+       "dof": 749,
+       "mean_difference": -0.001173695033486597,
+       "sd_difference": 0.13990551336038906,
+       "significant": false,
+       "mde_80_power": 0.01431232951280335,
+       "n_needed_for_observed_diff": 111525
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -1.5637715884160688,
+       "p_value": 0.11829360345847634,
+       "dof": 749,
+       "mean_difference": -0.032,
+       "sd_difference": 0.5604118264457788,
+       "significant": false,
+       "mde_80_power": 0.05733011180412029,
+       "n_needed_for_observed_diff": 2408
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0021385390133216277,
+      "ordered_step_accuracy": 0.0028335858585858686,
+      "reference_validity_micro": 0.1,
+      "step_count_term": -0.001955555555555555,
+      "_sum": 0.10301656931635195,
+      "_total_delta_composite": 0.10301656931635195,
+      "_residual": 0.0,
+      "_share_reference_term": 0.9707176298301257
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.5,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.7102222222222223,
+      "step_count_term_b": 0.7297777777777779
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6203444212654308,
+        "system_b": 0.6318814281966165,
+        "difference": -0.011537006931185756,
+        "ci_low": -0.03280111401264912,
+        "ci_high": 0.009371907433397282,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.3197206349206349,
+        "system_b": 0.31527619047619043,
+        "difference": 0.004444444444444473,
+        "ci_low": -0.02420317460317456,
+        "ci_high": 0.03187984126984136,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.31188333333333335,
+        "system_b": 0.3,
+        "difference": 0.011883333333333357,
+        "ci_low": -0.01775083333333332,
+        "ci_high": 0.04063416666666667,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.5051865873015873,
+        "system_b": 0.5037104761904763,
+        "difference": 0.0014761111111110115,
+        "ci_low": -0.019893692460317393,
+        "ci_high": 0.022410486111111037,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.128,
+        "system_b": 0.112,
+        "difference": 0.016,
+        "ci_low": -0.01999999999999999,
+        "ci_high": 0.05199999999999999,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.716,
+        "system_b": 0.748,
+        "difference": -0.03200000000000003,
+        "ci_low": -0.09199999999999997,
+        "ci_high": 0.028000000000000025,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.38148323412698415,
+        "system_b": 0.3796380952380953,
+        "difference": 0.0018451388888888753,
+        "ci_low": -0.024867115575396857,
+        "ci_high": 0.02801310763888882,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.128,
+        "system_b_rate": 0.112,
+        "difference": 0.016,
+        "correct_only_in_a": 12,
+        "correct_only_in_b": 8,
+        "discordant_pairs": 20,
+        "p_value": 0.5034446716308594,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.9073486328125e-06,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.716,
+        "system_b_rate": 0.748,
+        "difference": -0.032,
+        "correct_only_in_a": 25,
+        "correct_only_in_b": 33,
+        "discordant_pairs": 58,
+        "p_value": 0.3581433018061379,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.938893903907228e-18,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.8940681995381342,
+        "p_value": 0.37214875601929986,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.2829562811250397,
+        "significant": false,
+        "mde_80_power": 0.05013666745238945,
+        "n_needed_for_observed_diff": 2455
+       },
+       "step_f1": {
+        "t_statistic": 0.3067731283667985,
+        "p_value": 0.7592724452288148,
+        "dof": 249,
+        "mean_difference": 0.0044444444444444444,
+        "sd_difference": 0.22907103130821727,
+        "significant": false,
+        "mde_80_power": 0.04058880783282832,
+        "n_needed_for_observed_diff": 20851
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.7928536412045989,
+        "p_value": 0.4286178880963982,
+        "dof": 249,
+        "mean_difference": 0.01188333333333333,
+        "sd_difference": 0.23698194455688312,
+        "significant": false,
+        "mde_80_power": 0.041990532598279943,
+        "n_needed_for_observed_diff": 3122
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.0850175206496633,
+        "p_value": 0.27896327217702654,
+        "dof": 249,
+        "mean_difference": -0.011537006931185638,
+        "sd_difference": 0.16812271963060774,
+        "significant": false,
+        "mde_80_power": 0.02978945316851342,
+        "n_needed_for_observed_diff": 1667
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.0506697385087862,
+        "p_value": 0.2944289213421503,
+        "dof": 249,
+        "mean_difference": -0.032,
+        "sd_difference": 0.48156371796246383,
+        "significant": false,
+        "mde_80_power": 0.08532766930857055,
+        "n_needed_for_observed_diff": 1778
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0017777777777777894,
+       "ordered_step_accuracy": 0.003565000000000007,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.003866666666666663,
+       "_sum": 0.0014761111111111335,
+       "_total_delta_composite": 0.0014761111111110115,
+       "_residual": 1.220811646218678e-16,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5350538395536691,
+        "system_b": 0.534047389962992,
+        "difference": 0.0010064495906771942,
+        "ci_low": -0.014806414850802304,
+        "ci_high": 0.01673513398157549,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1590989898989899,
+        "system_b": 0.15070020703933748,
+        "difference": 0.008398782859652426,
+        "ci_low": -0.014185926971579166,
+        "ci_high": 0.03146752964426872,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13773333333333335,
+        "system_b": 0.13027619047619046,
+        "difference": 0.007457142857142884,
+        "ci_low": -0.014409523809523789,
+        "ci_high": 0.02999071428571431,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.378159595959596,
+        "system_b": 0.36549627329192547,
+        "difference": 0.012663322667670507,
+        "ci_low": -0.005572512045925103,
+        "ci_high": 0.031858041470606675,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.016,
+        "difference": 0.0,
+        "ci_low": -0.016,
+        "ci_high": 0.016,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.444,
+        "system_b": 0.464,
+        "difference": -0.020000000000000018,
+        "ci_low": -0.09200000000000003,
+        "ci_high": 0.055999999999999994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.22269949494949498,
+        "system_b": 0.20687034161490686,
+        "difference": 0.01582915333458812,
+        "ci_low": -0.006965640057406351,
+        "ci_high": 0.03982255183825832,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.016,
+        "difference": 0.0,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 4,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.444,
+        "system_b_rate": 0.464,
+        "difference": -0.02,
+        "correct_only_in_a": 42,
+        "correct_only_in_b": 47,
+        "discordant_pairs": 89,
+        "p_value": 0.6718086491746106,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.2311742677852644e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.12674485010489558,
+        "significant": false,
+        "mde_80_power": 0.02245776052663057,
+        "n_needed_for_observed_diff": null
+       },
+       "step_f1": {
+        "t_statistic": 0.7164516841068757,
+        "p_value": 0.474383910681181,
+        "dof": 249,
+        "mean_difference": 0.008398782859652423,
+        "sd_difference": 0.1853529274817226,
+        "significant": false,
+        "mde_80_power": 0.03284245201954493,
+        "n_needed_for_observed_diff": 3823
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.6535816662506708,
+        "p_value": 0.5139844488325777,
+        "dof": 249,
+        "mean_difference": 0.007457142857142857,
+        "sd_difference": 0.1804025226189769,
+        "significant": false,
+        "mde_80_power": 0.03196529601024435,
+        "n_needed_for_observed_diff": 4594
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.12472536590077657,
+        "p_value": 0.9008416080316649,
+        "dof": 249,
+        "mean_difference": 0.0010064495906771036,
+        "sd_difference": 0.127587240722779,
+        "significant": false,
+        "mde_80_power": 0.022607022660363407,
+        "n_needed_for_observed_diff": 126138
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.529235286759496,
+        "p_value": 0.5971137294239369,
+        "dof": 249,
+        "mean_difference": -0.02,
+        "sd_difference": 0.5975182946569914,
+        "significant": false,
+        "mde_80_power": 0.10587351486535135,
+        "n_needed_for_observed_diff": 7006
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0033595131438609706,
+       "ordered_step_accuracy": 0.002237142857142865,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0070666666666666655,
+       "_sum": 0.012663322667670502,
+       "_total_delta_composite": 0.012663322667670507,
+       "_residual": -5.204170427930421e-18,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.48242219089364474,
+        "system_b": 0.4754127186535961,
+        "difference": 0.007009472240048664,
+        "ci_low": -0.00793330812536397,
+        "ci_high": 0.021734024225960887,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.11521864801864802,
+        "system_b": 0.11202283272283273,
+        "difference": 0.0031958152958152936,
+        "ci_low": -0.01235952380952384,
+        "ci_high": 0.019341447441447435,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.10081760461760461,
+        "system_b": 0.09182222222222222,
+        "difference": 0.00899538239538239,
+        "ci_low": -0.004828001443001438,
+        "ci_high": 0.0234511038961039,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.23246607392607394,
+        "system_b": 0.13755579975579973,
+        "difference": 0.0949102741702742,
+        "ci_low": -0.014950066766566765,
+        "ci_high": 0.198374111999112,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.012,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.304,
+        "system_b": 0.348,
+        "difference": -0.043999999999999984,
+        "ci_low": -0.11609999999999995,
+        "ci_high": 0.028000000000000025,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16558259240759243,
+        "system_b": 0.1719447496947497,
+        "difference": -0.006362157287157277,
+        "ci_low": -0.02296784295565547,
+        "ci_high": 0.010296788870851335,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.012,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.304,
+        "system_b_rate": 0.348,
+        "difference": -0.044,
+        "correct_only_in_a": 39,
+        "correct_only_in_b": 50,
+        "discordant_pairs": 89,
+        "p_value": 0.2890960806960603,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.2311742677852644e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.06324555320336758,
+        "significant": false,
+        "mde_80_power": 0.0112064,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 0.39737521270698056,
+        "p_value": 0.6914312129001221,
+        "dof": 249,
+        "mean_difference": 0.0031958152958152927,
+        "sd_difference": 0.12716011206558545,
+        "significant": false,
+        "mde_80_power": 0.02253134027098526,
+        "n_needed_for_observed_diff": 12427
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.2538525188154368,
+        "p_value": 0.2110715116073911,
+        "dof": 249,
+        "mean_difference": 0.008995382395382395,
+        "sd_difference": 0.11343398193458835,
+        "significant": false,
+        "mde_80_power": 0.020099224542541993,
+        "n_needed_for_observed_diff": 1249
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.9315610384772742,
+        "p_value": 0.3524657599335815,
+        "dof": 249,
+        "mean_difference": 0.007009472240048738,
+        "sd_difference": 0.11897179335939603,
+        "significant": false,
+        "mde_80_power": 0.02108046238153144,
+        "n_needed_for_observed_diff": 2262
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.166840418385263,
+        "p_value": 0.24439108023333042,
+        "dof": 249,
+        "mean_difference": -0.044,
+        "sd_difference": 0.5962264198902129,
+        "significant": false,
+        "mde_80_power": 0.10564460920079223,
+        "n_needed_for_observed_diff": 1442
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0012783261183261176,
+       "ordered_step_accuracy": 0.002698614718614717,
+       "reference_validity_micro": 0.1,
+       "step_count_term": -0.009066666666666667,
+       "_sum": 0.09491027417027417,
+       "_total_delta_composite": 0.0949102741702742,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 1.0536267108510777
+      }
+     }
+    }
+   },
+   {
+    "family": "size_4000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 4000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "cell_b": "size4000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5439559318584793,
+       "system_b": 0.5459401505709149,
+       "difference": -0.0019842187124355926,
+       "ci_low": -0.011501521275279614,
+       "ci_high": 0.007961431922472355,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.21126165686165685,
+       "system_b": 0.19801275761275763,
+       "difference": 0.013248899248899215,
+       "ci_low": -0.0015203672253672146,
+       "ci_high": 0.02793844562844561,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.19383973063973062,
+       "system_b": 0.18347809042809043,
+       "difference": 0.010361640211640183,
+       "ci_low": -0.00494310606060603,
+       "ci_high": 0.025153406685906685,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.3341232486032486,
+       "system_b": 0.3052707523957524,
+       "difference": 0.028852496207496192,
+       "ci_low": -0.1864014011497762,
+       "ci_high": 0.2034982851685352,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.050666666666666665,
+       "system_b": 0.05333333333333334,
+       "difference": -0.0026666666666666713,
+       "ci_low": -0.015999999999999993,
+       "ci_high": 0.010666666666666665,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5133333333333333,
+       "system_b": 0.488,
+       "difference": 0.02533333333333332,
+       "ci_low": -0.016000000000000014,
+       "ci_high": 0.06799999999999995,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2676540607540608,
+       "system_b": 0.25658844049469054,
+       "difference": 0.011065620259370246,
+       "ci_low": -0.003320897655585173,
+       "ci_high": 0.02570436102670481,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.050666666666666665,
+       "system_b_rate": 0.05333333333333334,
+       "difference": -0.0026666666666666666,
+       "correct_only_in_a": 11,
+       "correct_only_in_b": 13,
+       "discordant_pairs": 24,
+       "p_value": 0.8388197422027588,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.1920928955078125e-07,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.5133333333333333,
+       "system_b_rate": 0.488,
+       "difference": 0.025333333333333333,
+       "correct_only_in_a": 140,
+       "correct_only_in_b": 121,
+       "discordant_pairs": 261,
+       "p_value": 0.26516924582804735,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.397605346934028e-79,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -0.40802137238148584,
+       "p_value": 0.6833745911910442,
+       "dof": 749,
+       "mean_difference": -0.0026666666666666666,
+       "sd_difference": 0.17898492401947494,
+       "significant": false,
+       "mde_80_power": 0.018310151965148208,
+       "n_needed_for_observed_diff": 35360
+      },
+      "step_f1": {
+       "t_statistic": 1.765298607253496,
+       "p_value": 0.07792102449439131,
+       "dof": 749,
+       "mean_difference": 0.013248899248899252,
+       "sd_difference": 0.2055380588563879,
+       "significant": false,
+       "mde_80_power": 0.021026536804141942,
+       "n_needed_for_observed_diff": 1890
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 1.3749958562117468,
+       "p_value": 0.16954388318640137,
+       "dof": 749,
+       "mean_difference": 0.010361640211640212,
+       "sd_difference": 0.20637531564291353,
+       "significant": false,
+       "mde_80_power": 0.021112188146449787,
+       "n_needed_for_observed_diff": 3114
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.39907234084072185,
+       "p_value": 0.6899536553572065,
+       "dof": 749,
+       "mean_difference": -0.001984218712435494,
+       "sd_difference": 0.13616595747217441,
+       "significant": false,
+       "mde_80_power": 0.013929773065826148,
+       "n_needed_for_observed_diff": 36964
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 1.176371392786994,
+       "p_value": 0.2398202355575459,
+       "dof": 749,
+       "mean_difference": 0.025333333333333333,
+       "sd_difference": 0.5897643468951933,
+       "significant": false,
+       "mde_80_power": 0.06033287370115258,
+       "n_needed_for_observed_diff": 4254
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.005299559699559687,
+      "ordered_step_accuracy": 0.003108492063492055,
+      "reference_validity_micro": 0.019999999999999997,
+      "step_count_term": 0.0004444444444444362,
+      "_sum": 0.028852496207496175,
+      "_total_delta_composite": 0.028852496207496192,
+      "_residual": -1.734723475976807e-17,
+      "_share_reference_term": 0.6931809246648053
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.6,
+      "ref_micro_b": 0.5,
+      "step_count_term_a": 0.7146666666666667,
+      "step_count_term_b": 0.7102222222222223
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6276116143355489,
+        "system_b": 0.6203444212654308,
+        "difference": 0.007267193070118139,
+        "ci_low": -0.010966898799464336,
+        "ci_high": 0.025334074801488624,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.32807619047619047,
+        "system_b": 0.3197206349206349,
+        "difference": 0.00835555555555556,
+        "ci_low": -0.023181111111111145,
+        "ci_high": 0.040476507936507956,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.3184666666666667,
+        "system_b": 0.31188333333333335,
+        "difference": 0.00658333333333333,
+        "ci_low": -0.025133750000000062,
+        "ci_high": 0.038817083333333384,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.5123704761904762,
+        "system_b": 0.5051865873015873,
+        "difference": 0.0071838888888888786,
+        "ci_low": -0.016203843253968238,
+        "ci_high": 0.03140072222222226,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.12,
+        "system_b": 0.128,
+        "difference": -0.008000000000000007,
+        "ci_low": -0.044,
+        "ci_high": 0.027999999999999997,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.712,
+        "system_b": 0.716,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.06400000000000006,
+        "ci_high": 0.05999999999999994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3904630952380953,
+        "system_b": 0.38148323412698415,
+        "difference": 0.008979861111111154,
+        "ci_low": -0.020254804067460355,
+        "ci_high": 0.03925090277777784,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.12,
+        "system_b_rate": 0.128,
+        "difference": -0.008,
+        "correct_only_in_a": 9,
+        "correct_only_in_b": 11,
+        "discordant_pairs": 20,
+        "p_value": 0.8238029479980469,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.9073486328125e-06,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.712,
+        "system_b_rate": 0.716,
+        "difference": -0.004,
+        "correct_only_in_a": 32,
+        "correct_only_in_b": 33,
+        "discordant_pairs": 65,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.421010862427522e-20,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.4464969065851096,
+        "p_value": 0.655626407259774,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.28329671391043315,
+        "significant": false,
+        "mde_80_power": 0.05019698830931936,
+        "n_needed_for_observed_diff": 9843
+       },
+       "step_f1": {
+        "t_statistic": 0.515419642027174,
+        "p_value": 0.6067171047098927,
+        "dof": 249,
+        "mean_difference": 0.008355555555555555,
+        "sd_difference": 0.25632110727976554,
+        "significant": false,
+        "mde_80_power": 0.045417214509667986,
+        "n_needed_for_observed_diff": 7387
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.39988200400962315,
+        "p_value": 0.6895862448563417,
+        "dof": 249,
+        "mean_difference": 0.006583333333333336,
+        "sd_difference": 0.2603058867452916,
+        "significant": false,
+        "mde_80_power": 0.04612327256973241,
+        "n_needed_for_observed_diff": 12272
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.7761396840713095,
+        "p_value": 0.43840309951209533,
+        "dof": 249,
+        "mean_difference": 0.007267193070117983,
+        "sd_difference": 0.14804604615251923,
+        "significant": false,
+        "mde_80_power": 0.026232092654306212,
+        "n_needed_for_observed_diff": 3258
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.1237902255417955,
+        "p_value": 0.9015812383332797,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.5109091039018576,
+        "significant": false,
+        "mde_80_power": 0.09052734132240808,
+        "n_needed_for_observed_diff": 128050
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0033422222222222243,
+       "ordered_step_accuracy": 0.001974999999999999,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.001866666666666661,
+       "_sum": 0.007183888888888884,
+       "_total_delta_composite": 0.0071838888888888786,
+       "_residual": 5.204170427930421e-18,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5297035936179757,
+        "system_b": 0.5350538395536691,
+        "difference": -0.005350245935693443,
+        "ci_low": -0.022328878186390753,
+        "ci_high": 0.011501255547690815,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1682920634920635,
+        "system_b": 0.1590989898989899,
+        "difference": 0.009193073593073586,
+        "ci_low": -0.013406443001442996,
+        "ci_high": 0.032899509379509397,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.1439111111111111,
+        "system_b": 0.13773333333333335,
+        "difference": 0.006177777777777754,
+        "ci_low": -0.01748888888888886,
+        "ci_high": 0.029999999999999985,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3792901587301587,
+        "system_b": 0.378159595959596,
+        "difference": 0.0011305627705627264,
+        "ci_low": -0.016909093795093803,
+        "ci_high": 0.019300101731601692,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.016,
+        "difference": 0.0,
+        "ci_low": -0.016,
+        "ci_high": 0.016,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.472,
+        "system_b": 0.444,
+        "difference": 0.02799999999999997,
+        "ci_low": -0.04799999999999999,
+        "ci_high": 0.10400000000000004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.22411269841269843,
+        "system_b": 0.22269949494949498,
+        "difference": 0.0014132034632034496,
+        "ci_low": -0.021136367243867228,
+        "ci_high": 0.02412512716450217,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.016,
+        "difference": 0.0,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 4,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.472,
+        "system_b_rate": 0.444,
+        "difference": 0.028,
+        "correct_only_in_a": 51,
+        "correct_only_in_b": 44,
+        "discordant_pairs": 95,
+        "p_value": 0.5383940262921683,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.048709793414476e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.12674485010489558,
+        "significant": false,
+        "mde_80_power": 0.02245776052663057,
+        "n_needed_for_observed_diff": null
+       },
+       "step_f1": {
+        "t_statistic": 0.7691176669513483,
+        "p_value": 0.4425523874671152,
+        "dof": 249,
+        "mean_difference": 0.009193073593073595,
+        "sd_difference": 0.18898962083976814,
+        "significant": false,
+        "mde_80_power": 0.033486833140167836,
+        "n_needed_for_observed_diff": 3318
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.51029362920715,
+        "p_value": 0.6102978197926077,
+        "dof": 249,
+        "mean_difference": 0.006177777777777778,
+        "sd_difference": 0.191417720484816,
+        "significant": false,
+        "mde_80_power": 0.033917065061371356,
+        "n_needed_for_observed_diff": 7536
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.6271308381216184,
+        "p_value": 0.5311480825976783,
+        "dof": 249,
+        "mean_difference": -0.005350245935693369,
+        "sd_difference": 0.1348918134015341,
+        "significant": false,
+        "mde_80_power": 0.023901310703097183,
+        "n_needed_for_observed_diff": 4990
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.7174875647371933,
+        "p_value": 0.47374585671301556,
+        "dof": 249,
+        "mean_difference": 0.028,
+        "sd_difference": 0.6170404815109728,
+        "significant": false,
+        "mde_80_power": 0.10933262659225786,
+        "n_needed_for_observed_diff": 3812
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0036772294372294347,
+       "ordered_step_accuracy": 0.0018533333333333262,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.004400000000000004,
+       "_sum": 0.0011305627705627572,
+       "_total_delta_composite": 0.0011305627705627264,
+       "_residual": 3.0791341698588326e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4745525876219137,
+        "system_b": 0.48242219089364474,
+        "difference": -0.00786960327173103,
+        "ci_low": -0.02316301599458882,
+        "ci_high": 0.007489107554452097,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13741671661671662,
+        "system_b": 0.11521864801864802,
+        "difference": 0.022198068598068596,
+        "ci_low": 0.0028111732711732754,
+        "ci_high": 0.04230796758796757,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11914141414141415,
+        "system_b": 0.10081760461760461,
+        "difference": 0.018323809523809534,
+        "ci_low": -0.00026691919191918417,
+        "ci_high": 0.037568820346320315,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.27070911088911087,
+        "system_b": 0.23246607392607394,
+        "difference": 0.038243036963036936,
+        "ci_low": -0.1726646514041514,
+        "ci_high": 0.2136122140914641,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.016,
+        "difference": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.356,
+        "system_b": 0.304,
+        "difference": 0.05199999999999999,
+        "ci_low": -0.02799999999999997,
+        "ci_high": 0.128,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.18838638861138865,
+        "system_b": 0.16558259240759243,
+        "difference": 0.022803796203796217,
+        "ci_low": 0.0014045978327228725,
+        "ci_high": 0.044660372231934746,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.016,
+        "difference": 0.0,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 0,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.356,
+        "system_b_rate": 0.304,
+        "difference": 0.052,
+        "correct_only_in_a": 57,
+        "correct_only_in_b": 44,
+        "discordant_pairs": 101,
+        "p_value": 0.23230046428473858,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 7.888609052210118e-31,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.0,
+        "significant": false,
+        "degenerate_all_zero_differences": true
+       },
+       "step_f1": {
+        "t_statistic": 2.1962810002232716,
+        "p_value": 0.028994255199121285,
+        "dof": 249,
+        "mean_difference": 0.022198068598068603,
+        "sd_difference": 0.15980754834973637,
+        "significant": true,
+        "mde_80_power": 0.028316098430950697,
+        "n_needed_for_observed_diff": 407
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.8851915211223258,
+        "p_value": 0.06056835978014492,
+        "dof": 249,
+        "mean_difference": 0.018323809523809523,
+        "sd_difference": 0.15368458020601167,
+        "significant": false,
+        "mde_80_power": 0.0272311774091486,
+        "n_needed_for_observed_diff": 553
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.9985741314918631,
+        "p_value": 0.3189704460538271,
+        "dof": 249,
+        "mean_difference": -0.0078696032717311,
+        "sd_difference": 0.1246070263376637,
+        "significant": false,
+        "mde_80_power": 0.022078962223007984,
+        "n_needed_for_observed_diff": 1968
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.29530070459117,
+        "p_value": 0.19641612530323857,
+        "dof": 249,
+        "mean_difference": 0.052,
+        "sd_difference": 0.6347500535817925,
+        "significant": false,
+        "mde_80_power": 0.11247056338626896,
+        "n_needed_for_observed_diff": 1170
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.008879227439227439,
+       "ordered_step_accuracy": 0.00549714285714286,
+       "reference_validity_micro": 0.019999999999999997,
+       "step_count_term": 0.003866666666666685,
+       "_sum": 0.03824303696303698,
+       "_total_delta_composite": 0.038243036963036936,
+       "_residual": 4.163336342344337e-17,
+       "_share_reference_term": 0.5229710187329162
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 1000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "typed"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5439559318584793,
+       "system_b": 0.5375348919863999,
+       "difference": 0.006421039872079426,
+       "ci_low": -0.004617713476602586,
+       "ci_high": 0.017584964613297446,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.21126165686165685,
+       "system_b": 0.1817014541014541,
+       "difference": 0.02956020276020274,
+       "ci_low": 0.014111532911532942,
+       "ci_high": 0.04567755910755911,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.19383973063973062,
+       "system_b": 0.16300634920634918,
+       "difference": 0.030833381433381435,
+       "ci_low": 0.015458578643578694,
+       "ci_high": 0.047014824434824395,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.3341232486032486,
+       "system_b": 0.1950935975135975,
+       "difference": 0.1390296510896511,
+       "ci_low": -0.17814045726495725,
+       "ci_high": 0.22190686519036518,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.050666666666666665,
+       "system_b": 0.032,
+       "difference": 0.018666666666666665,
+       "ci_low": 0.005333333333333329,
+       "ci_high": 0.03333333333333333,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5133333333333333,
+       "system_b": 0.5093333333333333,
+       "difference": 0.0040000000000000036,
+       "ci_low": -0.03999999999999998,
+       "ci_high": 0.04669999999999959,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2676540607540608,
+       "system_b": 0.24386699689199692,
+       "difference": 0.023787063862063862,
+       "ci_low": 0.008576752784252769,
+       "ci_high": 0.039413442760942774,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.050666666666666665,
+       "system_b_rate": 0.032,
+       "difference": 0.018666666666666668,
+       "correct_only_in_a": 22,
+       "correct_only_in_b": 8,
+       "discordant_pairs": 30,
+       "p_value": 0.016124801710247993,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 1.862645149230957e-09,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.5133333333333333,
+       "system_b_rate": 0.5093333333333333,
+       "difference": 0.004,
+       "correct_only_in_a": 138,
+       "correct_only_in_b": 135,
+       "discordant_pairs": 273,
+       "p_value": 0.9036839812655058,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.3177747429038154e-82,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 2.565532769838137,
+       "p_value": 0.010495275633594795,
+       "dof": 749,
+       "mean_difference": 0.018666666666666668,
+       "sd_difference": 0.19925986771566667,
+       "significant": true,
+       "mde_80_power": 0.02038427805255935,
+       "n_needed_for_observed_diff": 895
+      },
+      "step_f1": {
+       "t_statistic": 3.6830576279325533,
+       "p_value": 0.0002470277852292186,
+       "dof": 749,
+       "mean_difference": 0.029560202760202763,
+       "sd_difference": 0.21980093025693523,
+       "significant": true,
+       "mde_80_power": 0.022485628089254715,
+       "n_needed_for_observed_diff": 434
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 3.8511674339275235,
+       "p_value": 0.00012760925905727256,
+       "dof": 749,
+       "mean_difference": 0.03083338143338144,
+       "sd_difference": 0.2192599883667095,
+       "significant": true,
+       "mde_80_power": 0.022430289751299116,
+       "n_needed_for_observed_diff": 397
+      },
+      "rouge_l_f1": {
+       "t_statistic": 1.1426397469999,
+       "p_value": 0.25355330970774836,
+       "dof": 749,
+       "mean_difference": 0.006421039872079466,
+       "sd_difference": 0.15389576591450035,
+       "significant": false,
+       "mde_80_power": 0.01574353189870211,
+       "n_needed_for_observed_diff": 4509
+      },
+      "hop_count_exact_match": {
+       "t_statistic": 0.181451161900132,
+       "p_value": 0.8560625550157991,
+       "dof": 749,
+       "mean_difference": 0.004,
+       "sd_difference": 0.6037134750414268,
+       "significant": false,
+       "mde_80_power": 0.06175986906144936,
+       "n_needed_for_observed_diff": 178795
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.011824081104081098,
+      "ordered_step_accuracy": 0.00925001443001443,
+      "reference_validity_micro": 0.12,
+      "step_count_term": -0.0020444444444444377,
+      "_sum": 0.1390296510896511,
+      "_total_delta_composite": 0.1390296510896511,
+      "_residual": 0.0,
+      "_share_reference_term": 0.8631252330671525
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.6,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.7146666666666667,
+      "step_count_term_b": 0.735111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6276116143355489,
+        "system_b": 0.6194803222315687,
+        "difference": 0.008131292103980226,
+        "ci_low": -0.014031437322121825,
+        "ci_high": 0.030756910753918374,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.32807619047619047,
+        "system_b": 0.2948,
+        "difference": 0.03327619047619046,
+        "ci_low": -0.0017919047619046906,
+        "ci_high": 0.06940952380952381,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.3184666666666667,
+        "system_b": 0.2843333333333333,
+        "difference": 0.03413333333333335,
+        "ci_low": -0.001333333333333353,
+        "ci_high": 0.07100000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.5123704761904762,
+        "system_b": 0.49108666666666667,
+        "difference": 0.021283809523809483,
+        "ci_low": -0.0045631190476189964,
+        "ci_high": 0.04812397619047613,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.12,
+        "system_b": 0.096,
+        "difference": 0.023999999999999994,
+        "ci_low": -0.011999999999999997,
+        "ci_high": 0.06000000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.712,
+        "system_b": 0.724,
+        "difference": -0.01200000000000001,
+        "ci_low": -0.07200000000000006,
+        "ci_high": 0.051999999999999935,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3904630952380953,
+        "system_b": 0.3638583333333334,
+        "difference": 0.02660476190476191,
+        "ci_low": -0.005703898809523852,
+        "ci_high": 0.060154970238095205,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.12,
+        "system_b_rate": 0.096,
+        "difference": 0.024,
+        "correct_only_in_a": 14,
+        "correct_only_in_b": 8,
+        "discordant_pairs": 22,
+        "p_value": 0.28627872467041016,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.76837158203125e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.712,
+        "system_b_rate": 0.724,
+        "difference": -0.012,
+        "correct_only_in_a": 30,
+        "correct_only_in_b": 33,
+        "discordant_pairs": 63,
+        "p_value": 0.8013064925040662,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.168404344971009e-19,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.2808420546501698,
+        "p_value": 0.20144084845265725,
+        "dof": 249,
+        "mean_difference": 0.024,
+        "sd_difference": 0.29626862878409255,
+        "significant": false,
+        "mde_80_power": 0.05249546558522745,
+        "n_needed_for_observed_diff": 1197
+       },
+       "step_f1": {
+        "t_statistic": 1.846161176622587,
+        "p_value": 0.06605566031204566,
+        "dof": 249,
+        "mean_difference": 0.03327619047619048,
+        "sd_difference": 0.2849928681494447,
+        "significant": false,
+        "mde_80_power": 0.050497527744921084,
+        "n_needed_for_observed_diff": 576
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.87061892850254,
+        "p_value": 0.06257095353256115,
+        "dof": 249,
+        "mean_difference": 0.034133333333333335,
+        "sd_difference": 0.28851166804317446,
+        "significant": false,
+        "mde_80_power": 0.05112101947092901,
+        "n_needed_for_observed_diff": 561
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.715706845149455,
+        "p_value": 0.4748429899639241,
+        "dof": 249,
+        "mean_difference": 0.00813129210398012,
+        "sd_difference": 0.17963642197211593,
+        "significant": false,
+        "mde_80_power": 0.0318295516004931,
+        "n_needed_for_observed_diff": 3831
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.37731560648264834,
+        "p_value": 0.70626046447548,
+        "dof": 249,
+        "mean_difference": -0.012,
+        "sd_difference": 0.5028592943155352,
+        "significant": false,
+        "mde_80_power": 0.08910100568963888,
+        "n_needed_for_observed_diff": 13783
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.013310476190476185,
+       "ordered_step_accuracy": 0.010240000000000004,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0022666666666666725,
+       "_sum": 0.021283809523809517,
+       "_total_delta_composite": 0.021283809523809483,
+       "_residual": 3.469446951953614e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5297035936179757,
+        "system_b": 0.5202871082354069,
+        "difference": 0.009416485382568784,
+        "ci_low": -0.008704942045689988,
+        "ci_high": 0.027528586620244797,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1682920634920635,
+        "system_b": 0.14674285714285712,
+        "difference": 0.021549206349206373,
+        "ci_low": -0.0006796825396825458,
+        "ci_high": 0.044336507936507924,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.1439111111111111,
+        "system_b": 0.11846666666666665,
+        "difference": 0.02544444444444445,
+        "ci_low": 0.0033549999999999865,
+        "ci_high": 0.04800166666666666,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3792901587301587,
+        "system_b": 0.36383714285714286,
+        "difference": 0.01545301587301584,
+        "ci_low": -0.003683206349206415,
+        "ci_high": 0.03467624603174602,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.0,
+        "difference": 0.016,
+        "ci_low": 0.004,
+        "ci_high": 0.032,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.472,
+        "system_b": 0.48,
+        "difference": -0.008000000000000007,
+        "ci_low": -0.08800000000000002,
+        "ci_high": 0.068,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.22411269841269843,
+        "system_b": 0.20479642857142857,
+        "difference": 0.019316269841269856,
+        "ci_low": -0.004604007936507924,
+        "ci_high": 0.04334530753968255,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.0,
+        "difference": 0.016,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 4,
+        "p_value": 0.125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.472,
+        "system_b_rate": 0.48,
+        "difference": -0.008,
+        "correct_only_in_a": 52,
+        "correct_only_in_b": 54,
+        "discordant_pairs": 106,
+        "p_value": 0.9226851594412759,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.465190328815662e-32,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.012158166696862,
+        "p_value": 0.04528026312539455,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.12572680269402645,
+        "significant": true,
+        "mde_80_power": 0.02227737398675038,
+        "n_needed_for_observed_diff": 485
+       },
+       "step_f1": {
+        "t_statistic": 1.8811560236291895,
+        "p_value": 0.061117501733475896,
+        "dof": 249,
+        "mean_difference": 0.02154920634920635,
+        "sd_difference": 0.18112419431586282,
+        "significant": false,
+        "mde_80_power": 0.03209316811024761,
+        "n_needed_for_observed_diff": 555
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.2251008894057036,
+        "p_value": 0.026970860096634033,
+        "dof": 249,
+        "mean_difference": 0.025444444444444447,
+        "sd_difference": 0.1808061796774361,
+        "significant": true,
+        "mde_80_power": 0.03203681949657344,
+        "n_needed_for_observed_diff": 397
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.0351396995699793,
+        "p_value": 0.30160793228618815,
+        "dof": 249,
+        "mean_difference": 0.009416485382568776,
+        "sd_difference": 0.14383344284336505,
+        "significant": false,
+        "mde_80_power": 0.025485666774024848,
+        "n_needed_for_observed_diff": 1832
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.1938829020572596,
+        "p_value": 0.8464256451314969,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.6524098054266716,
+        "significant": false,
+        "mde_80_power": 0.11559967259712674,
+        "n_needed_for_observed_diff": 52201
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.00861968253968255,
+       "ordered_step_accuracy": 0.007633333333333335,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0008000000000000008,
+       "_sum": 0.015453015873015884,
+       "_total_delta_composite": 0.01545301587301584,
+       "_residual": 4.336808689942018e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4745525876219137,
+        "system_b": 0.47283724549222417,
+        "difference": 0.0017153421296895455,
+        "ci_low": -0.015413332934326607,
+        "ci_high": 0.018579159575871907,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13741671661671662,
+        "system_b": 0.10356150516150515,
+        "difference": 0.03385521145521146,
+        "ci_low": 0.012474208569208571,
+        "ci_high": 0.05651801809301809,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11914141414141415,
+        "system_b": 0.08621904761904761,
+        "difference": 0.032922366522366533,
+        "ci_low": 0.012661608946608954,
+        "ci_high": 0.0547955772005772,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.27070911088911087,
+        "system_b": 0.130356983016983,
+        "difference": 0.14035212787212786,
+        "ci_low": -0.16951505949605952,
+        "ci_high": 0.22448942640692646,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.016,
+        "system_b": 0.0,
+        "difference": 0.016,
+        "ci_low": 0.004,
+        "ci_high": 0.032,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.356,
+        "system_b": 0.324,
+        "difference": 0.03199999999999997,
+        "ci_low": -0.04799999999999999,
+        "ci_high": 0.11199999999999999,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.18838638861138865,
+        "system_b": 0.16294622877122877,
+        "difference": 0.025440159840159876,
+        "ci_low": 0.003065863997114025,
+        "ci_high": 0.0489577435064935,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.016,
+        "system_b_rate": 0.0,
+        "difference": 0.016,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 4,
+        "p_value": 0.125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.356,
+        "system_b_rate": 0.324,
+        "difference": 0.032,
+        "correct_only_in_a": 56,
+        "correct_only_in_b": 48,
+        "discordant_pairs": 104,
+        "p_value": 0.49264506648650275,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 9.860761315262648e-32,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.012158166696862,
+        "p_value": 0.04528026312539455,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.12572680269402645,
+        "significant": true,
+        "mde_80_power": 0.02227737398675038,
+        "n_needed_for_observed_diff": 485
+       },
+       "step_f1": {
+        "t_statistic": 3.030446412138533,
+        "p_value": 0.00269940188039862,
+        "dof": 249,
+        "mean_difference": 0.033855211455211455,
+        "sd_difference": 0.17663994723064866,
+        "significant": true,
+        "mde_80_power": 0.03129861001105356,
+        "n_needed_for_observed_diff": 214
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 3.0760968307758527,
+        "p_value": 0.00233136618724158,
+        "dof": 249,
+        "mean_difference": 0.03292236652236653,
+        "sd_difference": 0.1692236459072982,
+        "significant": true,
+        "mde_80_power": 0.029984524910354818,
+        "n_needed_for_observed_diff": 208
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.20076301925273374,
+        "p_value": 0.8410477686763372,
+        "dof": 249,
+        "mean_difference": 0.0017153421296894952,
+        "sd_difference": 0.13509430462973274,
+        "significant": false,
+        "mde_80_power": 0.023937189869058278,
+        "n_needed_for_observed_diff": 48684
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.7838593838318333,
+        "p_value": 0.43386762211718066,
+        "dof": 249,
+        "mean_difference": 0.032,
+        "sd_difference": 0.6454785591180582,
+        "significant": false,
+        "mde_80_power": 0.11437153378421949,
+        "n_needed_for_observed_diff": 3194
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.013542084582084585,
+       "ordered_step_accuracy": 0.00987670995670996,
+       "reference_validity_micro": 0.12,
+       "step_count_term": -0.003066666666666662,
+       "_sum": 0.1403521278721279,
+       "_total_delta_composite": 0.14035212787212786,
+       "_residual": 2.7755575615628914e-17,
+       "_share_reference_term": 0.8549923810868738
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_2000",
+    "kind": "pool_size",
+    "contrast": "2000 vs 1000",
+    "cell_a": "size2000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5330499591507277,
+       "system_b": 0.5309588431125554,
+       "difference": 0.002091116038172358,
+       "ci_low": -0.008360819936394814,
+       "ci_high": 0.012545301586423556,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1763048877048877,
+       "system_b": 0.17149318089318089,
+       "difference": 0.004811706811706812,
+       "ci_low": -0.010045709290709292,
+       "ci_high": 0.019329611129611117,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1599015873015873,
+       "system_b": 0.15812698412698412,
+       "difference": 0.0017746031746031787,
+       "ci_low": -0.012779365079365057,
+       "ci_high": 0.015911111111111098,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.38978132016132017,
+       "system_b": 0.2565242564842565,
+       "difference": 0.1332570636770637,
+       "ci_low": -0.00907728192178197,
+       "ci_high": 0.14356208177933172,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.042666666666666665,
+       "system_b": 0.03333333333333333,
+       "difference": 0.009333333333333332,
+       "ci_low": -0.004,
+       "ci_high": 0.022666666666666665,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.5026666666666667,
+       "system_b": 0.5333333333333333,
+       "difference": -0.03066666666666662,
+       "ci_low": -0.07066666666666671,
+       "ci_high": 0.010666666666666658,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.23722665020165024,
+       "system_b": 0.23732198727198728,
+       "difference": -9.533707033704264e-05,
+       "ci_low": -0.014435981992544481,
+       "ci_high": 0.014082600709475717,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.042666666666666665,
+       "system_b_rate": 0.03333333333333333,
+       "difference": 0.009333333333333334,
+       "correct_only_in_a": 16,
+       "correct_only_in_b": 9,
+       "discordant_pairs": 25,
+       "p_value": 0.2295229434967041,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.960464477539063e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.5026666666666667,
+       "system_b_rate": 0.5333333333333333,
+       "difference": -0.030666666666666665,
+       "correct_only_in_a": 112,
+       "correct_only_in_b": 135,
+       "discordant_pairs": 247,
+       "p_value": 0.16142989032066304,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 8.843436600416711e-75,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.400898059642256,
+       "p_value": 0.16165872189408273,
+       "dof": 749,
+       "mean_difference": 0.009333333333333334,
+       "sd_difference": 0.18245714483632772,
+       "significant": false,
+       "mde_80_power": 0.018665360042931383,
+       "n_needed_for_observed_diff": 3000
+      },
+      "step_f1": {
+       "t_statistic": 0.6447292399687391,
+       "p_value": 0.5193000758671749,
+       "dof": 749,
+       "mean_difference": 0.004811706811706809,
+       "sd_difference": 0.2043866011878776,
+       "significant": false,
+       "mde_80_power": 0.020908742721722103,
+       "n_needed_for_observed_diff": 14162
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 0.24375717994027582,
+       "p_value": 0.8074856345141086,
+       "dof": 749,
+       "mean_difference": 0.0017746031746031755,
+       "sd_difference": 0.19937673006977483,
+       "significant": false,
+       "mde_80_power": 0.02039623306762248,
+       "n_needed_for_observed_diff": 99074
+      },
+      "rouge_l_f1": {
+       "t_statistic": 0.390874113797361,
+       "p_value": 0.6960014427657394,
+       "dof": 749,
+       "mean_difference": 0.002091116038172351,
+       "sd_difference": 0.14651154732922655,
+       "significant": false,
+       "mde_80_power": 0.014988126575148024,
+       "n_needed_for_observed_diff": 38531
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -1.46457160349239,
+       "p_value": 0.14345742452603732,
+       "dof": 749,
+       "mean_difference": -0.030666666666666665,
+       "sd_difference": 0.5734381663816129,
+       "significant": false,
+       "mde_80_power": 0.058662705960200436,
+       "n_needed_for_observed_diff": 2745
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.001924682724682725,
+      "ordered_step_accuracy": 0.0005323809523809536,
+      "reference_validity_micro": 0.13333333333333336,
+      "step_count_term": -0.002533333333333332,
+      "_sum": 0.13325706367706372,
+      "_total_delta_composite": 0.1332570636770637,
+      "_residual": 2.7755575615628914e-17,
+      "_share_reference_term": 1.0005723498189523
+     },
+     "reference_terms": {
+      "ref_micro_a": 1.0,
+      "ref_micro_b": 0.3333333333333333,
+      "step_count_term_a": 0.7128888888888889,
+      "step_count_term_b": 0.7382222222222222
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.61461121200966,
+        "system_b": 0.6176363641175623,
+        "difference": -0.003025152107902329,
+        "ci_low": -0.024174699490117413,
+        "ci_high": 0.017842215634153925,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.28607619047619043,
+        "system_b": 0.28986666666666666,
+        "difference": -0.003790476190476233,
+        "ci_low": -0.03725738095238097,
+        "ci_high": 0.029878333333333378,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.27579999999999993,
+        "system_b": 0.286,
+        "difference": -0.010200000000000042,
+        "ci_low": -0.04333333333333339,
+        "ci_high": 0.022799999999999987,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.48103714285714283,
+        "system_b": 0.4872133333333334,
+        "difference": -0.006176190476190557,
+        "ci_low": -0.031120904761904798,
+        "ci_high": 0.018617476190476216,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.088,
+        "difference": 0.02800000000000001,
+        "ci_low": -0.0040000000000000036,
+        "ci_high": 0.064,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.712,
+        "system_b": 0.724,
+        "difference": -0.01200000000000001,
+        "ci_low": -0.07200000000000006,
+        "ci_high": 0.051999999999999935,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3512964285714286,
+        "system_b": 0.35901666666666665,
+        "difference": -0.00772023809523803,
+        "ci_low": -0.03890113095238099,
+        "ci_high": 0.023271845238095213,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.116,
+        "system_b_rate": 0.088,
+        "difference": 0.028,
+        "correct_only_in_a": 13,
+        "correct_only_in_b": 6,
+        "discordant_pairs": 19,
+        "p_value": 0.1670684814453125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.814697265625e-06,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.712,
+        "system_b_rate": 0.724,
+        "difference": -0.012,
+        "correct_only_in_a": 29,
+        "correct_only_in_b": 32,
+        "discordant_pairs": 61,
+        "p_value": 0.798152627305718,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.673617379884035e-19,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.611026142844729,
+        "p_value": 0.1084408818996259,
+        "dof": 249,
+        "mean_difference": 0.028,
+        "sd_difference": 0.27480551721018376,
+        "significant": false,
+        "mde_80_power": 0.048692443849162624,
+        "n_needed_for_observed_diff": 757
+       },
+       "step_f1": {
+        "t_statistic": -0.2229725502613909,
+        "p_value": 0.8237396725438213,
+        "dof": 249,
+        "mean_difference": -0.003790476190476188,
+        "sd_difference": 0.26878954751361017,
+        "significant": false,
+        "mde_80_power": 0.04762648174759162,
+        "n_needed_for_observed_diff": 39469
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.6070210812238301,
+        "p_value": 0.5443900267166377,
+        "dof": 249,
+        "mean_difference": -0.010199999999999996,
+        "sd_difference": 0.26568461237529745,
+        "significant": false,
+        "mde_80_power": 0.047076322196894,
+        "n_needed_for_observed_diff": 5326
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.28099606940603833,
+        "p_value": 0.77894676445588,
+        "dof": 249,
+        "mean_difference": -0.0030251521079022563,
+        "sd_difference": 0.17022250435124797,
+        "significant": false,
+        "mde_80_power": 0.03016151138132908,
+        "n_needed_for_observed_diff": 24852
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.3834548160582553,
+        "p_value": 0.7017097539375959,
+        "dof": 249,
+        "mean_difference": -0.012,
+        "sd_difference": 0.49480838853586734,
+        "significant": false,
+        "mde_80_power": 0.08767447582374997,
+        "n_needed_for_observed_diff": 13346
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0015161904761904932,
+       "ordered_step_accuracy": -0.003060000000000013,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0016000000000000016,
+       "_sum": -0.006176190476190508,
+       "_total_delta_composite": -0.006176190476190557,
+       "_residual": 4.9439619065339e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5165669665988813,
+        "system_b": 0.5160879867754459,
+        "difference": 0.00047897982343547696,
+        "ci_low": -0.01719054501436711,
+        "ci_high": 0.018258785728269344,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.14488888888888887,
+        "system_b": 0.13702886002886003,
+        "difference": 0.007860028860028845,
+        "ci_low": -0.013947128427128449,
+        "ci_high": 0.029190743145743117,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11866666666666666,
+        "system_b": 0.1158,
+        "difference": 0.0028666666666666563,
+        "ci_low": -0.018466666666666645,
+        "ci_high": 0.024133333333333326,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3619555555555556,
+        "system_b": 0.3622182106782107,
+        "difference": -0.0002626551226551088,
+        "ci_low": -0.017669283549783577,
+        "ci_high": 0.017264573593073564,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.012,
+        "difference": -0.004,
+        "ci_low": -0.02,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.46,
+        "system_b": 0.496,
+        "difference": -0.035999999999999976,
+        "ci_low": -0.10800000000000004,
+        "ci_high": 0.03999999999999998,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.20244444444444445,
+        "system_b": 0.20277276334776337,
+        "difference": -0.0003283189033189138,
+        "ci_low": -0.022086604437229432,
+        "ci_high": 0.021580716991341953,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.012,
+        "difference": -0.004,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 3,
+        "discordant_pairs": 5,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.46,
+        "system_b_rate": 0.496,
+        "difference": -0.036,
+        "correct_only_in_a": 40,
+        "correct_only_in_b": 49,
+        "discordant_pairs": 89,
+        "p_value": 0.39657015814551616,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.2311742677852644e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.4464969065851096,
+        "p_value": 0.655626407259774,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.14164835695521658,
+        "significant": false,
+        "mde_80_power": 0.02509849415465968,
+        "n_needed_for_observed_diff": 9843
+       },
+       "step_f1": {
+        "t_statistic": 0.7042889055713752,
+        "p_value": 0.48191102709122235,
+        "dof": 249,
+        "mean_difference": 0.007860028860028859,
+        "sd_difference": 0.17645879038931583,
+        "significant": false,
+        "mde_80_power": 0.03126651105825945,
+        "n_needed_for_observed_diff": 3956
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.2638192338073853,
+        "p_value": 0.792137417913113,
+        "dof": 249,
+        "mean_difference": 0.002866666666666669,
+        "sd_difference": 0.17180695714111333,
+        "significant": false,
+        "mde_80_power": 0.03044225857769326,
+        "n_needed_for_observed_diff": 28193
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.0526745610570971,
+        "p_value": 0.9580334422816822,
+        "dof": 249,
+        "mean_difference": 0.00047897982343541836,
+        "sd_difference": 0.1437759674617298,
+        "significant": false,
+        "mde_80_power": 0.02547548278346529,
+        "n_needed_for_observed_diff": 707214
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.9538259445613657,
+        "p_value": 0.341096781880704,
+        "dof": 249,
+        "mean_difference": -0.036,
+        "sd_difference": 0.5967650409132768,
+        "significant": false,
+        "mde_80_power": 0.10574004678220533,
+        "n_needed_for_observed_diff": 2157
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.003144011544011538,
+       "ordered_step_accuracy": 0.0008599999999999968,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.004266666666666675,
+       "_sum": -0.00026265512265513983,
+       "_total_delta_composite": -0.0002626551226551088,
+       "_residual": -3.1008182133085427e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.46797169884364187,
+        "system_b": 0.45915217844465805,
+        "difference": 0.008819520398983816,
+        "ci_low": -0.006500368203828125,
+        "ci_high": 0.023937758569710876,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.09794958374958375,
+        "system_b": 0.087584015984016,
+        "difference": 0.010365567765567754,
+        "ci_low": -0.007550091575091578,
+        "ci_high": 0.02909906260406259,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08523809523809524,
+        "system_b": 0.07258095238095237,
+        "difference": 0.012657142857142867,
+        "ci_low": -0.004033333333333333,
+        "ci_high": 0.03002916666666665,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3263512620712621,
+        "system_b": 0.18680789210789212,
+        "difference": 0.13954336996336997,
+        "ci_low": -0.006031629648129613,
+        "ci_high": 0.15406688098013097,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.336,
+        "system_b": 0.38,
+        "difference": -0.043999999999999984,
+        "ci_low": -0.12,
+        "ci_high": 0.035999999999999976,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.15793907758907763,
+        "system_b": 0.15017653180153184,
+        "difference": 0.007762545787545788,
+        "ci_low": -0.011497988782051303,
+        "ci_high": 0.027823062562437578,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.0,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.336,
+        "system_b_rate": 0.38,
+        "difference": -0.044,
+        "correct_only_in_a": 43,
+        "correct_only_in_b": 54,
+        "discordant_pairs": 97,
+        "p_value": 0.30993353423900705,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.262177448353619e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 1.1010499209455067,
+        "p_value": 0.27193815167565266,
+        "dof": 249,
+        "mean_difference": 0.010365567765567765,
+        "sd_difference": 0.1488524850529402,
+        "significant": false,
+        "mde_80_power": 0.026374984548454373,
+        "n_needed_for_observed_diff": 1619
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.4441976801558936,
+        "p_value": 0.149940457868064,
+        "dof": 249,
+        "mean_difference": 0.012657142857142856,
+        "sd_difference": 0.13857313527322002,
+        "significant": false,
+        "mde_80_power": 0.02455359949390286,
+        "n_needed_for_observed_diff": 941
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.1444182513453833,
+        "p_value": 0.2535491194662521,
+        "dof": 249,
+        "mean_difference": 0.008819520398983892,
+        "sd_difference": 0.12185130872527909,
+        "significant": false,
+        "mde_80_power": 0.02159068008636312,
+        "n_needed_for_observed_diff": 1499
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.117436098415486,
+        "p_value": 0.26488492068952774,
+        "dof": 249,
+        "mean_difference": -0.044,
+        "sd_difference": 0.6225869078540965,
+        "significant": false,
+        "mde_80_power": 0.11031539089778492,
+        "n_needed_for_observed_diff": 1572
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0041462271062271015,
+       "ordered_step_accuracy": 0.00379714285714286,
+       "reference_validity_micro": 0.13333333333333336,
+       "step_count_term": -0.0017333333333333202,
+       "_sum": 0.13954336996337,
+       "_total_delta_composite": 0.13954336996336997,
+       "_residual": 2.7755575615628914e-17,
+       "_share_reference_term": 0.9554974440443373
+      }
+     }
+    }
+   },
+   {
+    "family": "size_2000_vs_4000",
+    "kind": "pool_size",
+    "contrast": "4000 vs 2000",
+    "cell_a": "size4000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5327379194016908,
+       "system_b": 0.5330499591507277,
+       "difference": -0.00031203974903692977,
+       "ci_low": -0.010203483076811399,
+       "ci_high": 0.009717080649361593,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.18295842305842305,
+       "system_b": 0.1763048877048877,
+       "difference": 0.006653535353535356,
+       "ci_low": -0.005917340344840358,
+       "ci_high": 0.0199439578939579,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.16658422873422873,
+       "system_b": 0.1599015873015873,
+       "difference": 0.00668264143264144,
+       "ci_low": -0.005698498168498165,
+       "ci_high": 0.01961444902319902,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.1928030822880823,
+       "system_b": 0.38978132016132017,
+       "difference": -0.19697823787323787,
+       "ci_low": -0.20691433536371037,
+       "ci_high": 0.007122097499722545,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.04133333333333333,
+       "system_b": 0.042666666666666665,
+       "difference": -0.0013333333333333322,
+       "ci_low": -0.012000000000000004,
+       "ci_high": 0.009333333333333332,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.49733333333333335,
+       "system_b": 0.5026666666666667,
+       "difference": -0.005333333333333357,
+       "ci_low": -0.043999999999999984,
+       "ci_high": 0.033333333333333326,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2410038528601029,
+       "system_b": 0.23722665020165024,
+       "difference": 0.003777202658452661,
+       "ci_low": -0.009236378164659404,
+       "ci_high": 0.017127251643032828,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.04133333333333333,
+       "system_b_rate": 0.042666666666666665,
+       "difference": -0.0013333333333333333,
+       "correct_only_in_a": 8,
+       "correct_only_in_b": 9,
+       "discordant_pairs": 17,
+       "p_value": 1.0,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.52587890625e-05,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.49733333333333335,
+       "system_b_rate": 0.5026666666666667,
+       "difference": -0.005333333333333333,
+       "correct_only_in_a": 106,
+       "correct_only_in_b": 110,
+       "discordant_pairs": 216,
+       "p_value": 0.8383158696331667,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.8991135491519597e-65,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -0.24238338610408727,
+       "p_value": 0.8085494596965075,
+       "dof": 749,
+       "mean_difference": -0.0013333333333333333,
+       "sd_difference": 0.1506490925550913,
+       "significant": false,
+       "mde_80_power": 0.0154113973185544,
+       "n_needed_for_observed_diff": 100201
+      },
+      "step_f1": {
+       "t_statistic": 1.0027782916493553,
+       "p_value": 0.31629169144663744,
+       "dof": 749,
+       "mean_difference": 0.006653535353535352,
+       "sd_difference": 0.18170972739623953,
+       "significant": false,
+       "mde_80_power": 0.018588899262871897,
+       "n_needed_for_observed_diff": 5855
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 1.0259642484645293,
+       "p_value": 0.3052396575274156,
+       "dof": 749,
+       "mean_difference": 0.006682641432641431,
+       "sd_difference": 0.17838016587099903,
+       "significant": false,
+       "mde_80_power": 0.018248285226028043,
+       "n_needed_for_observed_diff": 5593
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.06148981879324365,
+       "p_value": 0.9509855263713132,
+       "dof": 749,
+       "mean_difference": -0.00031203974903695606,
+       "sd_difference": 0.1389752098314616,
+       "significant": false,
+       "mde_80_power": 0.014217159491743243,
+       "n_needed_for_observed_diff": 1556923
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.2719974550744355,
+       "p_value": 0.7856989342416671,
+       "dof": 749,
+       "mean_difference": -0.005333333333333333,
+       "sd_difference": 0.5369879237586003,
+       "significant": false,
+       "mde_80_power": 0.05493384731330533,
+       "n_needed_for_observed_diff": 79569
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0026614141414141425,
+      "ordered_step_accuracy": 0.0020047924297924317,
+      "reference_validity_micro": -0.2,
+      "step_count_term": -0.0016444444444444484,
+      "_sum": -0.19697823787323787,
+      "_total_delta_composite": -0.19697823787323787,
+      "_residual": 0.0,
+      "_share_reference_term": 1.015340588683237
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 1.0,
+      "step_count_term_a": 0.6964444444444444,
+      "step_count_term_b": 0.7128888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6124433979577218,
+        "system_b": 0.61461121200966,
+        "difference": -0.0021678140519381106,
+        "ci_low": -0.023092228276519963,
+        "ci_high": 0.018837909376468953,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.2962095238095238,
+        "system_b": 0.28607619047619043,
+        "difference": 0.010133333333333383,
+        "ci_low": -0.018174920634920582,
+        "ci_high": 0.03851587301587289,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2841910256410256,
+        "system_b": 0.27579999999999993,
+        "difference": 0.008391025641025673,
+        "ci_low": -0.01876064102564111,
+        "ci_high": 0.03657458333333337,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4832077838827839,
+        "system_b": 0.48103714285714283,
+        "difference": 0.0021706410256410735,
+        "ci_low": -0.020455900641025624,
+        "ci_high": 0.0241638928571428,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.116,
+        "system_b": 0.116,
+        "difference": 0.0,
+        "ci_low": -0.02800000000000001,
+        "ci_high": 0.02800000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.688,
+        "system_b": 0.712,
+        "difference": -0.02400000000000002,
+        "ci_low": -0.08000000000000007,
+        "ci_high": 0.03599999999999992,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3540097298534799,
+        "system_b": 0.3512964285714286,
+        "difference": 0.0027133012820512725,
+        "ci_low": -0.025569875801282015,
+        "ci_high": 0.030204866071428596,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.116,
+        "system_b_rate": 0.116,
+        "difference": 0.0,
+        "correct_only_in_a": 7,
+        "correct_only_in_b": 7,
+        "discordant_pairs": 14,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0001220703125,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.688,
+        "system_b_rate": 0.712,
+        "difference": -0.024,
+        "correct_only_in_a": 25,
+        "correct_only_in_b": 31,
+        "discordant_pairs": 56,
+        "p_value": 0.5044037600228256,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.7755575615628914e-17,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.23711790231526925,
+        "significant": false,
+        "mde_80_power": 0.042014622782433744,
+        "n_needed_for_observed_diff": null
+       },
+       "step_f1": {
+        "t_statistic": 0.6979042044078005,
+        "p_value": 0.48588830039297776,
+        "dof": 249,
+        "mean_difference": 0.010133333333333333,
+        "sd_difference": 0.22957601788794588,
+        "significant": false,
+        "mde_80_power": 0.04067828576954386,
+        "n_needed_for_observed_diff": 4029
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.5874161694739706,
+        "p_value": 0.5574565223214996,
+        "dof": 249,
+        "mean_difference": 0.008391025641025642,
+        "sd_difference": 0.2258599125240052,
+        "significant": false,
+        "mde_80_power": 0.04001983373550825,
+        "n_needed_for_observed_diff": 5687
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.20270017204623786,
+        "p_value": 0.8395349177837388,
+        "dof": 249,
+        "mean_difference": -0.002167814051938227,
+        "sd_difference": 0.16909778316023347,
+        "significant": false,
+        "mde_80_power": 0.029962223448556067,
+        "n_needed_for_observed_diff": 47758
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.801209340875432,
+        "p_value": 0.4237743358726199,
+        "dof": 249,
+        "mean_difference": -0.024,
+        "sd_difference": 0.4736256804065445,
+        "significant": false,
+        "mde_80_power": 0.08392113842124302,
+        "n_needed_for_observed_diff": 3057
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.004053333333333353,
+       "ordered_step_accuracy": 0.002517307692307702,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.004400000000000004,
+       "_sum": 0.0021706410256410514,
+       "_total_delta_composite": 0.0021706410256410735,
+       "_residual": -2.211772431870429e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.519360298788536,
+        "system_b": 0.5165669665988813,
+        "difference": 0.002793332189654607,
+        "ci_low": -0.01333780013354315,
+        "ci_high": 0.01921182199637947,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.15976507936507936,
+        "system_b": 0.14488888888888887,
+        "difference": 0.014876190476190487,
+        "ci_low": -0.005971825396825424,
+        "ci_high": 0.035514523809523815,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13510476190476192,
+        "system_b": 0.11866666666666666,
+        "difference": 0.016438095238095266,
+        "ci_low": -0.003934047619047602,
+        "ci_high": 0.03733333333333334,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3773707936507937,
+        "system_b": 0.3619555555555556,
+        "difference": 0.015415238095238093,
+        "ci_low": -0.0015230476190475806,
+        "ci_high": 0.03261934126984136,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.008,
+        "difference": -0.004,
+        "ci_low": -0.02,
+        "ci_high": 0.008,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.464,
+        "system_b": 0.46,
+        "difference": 0.0040000000000000036,
+        "ci_low": -0.068,
+        "ci_high": 0.08000000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2217134920634921,
+        "system_b": 0.20244444444444445,
+        "difference": 0.019269047619047658,
+        "ci_low": -0.0019038095238095435,
+        "ci_high": 0.040774176587301605,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.008,
+        "difference": -0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 3,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.25,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.464,
+        "system_b_rate": 0.46,
+        "difference": 0.004,
+        "correct_only_in_a": 45,
+        "correct_only_in_b": 44,
+        "discordant_pairs": 89,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.2311742677852644e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.5765789258001912,
+        "p_value": 0.5647447828879819,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.10969105940803119,
+        "significant": false,
+        "mde_80_power": 0.019436020809202256,
+        "n_needed_for_observed_diff": 5903
+       },
+       "step_f1": {
+        "t_statistic": 1.3905808442363061,
+        "p_value": 0.16559413023771302,
+        "dof": 249,
+        "mean_difference": 0.014876190476190479,
+        "sd_difference": 0.1691474645514124,
+        "significant": false,
+        "mde_80_power": 0.029971026431752645,
+        "n_needed_for_observed_diff": 1015
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.5648870515408615,
+        "p_value": 0.1188793717842269,
+        "dof": 249,
+        "mean_difference": 0.016438095238095238,
+        "sd_difference": 0.16608809337378386,
+        "significant": false,
+        "mde_80_power": 0.029428940301922554,
+        "n_needed_for_observed_diff": 802
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.3417480525401243,
+        "p_value": 0.7328287485741357,
+        "dof": 249,
+        "mean_difference": 0.0027933321896546227,
+        "sd_difference": 0.1292369029628476,
+        "significant": false,
+        "mde_80_power": 0.02289932423716613,
+        "n_needed_for_observed_diff": 16802
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.10578995332903049,
+        "p_value": 0.9158341822345455,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.5978408271592647,
+        "significant": false,
+        "mde_80_power": 0.10593066399363636,
+        "n_needed_for_observed_diff": 175333
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.005950476190476195,
+       "ordered_step_accuracy": 0.00493142857142858,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.004533333333333345,
+       "_sum": 0.01541523809523812,
+       "_total_delta_composite": 0.015415238095238093,
+       "_residual": 2.7755575615628914e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.46641006145881464,
+        "system_b": 0.46797169884364187,
+        "difference": -0.0015616373848272302,
+        "ci_low": -0.015889475906770863,
+        "ci_high": 0.01245113954062083,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.092900666000666,
+        "system_b": 0.09794958374958375,
+        "difference": -0.005048917748917747,
+        "ci_low": -0.021776093073593055,
+        "ci_high": 0.011647126207126187,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08045689865689866,
+        "system_b": 0.08523809523809524,
+        "difference": -0.004781196581196578,
+        "ci_low": -0.020951746031746044,
+        "ci_high": 0.011652283272283254,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.11783066933066932,
+        "system_b": 0.3263512620712621,
+        "difference": -0.20852059274059276,
+        "ci_low": -0.22198435486735493,
+        "ci_high": -0.0034943124930624635,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.004,
+        "difference": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.34,
+        "system_b": 0.336,
+        "difference": 0.0040000000000000036,
+        "ci_low": -0.06399999999999995,
+        "ci_high": 0.07200000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14728833666333668,
+        "system_b": 0.15793907758907763,
+        "difference": -0.010650740925740948,
+        "ci_low": -0.028509779526029507,
+        "ci_high": 0.006964515033577542,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.004,
+        "difference": 0.0,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 0,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.34,
+        "system_b_rate": 0.336,
+        "difference": 0.004,
+        "correct_only_in_a": 36,
+        "correct_only_in_b": 35,
+        "discordant_pairs": 71,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.470329472543003e-22,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.0,
+        "significant": false,
+        "degenerate_all_zero_differences": true
+       },
+       "step_f1": {
+        "t_statistic": -0.5985739029335214,
+        "p_value": 0.5500011790985814,
+        "dof": 249,
+        "mean_difference": -0.005048917748917749,
+        "sd_difference": 0.1333676570861413,
+        "significant": false,
+        "mde_80_power": 0.023631247363183054,
+        "n_needed_for_observed_diff": 5477
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.5817652459145055,
+        "p_value": 0.5612511298670236,
+        "dof": 249,
+        "mean_difference": -0.004781196581196581,
+        "sd_difference": 0.12994477793035172,
+        "significant": false,
+        "mde_80_power": 0.02302475171204852,
+        "n_needed_for_observed_diff": 5798
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.2183605098610451,
+        "p_value": 0.8273270875993638,
+        "dof": 249,
+        "mean_difference": -0.0015616373848272675,
+        "sd_difference": 0.1130774749167231,
+        "significant": false,
+        "mde_80_power": 0.02003605551258413,
+        "n_needed_for_observed_diff": 41154
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.11844390815062264,
+        "p_value": 0.905811430960281,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.5339705029231182,
+        "significant": false,
+        "mde_80_power": 0.09461356160039111,
+        "n_needed_for_observed_diff": 139871
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.002019567099567099,
+       "ordered_step_accuracy": -0.0014343589743589734,
+       "reference_validity_micro": -0.2,
+       "step_count_term": -0.005066666666666686,
+       "_sum": -0.20852059274059276,
+       "_total_delta_composite": -0.20852059274059276,
+       "_residual": 0.0,
+       "_share_reference_term": 0.9591378835605332
+      }
+     }
+    }
+   },
+   {
+    "family": "size_4000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 4000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "cell_b": "size4000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5301727377283056,
+       "system_b": 0.5327379194016908,
+       "difference": -0.002565181673385153,
+       "ci_low": -0.012952938344309927,
+       "ci_high": 0.007534161430878824,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.17474454913278445,
+       "system_b": 0.18295842305842305,
+       "difference": -0.008213873925638604,
+       "ci_low": -0.023106796814296796,
+       "ci_high": 0.006704639429198233,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.15753146591970124,
+       "system_b": 0.16658422873422873,
+       "difference": -0.009052762814527493,
+       "ci_low": -0.023755718774689363,
+       "ci_high": 0.00542886572577749,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.24296678323854798,
+       "system_b": 0.1928030822880823,
+       "difference": 0.050163700950465684,
+       "ci_low": -0.20401972148711858,
+       "ci_high": 0.19822646667629754,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.042666666666666665,
+       "system_b": 0.04133333333333333,
+       "difference": 0.0013333333333333322,
+       "ci_low": -0.010666666666666665,
+       "ci_high": 0.013333333333333336,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4746666666666667,
+       "system_b": 0.49733333333333335,
+       "difference": -0.02266666666666667,
+       "ci_low": -0.06133333333333335,
+       "ci_high": 0.01733333333333331,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2322799076196136,
+       "system_b": 0.2410038528601029,
+       "difference": -0.008723945240489306,
+       "ci_low": -0.023559975608541835,
+       "ci_high": 0.005880663420525602,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.042666666666666665,
+       "system_b_rate": 0.04133333333333333,
+       "difference": 0.0013333333333333333,
+       "correct_only_in_a": 11,
+       "correct_only_in_b": 10,
+       "discordant_pairs": 21,
+       "p_value": 1.0,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 9.5367431640625e-07,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.4746666666666667,
+       "system_b_rate": 0.49733333333333335,
+       "difference": -0.02266666666666667,
+       "correct_only_in_a": 104,
+       "correct_only_in_b": 121,
+       "discordant_pairs": 225,
+       "p_value": 0.28609877375780046,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 3.7092061506874214e-68,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 0.21807928637912496,
+       "p_value": 0.8274267363770448,
+       "dof": 749,
+       "mean_difference": 0.0013333333333333333,
+       "sd_difference": 0.16743835589928982,
+       "significant": false,
+       "mde_80_power": 0.017128938418170803,
+       "n_needed_for_observed_diff": 123779
+      },
+      "step_f1": {
+       "t_statistic": -1.1002261711497623,
+       "p_value": 0.27158706736463306,
+       "dof": 749,
+       "mean_difference": -0.008213873925638632,
+       "sd_difference": 0.20445450906127363,
+       "significant": false,
+       "mde_80_power": 0.020915689694984363,
+       "n_needed_for_observed_diff": 4864
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -1.2382688718218768,
+       "p_value": 0.21600434627912848,
+       "dof": 749,
+       "mean_difference": -0.00905276281452752,
+       "sd_difference": 0.200215095206477,
+       "significant": false,
+       "mde_80_power": 0.020481997794117704,
+       "n_needed_for_observed_diff": 3840
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.49003605015690394,
+       "p_value": 0.6242518922954909,
+       "dof": 749,
+       "mean_difference": -0.0025651816733850198,
+       "sd_difference": 0.14335760258474428,
+       "significant": false,
+       "mde_80_power": 0.01466547812932212,
+       "n_needed_for_observed_diff": 24515
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -1.1335485951613202,
+       "p_value": 0.2573466378105402,
+       "dof": 749,
+       "mean_difference": -0.02266666666666667,
+       "sd_difference": 0.547618544532576,
+       "significant": false,
+       "mde_80_power": 0.0560213594762525,
+       "n_needed_for_observed_diff": 4582
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.003285549570255442,
+      "ordered_step_accuracy": -0.002715828844358248,
+      "reference_validity_micro": 0.05714285714285714,
+      "step_count_term": -0.0009777777777777664,
+      "_sum": 0.050163700950465684,
+      "_total_delta_composite": 0.050163700950465684,
+      "_residual": 0.0,
+      "_share_reference_term": 1.139127617383794
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.2857142857142857,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6866666666666668,
+      "step_count_term_b": 0.6964444444444444
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6153923223234047,
+        "system_b": 0.6124433979577218,
+        "difference": 0.0029489243656828368,
+        "ci_low": -0.018319920969780985,
+        "ci_high": 0.024020820588691646,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.29887619047619046,
+        "system_b": 0.2962095238095238,
+        "difference": 0.0026666666666666505,
+        "ci_low": -0.02991285714285709,
+        "ci_high": 0.03408920634920629,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.28713333333333335,
+        "system_b": 0.2841910256410256,
+        "difference": 0.002942307692307744,
+        "ci_low": -0.02919894230769228,
+        "ci_high": 0.03412628205128204,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.28902380952380957,
+        "system_b": 0.4832077838827839,
+        "difference": -0.19418397435897433,
+        "ci_low": -0.21797267857142866,
+        "ci_high": 0.025994418650793653,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.108,
+        "system_b": 0.116,
+        "difference": -0.008000000000000007,
+        "ci_low": -0.04,
+        "ci_high": 0.023999999999999994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.704,
+        "system_b": 0.688,
+        "difference": 0.016000000000000014,
+        "ci_low": -0.04400000000000004,
+        "ci_high": 0.07999999999999996,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.36127976190476196,
+        "system_b": 0.3540097298534799,
+        "difference": 0.0072700320512820715,
+        "ci_low": -0.024617906746031745,
+        "ci_high": 0.03859427293192923,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.108,
+        "system_b_rate": 0.116,
+        "difference": -0.008,
+        "correct_only_in_a": 7,
+        "correct_only_in_b": 9,
+        "discordant_pairs": 16,
+        "p_value": 0.803619384765625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.0517578125e-05,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.704,
+        "system_b_rate": 0.688,
+        "difference": 0.016,
+        "correct_only_in_a": 33,
+        "correct_only_in_b": 29,
+        "discordant_pairs": 62,
+        "p_value": 0.7035366713552734,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.336808689942018e-19,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -0.49924868477468143,
+        "p_value": 0.6180450118145276,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.25336292365762075,
+        "significant": false,
+        "mde_80_power": 0.0448930576754854,
+        "n_needed_for_observed_diff": 7873
+       },
+       "step_f1": {
+        "t_statistic": 0.1640174172626077,
+        "p_value": 0.8698504885517229,
+        "dof": 249,
+        "mean_difference": 0.0026666666666666644,
+        "sd_difference": 0.2570684433353209,
+        "significant": false,
+        "mde_80_power": 0.04554963404509439,
+        "n_needed_for_observed_diff": 72942
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.1804550100760427,
+        "p_value": 0.8569421527455623,
+        "dof": 249,
+        "mean_difference": 0.0029423076923076916,
+        "sd_difference": 0.25780370078961434,
+        "significant": false,
+        "mde_80_power": 0.04567991338835982,
+        "n_needed_for_observed_diff": 60258
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.27124621176101094,
+        "p_value": 0.7864264067395607,
+        "dof": 249,
+        "mean_difference": 0.0029489243656828446,
+        "sd_difference": 0.17189765679274077,
+        "significant": false,
+        "mde_80_power": 0.030458329534851773,
+        "n_needed_for_observed_diff": 26671
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.5072453606009633,
+        "p_value": 0.612431615954809,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.49873736156748194,
+        "significant": false,
+        "mde_80_power": 0.08837064561200224,
+        "n_needed_for_observed_diff": 7627
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0010666666666666602,
+       "ordered_step_accuracy": 0.0008826923076923231,
+       "reference_validity_micro": -0.2,
+       "step_count_term": 0.003866666666666674,
+       "_sum": -0.19418397435897436,
+       "_total_delta_composite": -0.19418397435897433,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 1.0299511103335128
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5148401039162502,
+        "system_b": 0.519360298788536,
+        "difference": -0.004520194872285721,
+        "ci_low": -0.02118114460304871,
+        "ci_high": 0.01206093884231478,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1402005772005772,
+        "system_b": 0.15976507936507936,
+        "difference": -0.019564502164502173,
+        "ci_low": -0.042863008658008676,
+        "ci_high": 0.003721753246753269,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11406666666666666,
+        "system_b": 0.13510476190476192,
+        "difference": -0.02103809523809526,
+        "ci_low": -0.043505,
+        "ci_high": 0.0012666666666666666,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.15830023088023087,
+        "system_b": 0.3773707936507937,
+        "difference": -0.2190705627705628,
+        "ci_low": -0.23538650432900432,
+        "ci_high": -0.005267840548340627,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.004,
+        "difference": 0.016,
+        "ci_low": 0.004,
+        "ci_high": 0.032,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.428,
+        "system_b": 0.464,
+        "difference": -0.03600000000000003,
+        "ci_low": -0.10799999999999998,
+        "ci_high": 0.03600000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19787528860028863,
+        "system_b": 0.2217134920634921,
+        "difference": -0.023838203463203478,
+        "ci_low": -0.046445042388167414,
+        "ci_high": -0.0012732305194805588,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.02,
+        "system_b_rate": 0.004,
+        "difference": 0.016,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 4,
+        "p_value": 0.125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.428,
+        "system_b_rate": 0.464,
+        "difference": -0.036,
+        "correct_only_in_a": 37,
+        "correct_only_in_b": 46,
+        "discordant_pairs": 83,
+        "p_value": 0.379999396411918,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.0679515313825692e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.012158166696862,
+        "p_value": 0.04528026312539455,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.12572680269402645,
+        "significant": true,
+        "mde_80_power": 0.02227737398675038,
+        "n_needed_for_observed_diff": 485
+       },
+       "step_f1": {
+        "t_statistic": -1.6332201046338644,
+        "p_value": 0.10368651562324974,
+        "dof": 249,
+        "mean_difference": -0.01956450216450216,
+        "sd_difference": 0.18940615521320303,
+        "significant": false,
+        "mde_80_power": 0.03356063834173594,
+        "n_needed_for_observed_diff": 736
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.840018680880585,
+        "p_value": 0.06695567483913799,
+        "dof": 249,
+        "mean_difference": -0.021038095238095238,
+        "sd_difference": 0.18078158465240315,
+        "significant": false,
+        "mde_80_power": 0.03203246153503198,
+        "n_needed_for_observed_diff": 580
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.5373783831365364,
+        "p_value": 0.5914861723685385,
+        "dof": 249,
+        "mean_difference": -0.004520194872285686,
+        "sd_difference": 0.13299856965594445,
+        "significant": false,
+        "mde_80_power": 0.023565849225792145,
+        "n_needed_for_observed_diff": 6796
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.9878305435823476,
+        "p_value": 0.3241945629963503,
+        "dof": 249,
+        "mean_difference": -0.036,
+        "sd_difference": 0.5762222908861269,
+        "significant": false,
+        "mde_80_power": 0.10210010275066203,
+        "n_needed_for_observed_diff": 2011
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.00782580086580087,
+       "ordered_step_accuracy": -0.006311428571428577,
+       "reference_validity_micro": -0.2,
+       "step_count_term": -0.004933333333333345,
+       "_sum": -0.2190705627705628,
+       "_total_delta_composite": -0.2190705627705628,
+       "_residual": 0.0,
+       "_share_reference_term": 0.9129478532880942
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.46028578694526245,
+        "system_b": 0.46641006145881464,
+        "difference": -0.006124274513552186,
+        "ci_low": -0.02135860926522927,
+        "ci_high": 0.008759000796820215,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.0851568797215856,
+        "system_b": 0.092900666000666,
+        "difference": -0.0077437862790804,
+        "ci_low": -0.026822768326444806,
+        "ci_high": 0.01093430673901261,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.07139439775910364,
+        "system_b": 0.08045689865689866,
+        "difference": -0.00906250089779502,
+        "ci_low": -0.026963347698053572,
+        "ci_high": 0.008658365653953878,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.31014773788303196,
+        "system_b": 0.11783066933066932,
+        "difference": 0.19231706855236264,
+        "ci_low": -0.014660834129922331,
+        "ci_high": 0.20807504096883508,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.004,
+        "difference": -0.004,
+        "ci_low": -0.012,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.292,
+        "system_b": 0.34,
+        "difference": -0.04800000000000004,
+        "ci_low": -0.12,
+        "ci_high": 0.023999999999999966,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.13768467235379,
+        "system_b": 0.14728833666333668,
+        "difference": -0.009603664309546678,
+        "ci_low": -0.030204274622436387,
+        "ci_high": 0.011114884943487882,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.0,
+        "system_b_rate": 0.004,
+        "difference": -0.004,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.292,
+        "system_b_rate": 0.34,
+        "difference": -0.048,
+        "correct_only_in_a": 34,
+        "correct_only_in_b": 46,
+        "discordant_pairs": 80,
+        "p_value": 0.2185180394787037,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.6543612251060553e-24,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -0.7981438987497904,
+        "p_value": 0.42554752976374943,
+        "dof": 249,
+        "mean_difference": -0.007743786279080397,
+        "sd_difference": 0.1534059359083761,
+        "significant": false,
+        "mde_80_power": 0.027181804776625604,
+        "n_needed_for_observed_diff": 3081
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.985361478217531,
+        "p_value": 0.32540303469645304,
+        "dof": 249,
+        "mean_difference": -0.009062500897795015,
+        "sd_difference": 0.14541944640556778,
+        "significant": false,
+        "mde_80_power": 0.025766688749788394,
+        "n_needed_for_observed_diff": 2021
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.8031941786597903,
+        "p_value": 0.42262853659385247,
+        "dof": 249,
+        "mean_difference": -0.006124274513552221,
+        "sd_difference": 0.1205602393138603,
+        "significant": false,
+        "mde_80_power": 0.02136191712170692,
+        "n_needed_for_observed_diff": 3042
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.3438012400514816,
+        "p_value": 0.18023588114803066,
+        "dof": 249,
+        "mean_difference": -0.048,
+        "sd_difference": 0.5647759622630913,
+        "significant": false,
+        "mde_80_power": 0.1000719421830926,
+        "n_needed_for_observed_diff": 1087
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0030975145116321602,
+       "ordered_step_accuracy": -0.0027187502693385057,
+       "reference_validity_micro": 0.2,
+       "step_count_term": -0.001866666666666661,
+       "_sum": 0.1923170685523627,
+       "_total_delta_composite": 0.19231706855236264,
+       "_residual": 5.551115123125783e-17,
+       "_share_reference_term": 1.0399492957409837
+      }
+     }
+    }
+   },
+   {
+    "family": "size_1000_vs_8000",
+    "kind": "pool_size",
+    "contrast": "8000 vs 1000",
+    "cell_a": "size8000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "fixed": {
+     "balance": "imbalanced",
+     "retrieval": "biencoder_plus_ce",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = larger pool, B = smaller pool",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5301727377283056,
+       "system_b": 0.5309588431125554,
+       "difference": -0.0007861053842497245,
+       "ci_low": -0.01204107962714549,
+       "ci_high": 0.010405948638447998,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.17474454913278445,
+       "system_b": 0.17149318089318089,
+       "difference": 0.0032513682396035637,
+       "ci_low": -0.013720543487014071,
+       "ci_high": 0.020427262399909458,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.15753146591970124,
+       "system_b": 0.15812698412698412,
+       "difference": -0.0005955182072828746,
+       "ci_low": -0.017361190476190454,
+       "ci_high": 0.015726676003734858,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.24296678323854798,
+       "system_b": 0.2565242564842565,
+       "difference": -0.013557473245708496,
+       "ci_low": -0.20914884027736969,
+       "ci_high": 0.13271940806034924,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.042666666666666665,
+       "system_b": 0.03333333333333333,
+       "difference": 0.009333333333333332,
+       "ci_low": -0.004,
+       "ci_high": 0.02266666666666667,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4746666666666667,
+       "system_b": 0.5333333333333333,
+       "difference": -0.058666666666666645,
+       "ci_low": -0.10133333333333339,
+       "ci_high": -0.01599999999999996,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2322799076196136,
+       "system_b": 0.23732198727198728,
+       "difference": -0.005042079652373688,
+       "ci_low": -0.02137891970910351,
+       "ci_high": 0.010926230848399977,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.042666666666666665,
+       "system_b_rate": 0.03333333333333333,
+       "difference": 0.009333333333333334,
+       "correct_only_in_a": 17,
+       "correct_only_in_b": 10,
+       "discordant_pairs": 27,
+       "p_value": 0.24778856337070465,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.4901161193847656e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.4746666666666667,
+       "system_b_rate": 0.5333333333333333,
+       "difference": -0.058666666666666666,
+       "correct_only_in_a": 118,
+       "correct_only_in_b": 162,
+       "discordant_pairs": 280,
+       "p_value": 0.01005122297986325,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 1.0295115178936058e-84,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.3478839890576717,
+       "p_value": 0.1781032163484179,
+       "dof": 749,
+       "mean_difference": 0.009333333333333334,
+       "sd_difference": 0.18963342709321332,
+       "significant": false,
+       "mde_80_power": 0.019399493486785428,
+       "n_needed_for_observed_diff": 3241
+      },
+      "step_f1": {
+       "t_statistic": 0.3810925124197347,
+       "p_value": 0.7032426728219267,
+       "dof": 749,
+       "mean_difference": 0.0032513682396035364,
+       "sd_difference": 0.23365031712106898,
+       "significant": false,
+       "mde_80_power": 0.023902419919603648,
+       "n_needed_for_observed_diff": 40534
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.07158905377348282,
+       "p_value": 0.9429480623621519,
+       "dof": 749,
+       "mean_difference": -0.0005955182072829116,
+       "sd_difference": 0.22781328872285453,
+       "significant": false,
+       "mde_80_power": 0.023305292102377192,
+       "n_needed_for_observed_diff": 1148631
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.13858010801363652,
+       "p_value": 0.8898192123028105,
+       "dof": 749,
+       "mean_difference": -0.000786105384249626,
+       "sd_difference": 0.1553497315384607,
+       "significant": false,
+       "mde_80_power": 0.01589227253522588,
+       "n_needed_for_observed_diff": 306530
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -2.6399464261969006,
+       "p_value": 0.008464485595569471,
+       "dof": 749,
+       "mean_difference": -0.058666666666666666,
+       "sd_difference": 0.6085929696925808,
+       "significant": true,
+       "mde_80_power": 0.06225904120717732,
+       "n_needed_for_observed_diff": 845
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0013005472958414256,
+      "ordered_step_accuracy": -0.00017865546218486238,
+      "reference_validity_micro": -0.009523809523809525,
+      "step_count_term": -0.005155555555555547,
+      "_sum": -0.013557473245708508,
+      "_total_delta_composite": -0.013557473245708496,
+      "_residual": -1.214306433183765e-17,
+      "_share_reference_term": 0.7024767337692668
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.2857142857142857,
+      "ref_micro_b": 0.3333333333333333,
+      "step_count_term_a": 0.6866666666666668,
+      "step_count_term_b": 0.7382222222222222
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.6153923223234047,
+        "system_b": 0.6176363641175623,
+        "difference": -0.002244041794157603,
+        "ci_low": -0.025512521148959164,
+        "ci_high": 0.020910372135136076,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.29887619047619046,
+        "system_b": 0.28986666666666666,
+        "difference": 0.0090095238095238,
+        "ci_low": -0.028990476190476178,
+        "ci_high": 0.04727619047619047,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.28713333333333335,
+        "system_b": 0.286,
+        "difference": 0.001133333333333375,
+        "ci_low": -0.03733333333333333,
+        "ci_high": 0.03966666666666663,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.28902380952380957,
+        "system_b": 0.4872133333333334,
+        "difference": -0.19818952380952382,
+        "ci_low": -0.2235966904761905,
+        "ci_high": 0.023446761904761908,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.108,
+        "system_b": 0.088,
+        "difference": 0.020000000000000004,
+        "ci_low": -0.016000000000000014,
+        "ci_high": 0.05600000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.704,
+        "system_b": 0.724,
+        "difference": -0.020000000000000018,
+        "ci_low": -0.08400000000000007,
+        "ci_high": 0.04400000000000004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.36127976190476196,
+        "system_b": 0.35901666666666665,
+        "difference": 0.002263095238095314,
+        "ci_low": -0.03298794642857147,
+        "ci_high": 0.03703068452380953,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.108,
+        "system_b_rate": 0.088,
+        "difference": 0.02,
+        "correct_only_in_a": 14,
+        "correct_only_in_b": 9,
+        "discordant_pairs": 23,
+        "p_value": 0.4048728942871094,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.384185791015625e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.704,
+        "system_b_rate": 0.724,
+        "difference": -0.02,
+        "correct_only_in_a": 32,
+        "correct_only_in_b": 37,
+        "discordant_pairs": 69,
+        "p_value": 0.630456491786798,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 3.3881317890172014e-21,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0427541630420303,
+        "p_value": 0.2980735001716106,
+        "dof": 249,
+        "mean_difference": 0.02,
+        "sd_difference": 0.30326205085032276,
+        "significant": false,
+        "mde_80_power": 0.05373462124240066,
+        "n_needed_for_observed_diff": 1805
+       },
+       "step_f1": {
+        "t_statistic": 0.4730636294375455,
+        "p_value": 0.6365822103025007,
+        "dof": 249,
+        "mean_difference": 0.009009523809523816,
+        "sd_difference": 0.30112879218263433,
+        "significant": false,
+        "mde_80_power": 0.053356631823022624,
+        "n_needed_for_observed_diff": 8769
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.05873149154610308,
+        "p_value": 0.9532130822461595,
+        "dof": 249,
+        "mean_difference": 0.0011333333333333328,
+        "sd_difference": 0.3051101365875289,
+        "significant": false,
+        "mde_80_power": 0.05406208122901556,
+        "n_needed_for_observed_diff": 568867
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.18794609727475411,
+        "p_value": 0.8510719779341187,
+        "dof": 249,
+        "mean_difference": -0.002244041794157634,
+        "sd_difference": 0.18878506489482885,
+        "significant": false,
+        "mde_80_power": 0.03345058812964518,
+        "n_needed_for_observed_diff": 55551
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.6011599817498456,
+        "p_value": 0.5482803006772575,
+        "dof": 249,
+        "mean_difference": -0.02,
+        "sd_difference": 0.5260293027096845,
+        "significant": false,
+        "mde_80_power": 0.09320647032575767,
+        "n_needed_for_observed_diff": 5430
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0036038095238095204,
+       "ordered_step_accuracy": 0.0003400000000000125,
+       "reference_validity_micro": -0.2,
+       "step_count_term": -0.0021333333333333317,
+       "_sum": -0.19818952380952382,
+       "_total_delta_composite": -0.19818952380952382,
+       "_residual": 0.0,
+       "_share_reference_term": 1.009135075132509
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5148401039162502,
+        "system_b": 0.5160879867754459,
+        "difference": -0.001247882859195637,
+        "ci_low": -0.01988021059977359,
+        "ci_high": 0.017184031255059695,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1402005772005772,
+        "system_b": 0.13702886002886003,
+        "difference": 0.003171717171717159,
+        "ci_low": -0.023721284271284265,
+        "ci_high": 0.03022659451659454,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11406666666666666,
+        "system_b": 0.1158,
+        "difference": -0.0017333333333333367,
+        "ci_low": -0.026601666666666676,
+        "ci_high": 0.02373333333333333,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.15830023088023087,
+        "system_b": 0.3622182106782107,
+        "difference": -0.20391797979797982,
+        "ci_low": -0.22201443506493507,
+        "ci_high": 0.01176662121212122,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.012,
+        "difference": 0.008,
+        "ci_low": -0.008,
+        "ci_high": 0.024,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.428,
+        "system_b": 0.496,
+        "difference": -0.068,
+        "ci_low": -0.14800000000000002,
+        "ci_high": 0.01200000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19787528860028863,
+        "system_b": 0.20277276334776337,
+        "difference": -0.004897474747474734,
+        "ci_low": -0.030478716630591644,
+        "ci_high": 0.020736809163059162,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.02,
+        "system_b_rate": 0.012,
+        "difference": 0.008,
+        "correct_only_in_a": 3,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 4,
+        "p_value": 0.625,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.125,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.428,
+        "system_b_rate": 0.496,
+        "difference": -0.068,
+        "correct_only_in_a": 45,
+        "correct_only_in_b": 62,
+        "discordant_pairs": 107,
+        "p_value": 0.1215124218762441,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.232595164407831e-32,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.12649110640673517,
+        "significant": false,
+        "mde_80_power": 0.0224128,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 0.23051823695109183,
+        "p_value": 0.8178783740520609,
+        "dof": 249,
+        "mean_difference": 0.003171717171717175,
+        "sd_difference": 0.2175500404903247,
+        "significant": false,
+        "mde_80_power": 0.03854741796488805,
+        "n_needed_for_observed_diff": 36927
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.13501871917839747,
+        "p_value": 0.8927061528250801,
+        "dof": 249,
+        "mean_difference": -0.0017333333333333326,
+        "sd_difference": 0.20298227205010302,
+        "significant": false,
+        "mde_80_power": 0.03596617340333669,
+        "n_needed_for_observed_diff": 107638
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.13146590634883296,
+        "p_value": 0.8955129152655735,
+        "dof": 249,
+        "mean_difference": -0.0012478828591956476,
+        "sd_difference": 0.15008271717500202,
+        "significant": false,
+        "mde_80_power": 0.026592967830351564,
+        "n_needed_for_observed_diff": 113535
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.6490942163049407,
+        "p_value": 0.10038934229205443,
+        "dof": 249,
+        "mean_difference": -0.068,
+        "sd_difference": 0.6519787613265355,
+        "significant": false,
+        "mde_80_power": 0.1155232964353398,
+        "n_needed_for_observed_diff": 722
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0012686868686868635,
+       "ordered_step_accuracy": -0.000520000000000001,
+       "reference_validity_micro": -0.2,
+       "step_count_term": -0.004666666666666675,
+       "_sum": -0.20391797979797982,
+       "_total_delta_composite": -0.20391797979797982,
+       "_residual": 0.0,
+       "_share_reference_term": 0.9807864916969984
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.46028578694526245,
+        "system_b": 0.45915217844465805,
+        "difference": 0.0011336085006043994,
+        "ci_low": -0.013631823004954254,
+        "ci_high": 0.01583890497444638,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.0851568797215856,
+        "system_b": 0.087584015984016,
+        "difference": -0.0024271362624303933,
+        "ci_low": -0.022068249169131537,
+        "ci_high": 0.018054402558226084,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.07139439775910364,
+        "system_b": 0.07258095238095237,
+        "difference": -0.0011865546218487316,
+        "ci_low": -0.01933998599439776,
+        "ci_high": 0.017372296918767502,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.31014773788303196,
+        "system_b": 0.18680789210789212,
+        "difference": 0.12333984577513984,
+        "ci_low": -0.02317922705399172,
+        "ci_high": 0.13907815955286548,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.0,
+        "difference": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.292,
+        "system_b": 0.38,
+        "difference": -0.08800000000000002,
+        "ci_low": -0.16799999999999998,
+        "ci_high": -0.008000000000000007,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.13768467235379,
+        "system_b": 0.15017653180153184,
+        "difference": -0.012491859447741838,
+        "ci_low": -0.03361243102893842,
+        "ci_high": 0.009642307223005766,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.0,
+        "system_b_rate": 0.0,
+        "difference": 0.0,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 0,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.292,
+        "system_b_rate": 0.38,
+        "difference": -0.088,
+        "correct_only_in_a": 41,
+        "correct_only_in_b": 63,
+        "discordant_pairs": 104,
+        "p_value": 0.03895793340131187,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 9.860761315262648e-32,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.0,
+        "significant": false,
+        "degenerate_all_zero_differences": true
+       },
+       "step_f1": {
+        "t_statistic": -0.23734545776245916,
+        "p_value": 0.8125839640349308,
+        "dof": 249,
+        "mean_difference": -0.002427136262430379,
+        "sd_difference": 0.16169002881339656,
+        "significant": false,
+        "mde_80_power": 0.028649652775872426,
+        "n_needed_for_observed_diff": 34833
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.12702265954005335,
+        "p_value": 0.8990249792384715,
+        "dof": 249,
+        "mean_difference": -0.0011865546218487392,
+        "sd_difference": 0.14769865419400394,
+        "significant": false,
+        "mde_80_power": 0.026170538710246497,
+        "n_needed_for_observed_diff": 121616
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.1492428053769008,
+        "p_value": 0.8814828485827628,
+        "dof": 249,
+        "mean_difference": 0.0011336085006044038,
+        "sd_difference": 0.12009908376437949,
+        "significant": false,
+        "mde_80_power": 0.02128020555009517,
+        "n_needed_for_observed_diff": 88098
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -2.1732818729719847,
+        "p_value": 0.03070204560327145,
+        "dof": 249,
+        "mean_difference": -0.088,
+        "sd_difference": 0.64023088204906,
+        "significant": true,
+        "mde_80_power": 0.11344170448670471,
+        "n_needed_for_observed_diff": 416
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0009708545049721573,
+       "ordered_step_accuracy": -0.00035596638655461946,
+       "reference_validity_micro": 0.13333333333333336,
+       "step_count_term": -0.008666666666666668,
+       "_sum": 0.12333984577513991,
+       "_total_delta_composite": 0.12333984577513984,
+       "_residual": 6.938893903907228e-17,
+       "_share_reference_term": 1.0810239991414663
+      }
+     }
+    }
+   }
+  ]
+ },
+ "secondary_balance_pairs": {
+  "num_pairs": 9,
+  "sign_convention": "difference = balanced - imbalanced; positive favours the balanced pool",
+  "families": [
+   "balance_size1000",
+   "balance_size2000"
+  ],
+  "pairs": [
+   {
+    "family": "balance_size1000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 1000",
+    "cell_a": "size1000_balanced_trial0__biencoder_only__raw",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__raw",
+    "fixed": {
+     "size": 1000,
+     "retrieval": "biencoder_only",
+     "mask": "raw"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5237267087627537,
+       "system_b": 0.5253321480880906,
+       "difference": -0.0016054393253368548,
+       "ci_low": -0.013886530310549067,
+       "ci_high": 0.010531360191897867,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.16133865393865393,
+       "system_b": 0.1599082251082251,
+       "difference": 0.0014304288304288204,
+       "ci_low": -0.014491392496392499,
+       "ci_high": 0.017136498316498324,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.14889870129870128,
+       "system_b": 0.14317142857142856,
+       "difference": 0.00572727272727272,
+       "ci_low": -0.009664949494949495,
+       "ci_high": 0.021273943001442978,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.1762272941872942,
+       "system_b": 0.1774036075036075,
+       "difference": -0.001176313316313321,
+       "ci_low": -0.20385603174603173,
+       "ci_high": 0.20788113623413623,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.03866666666666667,
+       "system_b": 0.030666666666666665,
+       "difference": 0.008000000000000004,
+       "ci_low": -0.007999999999999997,
+       "ci_high": 0.023999999999999997,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.448,
+       "system_b": 0.46266666666666667,
+       "difference": -0.014666666666666661,
+       "ci_low": -0.0586666666666667,
+       "ci_high": 0.029333333333333322,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.22028411773411777,
+       "system_b": 0.2217545093795094,
+       "difference": -0.0014703916453916444,
+       "ci_low": -0.01646215173715175,
+       "ci_high": 0.013796442319254787,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.03866666666666667,
+       "system_b_rate": 0.030666666666666665,
+       "difference": 0.008,
+       "correct_only_in_a": 21,
+       "correct_only_in_b": 15,
+       "discordant_pairs": 36,
+       "p_value": 0.40503224614076316,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.9103830456733704e-11,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.448,
+       "system_b_rate": 0.46266666666666667,
+       "difference": -0.014666666666666666,
+       "correct_only_in_a": 136,
+       "correct_only_in_b": 147,
+       "discordant_pairs": 283,
+       "p_value": 0.5522952923876202,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.2868893973670072e-85,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.0,
+       "p_value": 0.31763345838622353,
+       "dof": 749,
+       "mean_difference": 0.008,
+       "sd_difference": 0.21908902300206645,
+       "significant": false,
+       "mde_80_power": 0.0224128,
+       "n_needed_for_observed_diff": 5887
+      },
+      "step_f1": {
+       "t_statistic": 0.17670435665754156,
+       "p_value": 0.8597883873956789,
+       "dof": 749,
+       "mean_difference": 0.0014304288304288295,
+       "sd_difference": 0.22169179983773876,
+       "significant": false,
+       "mde_80_power": 0.02267906398649834,
+       "n_needed_for_observed_diff": 188530
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 0.7234435805387234,
+       "p_value": 0.4696332688903151,
+       "dof": 749,
+       "mean_difference": 0.005727272727272727,
+       "sd_difference": 0.21680726390407826,
+       "significant": false,
+       "mde_80_power": 0.022179376117732255,
+       "n_needed_for_observed_diff": 11248
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.25806899359890045,
+       "p_value": 0.7964245527644525,
+       "dof": 749,
+       "mean_difference": -0.001605439325336782,
+       "sd_difference": 0.17036826488336743,
+       "significant": false,
+       "mde_80_power": 0.01742866801291967,
+       "n_needed_for_observed_diff": 88390
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.6536324000235922,
+       "p_value": 0.5135492735676022,
+       "dof": 749,
+       "mean_difference": -0.014666666666666666,
+       "sd_difference": 0.6145093309674124,
+       "significant": false,
+       "mde_80_power": 0.06286428477512776,
+       "n_needed_for_observed_diff": 13779
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0005721715321715282,
+      "ordered_step_accuracy": 0.001718181818181816,
+      "reference_validity_micro": 0.0,
+      "step_count_term": -0.0034666666666666626,
+      "_sum": -0.0011763133163133184,
+      "_total_delta_composite": -0.001176313316313321,
+      "_residual": 2.6020852139652106e-18,
+      "_share_reference_term": -0.0
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6702222222222223,
+      "step_count_term_b": 0.7048888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5746685352352963,
+        "system_b": 0.5881874136887768,
+        "difference": -0.013518878453480543,
+        "ci_low": -0.03855444607599428,
+        "ci_high": 0.011007762997153264,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.24200952380952379,
+        "system_b": 0.25001904761904764,
+        "difference": -0.008009523809523855,
+        "ci_low": -0.04215309523809531,
+        "ci_high": 0.02713357142857146,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.23298181818181818,
+        "system_b": 0.2339333333333333,
+        "difference": -0.0009515151515151199,
+        "ci_low": -0.03588530303030304,
+        "ci_high": 0.03484848484848482,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4424316883116883,
+        "system_b": 0.4517876190476191,
+        "difference": -0.009355930735930829,
+        "ci_low": -0.03576241991341997,
+        "ci_high": 0.017139309523809498,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.088,
+        "system_b": 0.076,
+        "difference": 0.011999999999999997,
+        "ci_low": -0.027999999999999997,
+        "ci_high": 0.052,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.576,
+        "system_b": 0.624,
+        "difference": -0.04800000000000004,
+        "ci_low": -0.12,
+        "ci_high": 0.02400000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3030396103896104,
+        "system_b": 0.3147345238095239,
+        "difference": -0.011694913419913466,
+        "ci_low": -0.04470302489177496,
+        "ci_high": 0.021424136904761887,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.088,
+        "system_b_rate": 0.076,
+        "difference": 0.012,
+        "correct_only_in_a": 14,
+        "correct_only_in_b": 11,
+        "discordant_pairs": 25,
+        "p_value": 0.6900379657745361,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.960464477539063e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.576,
+        "system_b_rate": 0.624,
+        "difference": -0.048,
+        "correct_only_in_a": 38,
+        "correct_only_in_b": 50,
+        "discordant_pairs": 88,
+        "p_value": 0.24079312453900145,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.462348535570529e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.5992303989136518,
+        "p_value": 0.5495640674652218,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.3166339023421999,
+        "significant": false,
+        "mde_80_power": 0.05610396278451232,
+        "n_needed_for_observed_diff": 5465
+       },
+       "step_f1": {
+        "t_statistic": -0.444940513057266,
+        "p_value": 0.6567492729965176,
+        "dof": 249,
+        "mean_difference": -0.00800952380952381,
+        "sd_difference": 0.2846261181905906,
+        "significant": false,
+        "mde_80_power": 0.05043254378113651,
+        "n_needed_for_observed_diff": 9912
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.05204574429872572,
+        "p_value": 0.958533972623134,
+        "dof": 249,
+        "mean_difference": -0.0009515151515151534,
+        "sd_difference": 0.2890683136048235,
+        "significant": false,
+        "mde_80_power": 0.05121965079765651,
+        "n_needed_for_observed_diff": 724406
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.0615226127312503,
+        "p_value": 0.2894809569927983,
+        "dof": 249,
+        "mean_difference": -0.013518878453480446,
+        "sd_difference": 0.20136380898178832,
+        "significant": false,
+        "mde_80_power": 0.03567939996852394,
+        "n_needed_for_observed_diff": 1742
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.2808420546501698,
+        "p_value": 0.20144084845265725,
+        "dof": 249,
+        "mean_difference": -0.048,
+        "sd_difference": 0.5925372575681851,
+        "significant": false,
+        "mde_80_power": 0.1049909311704549,
+        "n_needed_for_observed_diff": 1197
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0032038095238095424,
+       "ordered_step_accuracy": -0.00028545454545453596,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.005866666666666665,
+       "_sum": -0.009355930735930744,
+       "_total_delta_composite": -0.009355930735930829,
+       "_residual": 8.500145032286355e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5178867205844552,
+        "system_b": 0.5224520146829778,
+        "difference": -0.0045652940985225765,
+        "ci_low": -0.02500084367865159,
+        "ci_high": 0.016046990336662927,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.15595873015873013,
+        "system_b": 0.14063174603174602,
+        "difference": 0.015326984126984106,
+        "ci_low": -0.010292777777777776,
+        "ci_high": 0.04050523809523806,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13907619047619044,
+        "system_b": 0.11897142857142856,
+        "difference": 0.020104761904761875,
+        "ci_low": -0.0035052380952381034,
+        "ci_high": 0.04337214285714284,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3685063492063492,
+        "system_b": 0.36221079365079367,
+        "difference": 0.006295555555555554,
+        "ci_low": -0.013272253968253923,
+        "ci_high": 0.025504373015873046,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.028,
+        "system_b": 0.012,
+        "difference": 0.016,
+        "ci_low": -0.008,
+        "ci_high": 0.04,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.436,
+        "system_b": 0.456,
+        "difference": -0.020000000000000018,
+        "ci_low": -0.10399999999999998,
+        "ci_high": 0.06,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.21063293650793652,
+        "system_b": 0.2027634920634921,
+        "difference": 0.007869444444444429,
+        "ci_low": -0.016590317460317434,
+        "ci_high": 0.031880466269841236,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.028,
+        "system_b_rate": 0.012,
+        "difference": 0.016,
+        "correct_only_in_a": 7,
+        "correct_only_in_b": 3,
+        "discordant_pairs": 10,
+        "p_value": 0.34375,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.001953125,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.436,
+        "system_b_rate": 0.456,
+        "difference": -0.02,
+        "correct_only_in_a": 51,
+        "correct_only_in_b": 56,
+        "discordant_pairs": 107,
+        "p_value": 0.6991749840078736,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.232595164407831e-32,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.2664378130407814,
+        "p_value": 0.20653981163077162,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.19975889081047513,
+        "significant": false,
+        "mde_80_power": 0.035395026536969444,
+        "n_needed_for_observed_diff": 1224
+       },
+       "step_f1": {
+        "t_statistic": 1.1689954539346892,
+        "p_value": 0.2435233500928743,
+        "dof": 249,
+        "mean_difference": 0.015326984126984123,
+        "sd_difference": 0.20730696316816097,
+        "significant": false,
+        "mde_80_power": 0.03673245998145494,
+        "n_needed_for_observed_diff": 1436
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.6790780473971585,
+        "p_value": 0.09439119809856662,
+        "dof": 249,
+        "mean_difference": 0.020104761904761903,
+        "sd_difference": 0.1893206796818861,
+        "significant": false,
+        "mde_80_power": 0.033545493039882544,
+        "n_needed_for_observed_diff": 697
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.43721277815418175,
+        "p_value": 0.6623359887464024,
+        "dof": 249,
+        "mean_difference": -0.004565294098522629,
+        "sd_difference": 0.16509956091408637,
+        "significant": false,
+        "mde_80_power": 0.029253783479106368,
+        "n_needed_for_observed_diff": 10266
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.48262611830016183,
+        "p_value": 0.6297852473589154,
+        "dof": 249,
+        "mean_difference": -0.02,
+        "sd_difference": 0.6552230681808335,
+        "significant": false,
+        "mde_80_power": 0.11609815108504297,
+        "n_needed_for_observed_diff": 8425
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.006130793650793643,
+       "ordered_step_accuracy": 0.006031428571428563,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.005866666666666676,
+       "_sum": 0.006295555555555529,
+       "_total_delta_composite": 0.006295555555555554,
+       "_residual": -2.5153490401663703e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.47862487046850993,
+        "system_b": 0.4653570158925172,
+        "difference": 0.013267854575992721,
+        "ci_low": -0.00373642288608445,
+        "ci_high": 0.030295288891439072,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.08604770784770785,
+        "system_b": 0.08907388167388168,
+        "difference": -0.003026173826173831,
+        "ci_low": -0.022231890886890905,
+        "ci_high": 0.01533937895437894,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.07463809523809525,
+        "system_b": 0.07660952380952381,
+        "difference": -0.0019714285714285545,
+        "ci_low": -0.020543333333333323,
+        "ci_high": 0.015634166666666668,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.11774384504384505,
+        "system_b": 0.11821240981240982,
+        "difference": -0.00046856476856477203,
+        "ci_low": -0.20226880899655902,
+        "ci_high": 0.21086281654456654,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.004,
+        "difference": -0.004,
+        "ci_low": -0.012,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.332,
+        "system_b": 0.308,
+        "difference": 0.02400000000000002,
+        "ci_low": -0.04800000000000004,
+        "ci_high": 0.09600000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14717980630480632,
+        "system_b": 0.14776551226551232,
+        "difference": -0.0005857059607060067,
+        "ci_low": -0.020900327380952342,
+        "ci_high": 0.019314628184315674,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.0,
+        "system_b_rate": 0.004,
+        "difference": -0.004,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.332,
+        "system_b_rate": 0.308,
+        "difference": 0.024,
+        "correct_only_in_a": 47,
+        "correct_only_in_b": 41,
+        "discordant_pairs": 88,
+        "p_value": 0.5942882951469405,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 6.462348535570529e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.06324555320336758,
+        "significant": false,
+        "mde_80_power": 0.0112064,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -0.31182749097116497,
+        "p_value": 0.7554325725774378,
+        "dof": 249,
+        "mean_difference": -0.0030261738261738265,
+        "sd_difference": 0.15344384577017092,
+        "significant": false,
+        "mde_80_power": 0.027188521977340913,
+        "n_needed_for_observed_diff": 20181
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.2117047768058543,
+        "p_value": 0.8325105396394564,
+        "dof": 249,
+        "mean_difference": -0.0019714285714285715,
+        "sd_difference": 0.14723816401562265,
+        "significant": false,
+        "mde_80_power": 0.026088945034902736,
+        "n_needed_for_observed_diff": 43782
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.516726477144163,
+        "p_value": 0.1306042599888612,
+        "dof": 249,
+        "mean_difference": 0.01326785457599273,
+        "sd_difference": 0.1383131393704703,
+        "significant": false,
+        "mde_80_power": 0.0245075311470073,
+        "n_needed_for_observed_diff": 853
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.6388445680130395,
+        "p_value": 0.5235112476104012,
+        "dof": 249,
+        "mean_difference": 0.024,
+        "sd_difference": 0.5939994455935644,
+        "significant": false,
+        "mde_80_power": 0.10525001442702667,
+        "n_needed_for_observed_diff": 4808
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0012104695304695325,
+       "ordered_step_accuracy": -0.0005914285714285663,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0013333333333333198,
+       "_sum": -0.00046856476856477897,
+       "_total_delta_composite": -0.00046856476856477203,
+       "_residual": -6.938893903907228e-18,
+       "_share_reference_term": -0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "balance_size1000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 1000",
+    "cell_a": "size1000_balanced_trial0__biencoder_only__typed",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__typed",
+    "fixed": {
+     "size": 1000,
+     "retrieval": "biencoder_only",
+     "mask": "typed"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5223531262239297,
+       "system_b": 0.517633339818622,
+       "difference": 0.00471978640530768,
+       "ci_low": -0.007763270993635356,
+       "ci_high": 0.01696970996650332,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.16963798053798052,
+       "system_b": 0.16706542825366355,
+       "difference": 0.0025725522843169646,
+       "ci_low": -0.013946313305430983,
+       "ci_high": 0.018958744099038215,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1504810152810153,
+       "system_b": 0.14791856661856662,
+       "difference": 0.002562448662448674,
+       "ci_low": -0.012944473304473314,
+       "ci_high": 0.018059219391719398,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.24575505235505235,
+       "system_b": 0.18102396350925765,
+       "difference": 0.0647310888457947,
+       "ci_low": -0.19679767987350338,
+       "ci_high": 0.2068933051229816,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.04133333333333333,
+       "system_b": 0.02666666666666667,
+       "difference": 0.014666666666666665,
+       "ci_low": 0.0013333333333333322,
+       "ci_high": 0.028000000000000004,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.43733333333333335,
+       "system_b": 0.47333333333333333,
+       "difference": -0.035999999999999976,
+       "ci_low": -0.07999999999999996,
+       "ci_high": 0.008000000000000007,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.22386048211048215,
+       "system_b": 0.22627995438657206,
+       "difference": -0.0024194722760899068,
+       "ci_low": -0.01791462914808505,
+       "ci_high": 0.01306755838864295,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.04133333333333333,
+       "system_b_rate": 0.02666666666666667,
+       "difference": 0.014666666666666666,
+       "correct_only_in_a": 19,
+       "correct_only_in_b": 8,
+       "discordant_pairs": 27,
+       "p_value": 0.052238985896110535,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.4901161193847656e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.43733333333333335,
+       "system_b_rate": 0.47333333333333333,
+       "difference": -0.036,
+       "correct_only_in_a": 125,
+       "correct_only_in_b": 152,
+       "discordant_pairs": 277,
+       "p_value": 0.11808416554409962,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 8.236092143148846e-84,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 2.1218881824897178,
+       "p_value": 0.03417481128793973,
+       "dof": 749,
+       "mean_difference": 0.014666666666666666,
+       "sd_difference": 0.1892951815989805,
+       "significant": true,
+       "mde_80_power": 0.01936489098361452,
+       "n_needed_for_observed_diff": 1308
+      },
+      "step_f1": {
+       "t_statistic": 0.31073103007615804,
+       "p_value": 0.7560915562253258,
+       "dof": 749,
+       "mean_difference": 0.002572552284316989,
+       "sd_difference": 0.22673064163184975,
+       "significant": false,
+       "mde_80_power": 0.023194537339820954,
+       "n_needed_for_observed_diff": 60969
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": 0.3267848221414636,
+       "p_value": 0.7439219370300288,
+       "dof": 749,
+       "mean_difference": 0.0025624486624486616,
+       "sd_difference": 0.21474542876175867,
+       "significant": false,
+       "mde_80_power": 0.021968450449049416,
+       "n_needed_for_observed_diff": 55126
+      },
+      "rouge_l_f1": {
+       "t_statistic": 0.7612795262656641,
+       "p_value": 0.4467297397621614,
+       "dof": 749,
+       "mean_difference": 0.004719786405307689,
+       "sd_difference": 0.1697887169955958,
+       "significant": false,
+       "mde_80_power": 0.017369380282657963,
+       "n_needed_for_observed_diff": 10158
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -1.624042805687899,
+       "p_value": 0.10478740536537386,
+       "dof": 749,
+       "mean_difference": -0.036,
+       "sd_difference": 0.6070656512601581,
+       "significant": false,
+       "mde_80_power": 0.06210279658070929,
+       "n_needed_for_observed_diff": 2232
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.001029020913726786,
+      "ordered_step_accuracy": 0.0007687345987346022,
+      "reference_validity_micro": 0.06666666666666667,
+      "step_count_term": -0.003733333333333344,
+      "_sum": 0.0647310888457947,
+      "_total_delta_composite": 0.0647310888457947,
+      "_residual": 0.0,
+      "_share_reference_term": 1.029901827010557
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.3333333333333333,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6608888888888889,
+      "step_count_term_b": 0.6982222222222223
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5774413470405243,
+        "system_b": 0.5812850040425221,
+        "difference": -0.0038436570019978467,
+        "ci_low": -0.0317325109825328,
+        "ci_high": 0.023565190747294712,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.2392095238095238,
+        "system_b": 0.2664915750915751,
+        "difference": -0.02728205128205133,
+        "ci_low": -0.06541576923076926,
+        "ci_high": 0.011914523809523857,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2253047619047619,
+        "system_b": 0.25579999999999997,
+        "difference": -0.030495238095238075,
+        "ci_low": -0.06762952380952383,
+        "ci_high": 0.007305476190476146,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4388752380952381,
+        "system_b": 0.46666996336996336,
+        "difference": -0.027794725274725263,
+        "ci_low": -0.055723309523809474,
+        "ci_high": 0.0013128827838827831,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.096,
+        "system_b": 0.08,
+        "difference": 0.016,
+        "ci_low": -0.01999999999999999,
+        "ci_high": 0.052000000000000005,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.576,
+        "system_b": 0.688,
+        "difference": -0.11199999999999999,
+        "ci_low": -0.18399999999999994,
+        "ci_high": -0.040000000000000036,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2985940476190477,
+        "system_b": 0.33333745421245425,
+        "difference": -0.03474340659340658,
+        "ci_low": -0.06965413690476185,
+        "ci_high": 0.0016411034798535058,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.096,
+        "system_b_rate": 0.08,
+        "difference": 0.016,
+        "correct_only_in_a": 12,
+        "correct_only_in_b": 8,
+        "discordant_pairs": 20,
+        "p_value": 0.5034446716308594,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.9073486328125e-06,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.576,
+        "system_b_rate": 0.688,
+        "difference": -0.112,
+        "correct_only_in_a": 29,
+        "correct_only_in_b": 57,
+        "discordant_pairs": 86,
+        "p_value": 0.003353274658067905,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 2.5849394142282115e-26,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.8940681995381344,
+        "p_value": 0.3721487560192997,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.2829562811250396,
+        "significant": false,
+        "mde_80_power": 0.05013666745238944,
+        "n_needed_for_observed_diff": 2455
+       },
+       "step_f1": {
+        "t_statistic": -1.3798455074237181,
+        "p_value": 0.1688719601415743,
+        "dof": 249,
+        "mean_difference": -0.02728205128205128,
+        "sd_difference": 0.312619857906695,
+        "significant": false,
+        "mde_80_power": 0.05539271930123693,
+        "n_needed_for_observed_diff": 1031
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.5971311649343702,
+        "p_value": 0.1115047312758243,
+        "dof": 249,
+        "mean_difference": -0.030495238095238096,
+        "sd_difference": 0.30189884302348413,
+        "significant": false,
+        "mde_80_power": 0.053493076162676845,
+        "n_needed_for_observed_diff": 770
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.273644009728532,
+        "p_value": 0.7845850575668304,
+        "dof": 249,
+        "mean_difference": -0.003843657001997783,
+        "sd_difference": 0.222089836405069,
+        "significant": false,
+        "mde_80_power": 0.03935181869129804,
+        "n_needed_for_observed_diff": 26205
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -3.069762339121852,
+        "p_value": 0.0023795127215092988,
+        "dof": 249,
+        "mean_difference": -0.112,
+        "sd_difference": 0.5768770654085474,
+        "significant": true,
+        "mde_80_power": 0.10221612142448815,
+        "n_needed_for_observed_diff": 209
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.010912820512820533,
+       "ordered_step_accuracy": -0.009148571428571423,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.007733333333333337,
+       "_sum": -0.02779472527472529,
+       "_total_delta_composite": -0.027794725274725263,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5244788966279009,
+        "system_b": 0.527144581146914,
+        "difference": -0.0026656845190130563,
+        "ci_low": -0.020419287676454276,
+        "ci_high": 0.015421809745838557,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.16013333333333332,
+        "system_b": 0.15024155844155845,
+        "difference": 0.009891774891774868,
+        "ci_low": -0.013608232323232326,
+        "ci_high": 0.03321613997113994,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.13906666666666667,
+        "system_b": 0.12006666666666665,
+        "difference": 0.019000000000000017,
+        "ci_low": -0.002801666666666662,
+        "ci_high": 0.04040166666666666,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.37550666666666666,
+        "system_b": 0.37118329004329004,
+        "difference": 0.004323376623376618,
+        "ci_low": -0.013550899711399762,
+        "ci_high": 0.02177695238095228,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.024,
+        "system_b": 0.0,
+        "difference": 0.024,
+        "ci_low": 0.008,
+        "ci_high": 0.044,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.452,
+        "system_b": 0.5,
+        "difference": -0.04799999999999999,
+        "ci_low": -0.13199999999999995,
+        "ci_high": 0.03200000000000003,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.21938333333333337,
+        "system_b": 0.21397911255411262,
+        "difference": 0.005404220779220759,
+        "ci_low": -0.016938624639249673,
+        "ci_high": 0.027221190476190416,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.024,
+        "system_b_rate": 0.0,
+        "difference": 0.024,
+        "correct_only_in_a": 6,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 6,
+        "p_value": 0.03125,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 0.03125,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.452,
+        "system_b_rate": 0.5,
+        "difference": -0.048,
+        "correct_only_in_a": 49,
+        "correct_only_in_b": 61,
+        "discordant_pairs": 110,
+        "p_value": 0.2942337084442914,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.5407439555097887e-33,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 2.4744597025759245,
+        "p_value": 0.014010888417100414,
+        "dof": 249,
+        "mean_difference": 0.024,
+        "sd_difference": 0.1533560311469902,
+        "significant": true,
+        "mde_80_power": 0.02717296221474309,
+        "n_needed_for_observed_diff": 321
+       },
+       "step_f1": {
+        "t_statistic": 0.8219810965944488,
+        "p_value": 0.41187403964238456,
+        "dof": 249,
+        "mean_difference": 0.009891774891774893,
+        "sd_difference": 0.1902752927608231,
+        "significant": false,
+        "mde_80_power": 0.0337146397302973,
+        "n_needed_for_observed_diff": 2905
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.6918907454322156,
+        "p_value": 0.0919177959969372,
+        "dof": 249,
+        "mean_difference": 0.019,
+        "sd_difference": 0.17756251609453108,
+        "significant": false,
+        "mde_80_power": 0.03146207882731907,
+        "n_needed_for_observed_diff": 686
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.29076978708806955,
+        "p_value": 0.7714694329611473,
+        "dof": 249,
+        "mean_difference": -0.0026656845190131573,
+        "sd_difference": 0.14495375685264708,
+        "significant": false,
+        "mde_80_power": 0.025684173803811564,
+        "n_needed_for_observed_diff": 23209
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.1448659053441486,
+        "p_value": 0.25336396026988395,
+        "dof": 249,
+        "mean_difference": -0.048,
+        "sd_difference": 0.6629131279896666,
+        "significant": false,
+        "mde_80_power": 0.11746074310735638,
+        "n_needed_for_observed_diff": 1498
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0039567099567099475,
+       "ordered_step_accuracy": 0.0057000000000000045,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.005333333333333335,
+       "_sum": 0.004323376623376617,
+       "_total_delta_composite": 0.004323376623376618,
+       "_residual": -8.673617379884035e-19,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4651391350033641,
+        "system_b": 0.4444704342664301,
+        "difference": 0.020668700736933998,
+        "ci_low": 0.005161257247251569,
+        "ci_high": 0.036610868209606226,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10957108447108448,
+        "system_b": 0.08446315122785711,
+        "difference": 0.025107933243227368,
+        "ci_low": 0.007917913410119312,
+        "ci_high": 0.04207230831260245,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08707161727161727,
+        "system_b": 0.06788903318903318,
+        "difference": 0.019182584082584095,
+        "ci_low": 0.004329349261849264,
+        "ci_high": 0.03409420385170384,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.12288325230325232,
+        "system_b": 0.10521863711451947,
+        "difference": 0.017664615188732857,
+        "ci_low": -0.1865812887798476,
+        "ci_high": 0.22792041738327032,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.284,
+        "system_b": 0.232,
+        "difference": 0.05199999999999996,
+        "ci_low": -0.01999999999999999,
+        "ci_high": 0.12000000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1536040653790654,
+        "system_b": 0.13152329639314936,
+        "difference": 0.022080768985916044,
+        "ci_low": 0.003610030522990063,
+        "ci_high": 0.04010506939547382,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.0,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.284,
+        "system_b_rate": 0.232,
+        "difference": 0.052,
+        "correct_only_in_a": 47,
+        "correct_only_in_b": 34,
+        "discordant_pairs": 81,
+        "p_value": 0.1820767469408432,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.271806125530277e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 2.8621436535060822,
+        "p_value": 0.004565780044448878,
+        "dof": 249,
+        "mean_difference": 0.02510793324322736,
+        "sd_difference": 0.13870417770749421,
+        "significant": true,
+        "mde_80_power": 0.024576818737961463,
+        "n_needed_for_observed_diff": 240
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.527524791644703,
+        "p_value": 0.012106676356476137,
+        "dof": 249,
+        "mean_difference": 0.01918258408258408,
+        "sd_difference": 0.1200001228656283,
+        "significant": true,
+        "mde_80_power": 0.021262670792952652,
+        "n_needed_for_observed_diff": 308
+       },
+       "rouge_l_f1": {
+        "t_statistic": 2.583837159503603,
+        "p_value": 0.010341553555011,
+        "dof": 249,
+        "mean_difference": 0.020668700736934005,
+        "sd_difference": 0.1264788888972958,
+        "significant": true,
+        "mde_80_power": 0.02241063519487384,
+        "n_needed_for_observed_diff": 294
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.447605944299627,
+        "p_value": 0.1489851526540314,
+        "dof": 249,
+        "mean_difference": 0.052,
+        "sd_difference": 0.5679668523615847,
+        "significant": false,
+        "mde_80_power": 0.1006373319850408,
+        "n_needed_for_observed_diff": 937
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.010043173297290948,
+       "ordered_step_accuracy": 0.005754775224775228,
+       "reference_validity_micro": 0.0,
+       "step_count_term": 0.0018666666666666831,
+       "_sum": 0.017664615188732857,
+       "_total_delta_composite": 0.017664615188732857,
+       "_residual": 0.0,
+       "_share_reference_term": 0.0
+      }
+     }
+    }
+   },
+   {
+    "family": "balance_size1000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 1000",
+    "cell_a": "size1000_balanced_trial0__biencoder_only__uniform",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_only__uniform",
+    "fixed": {
+     "size": 1000,
+     "retrieval": "biencoder_only",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5131405987843701,
+       "system_b": 0.5193862670378518,
+       "difference": -0.006245668253481718,
+       "ci_low": -0.018422959222020707,
+       "ci_high": 0.005919895385955514,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.16026169386169387,
+       "system_b": 0.16287219914588333,
+       "difference": -0.0026105052841894627,
+       "ci_low": -0.01854849079770132,
+       "ci_high": 0.013647399958715743,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.14410089540089538,
+       "system_b": 0.14818973544973546,
+       "difference": -0.004088840048840081,
+       "ci_low": -0.019725195767195777,
+       "ci_high": 0.011609629629629591,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.1710682794982795,
+       "system_b": 0.25302802251549616,
+       "difference": -0.08195974301721667,
+       "ci_low": -0.20284265244385244,
+       "ci_high": 0.1597526492011886,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.044,
+       "system_b": 0.032,
+       "difference": 0.011999999999999997,
+       "ci_low": -0.0026666666666666644,
+       "ci_high": 0.02666666666666667,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.43466666666666665,
+       "system_b": 0.444,
+       "difference": -0.00933333333333336,
+       "ci_low": -0.053333333333333344,
+       "ci_high": 0.03466666666666668,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.21383534937284937,
+       "system_b": 0.21906280592214805,
+       "difference": -0.005227456549298681,
+       "ci_low": -0.02100331787948892,
+       "ci_high": 0.01068742465222399,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.044,
+       "system_b_rate": 0.032,
+       "difference": 0.012,
+       "correct_only_in_a": 20,
+       "correct_only_in_b": 11,
+       "discordant_pairs": 31,
+       "p_value": 0.14961278438568115,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 9.313225746154785e-10,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.43466666666666665,
+       "system_b_rate": 0.444,
+       "difference": -0.009333333333333334,
+       "correct_only_in_a": 135,
+       "correct_only_in_b": 142,
+       "discordant_pairs": 277,
+       "p_value": 0.7185404491687314,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 8.236092143148846e-84,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 1.6181909706059945,
+       "p_value": 0.10604244993324252,
+       "dof": 749,
+       "mean_difference": 0.012,
+       "sd_difference": 0.2030869906411788,
+       "significant": false,
+       "mde_80_power": 0.02077579260463305,
+       "n_needed_for_observed_diff": 2249
+      },
+      "step_f1": {
+       "t_statistic": -0.3194664409692767,
+       "p_value": 0.7494619169586625,
+       "dof": 749,
+       "mean_difference": -0.0026105052841894957,
+       "sd_difference": 0.22378448050737967,
+       "significant": false,
+       "mde_80_power": 0.02289314515163314,
+       "n_needed_for_observed_diff": 57680
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.5076173431409997,
+       "p_value": 0.6118711629300964,
+       "dof": 749,
+       "mean_difference": -0.004088840048840049,
+       "sd_difference": 0.22059430780304773,
+       "significant": false,
+       "mde_80_power": 0.022566790586680898,
+       "n_needed_for_observed_diff": 22846
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.9968118833598759,
+       "p_value": 0.3191777485712707,
+       "dof": 749,
+       "mean_difference": -0.006245668253481656,
+       "sd_difference": 0.17159172388652005,
+       "significant": false,
+       "mde_80_power": 0.017553827829555488,
+       "n_needed_for_observed_diff": 5925
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -0.4203583272034541,
+       "p_value": 0.6743442737011798,
+       "dof": 749,
+       "mean_difference": -0.009333333333333334,
+       "sd_difference": 0.6080618454011614,
+       "significant": false,
+       "mde_80_power": 0.06220470720926354,
+       "n_needed_for_observed_diff": 33315
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.001044202113675785,
+      "ordered_step_accuracy": -0.0012266520146520243,
+      "reference_validity_micro": -0.07777777777777778,
+      "step_count_term": -0.001911111111111108,
+      "_sum": -0.0819597430172167,
+      "_total_delta_composite": -0.08195974301721667,
+      "_residual": -2.7755575615628914e-17,
+      "_share_reference_term": 0.948975373939857
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 0.3888888888888889,
+      "step_count_term_a": 0.6373333333333333,
+      "step_count_term_b": 0.6564444444444444
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5836673787198069,
+        "system_b": 0.5917252890778902,
+        "difference": -0.008057910358083342,
+        "ci_low": -0.03468446962313613,
+        "ci_high": 0.018481882668493103,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.25767619047619045,
+        "system_b": 0.27620346320346323,
+        "difference": -0.01852727272727278,
+        "ci_low": -0.05720008658008658,
+        "ci_high": 0.019525238095238047,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.24946666666666664,
+        "system_b": 0.2627866666666666,
+        "difference": -0.01331999999999997,
+        "ci_low": -0.052653333333333274,
+        "ci_high": 0.02566699999999997,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.25857714285714284,
+        "system_b": 0.4674507186147186,
+        "difference": -0.20887357575757576,
+        "ci_low": -0.2358575935064935,
+        "ci_high": 0.013502829004329031,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.112,
+        "system_b": 0.088,
+        "difference": 0.024000000000000007,
+        "ci_low": -0.016,
+        "ci_high": 0.064,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.584,
+        "system_b": 0.648,
+        "difference": -0.06400000000000006,
+        "ci_low": -0.136,
+        "ci_high": 0.008000000000000007,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3232214285714286,
+        "system_b": 0.3343133982683983,
+        "difference": -0.011091969696969683,
+        "ci_low": -0.04771507251082256,
+        "ci_high": 0.02504618290043291,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.112,
+        "system_b_rate": 0.088,
+        "difference": 0.024,
+        "correct_only_in_a": 17,
+        "correct_only_in_b": 11,
+        "discordant_pairs": 28,
+        "p_value": 0.34492845088243484,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 7.450580596923828e-09,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.584,
+        "system_b_rate": 0.648,
+        "difference": -0.064,
+        "correct_only_in_a": 35,
+        "correct_only_in_b": 51,
+        "discordant_pairs": 86,
+        "p_value": 0.10522535125694397,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.5849394142282115e-26,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.134544520671362,
+        "p_value": 0.2576572211193157,
+        "dof": 249,
+        "mean_difference": 0.024,
+        "sd_difference": 0.3344719509073595,
+        "significant": false,
+        "mde_80_power": 0.059264664166913394,
+        "n_needed_for_observed_diff": 1525
+       },
+       "step_f1": {
+        "t_statistic": -0.942060440001915,
+        "p_value": 0.3470747782893853,
+        "dof": 249,
+        "mean_difference": -0.018527272727272732,
+        "sd_difference": 0.3109587143325026,
+        "significant": false,
+        "mde_80_power": 0.055098383361286,
+        "n_needed_for_observed_diff": 2212
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.6671308542578538,
+        "p_value": 0.5053063056164995,
+        "dof": 249,
+        "mean_difference": -0.013320000000000002,
+        "sd_difference": 0.31569172797667033,
+        "significant": false,
+        "mde_80_power": 0.05593702009407652,
+        "n_needed_for_observed_diff": 4409
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.587823983058316,
+        "p_value": 0.5571831614401304,
+        "dof": 249,
+        "mean_difference": -0.008057910358083413,
+        "sd_difference": 0.21674302722757952,
+        "significant": false,
+        "mde_80_power": 0.0384044243002023,
+        "n_needed_for_observed_diff": 5679
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.732213862481695,
+        "p_value": 0.08447381825187156,
+        "dof": 249,
+        "mean_difference": -0.064,
+        "sd_difference": 0.5841823998591714,
+        "significant": false,
+        "mde_80_power": 0.10351054444462095,
+        "n_needed_for_observed_diff": 654
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.007410909090909113,
+       "ordered_step_accuracy": -0.003995999999999991,
+       "reference_validity_micro": -0.2,
+       "step_count_term": 0.002533333333333332,
+       "_sum": -0.20887357575757579,
+       "_total_delta_composite": -0.20887357575757576,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 0.957517001729914
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5035458587859397,
+        "system_b": 0.5112249003003103,
+        "difference": -0.007679041514370599,
+        "ci_low": -0.026458482380564925,
+        "ci_high": 0.011770852902465523,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13755642135642138,
+        "system_b": 0.13114314574314573,
+        "difference": 0.0064132756132756485,
+        "ci_low": -0.014365634920634961,
+        "ci_high": 0.027732027417027395,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11288681318681318,
+        "system_b": 0.10979999999999998,
+        "difference": 0.0030868131868131976,
+        "ci_low": -0.017100714285714275,
+        "ci_high": 0.023405146520146525,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3491552791652792,
+        "system_b": 0.3537972582972583,
+        "difference": -0.004641979131979057,
+        "ci_low": -0.022073312104562055,
+        "ci_high": 0.01240362362637361,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.008,
+        "difference": 0.012,
+        "ci_low": 0.0,
+        "ci_high": 0.027999999999999997,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.416,
+        "system_b": 0.42,
+        "difference": -0.0040000000000000036,
+        "ci_low": -0.08000000000000002,
+        "ci_high": 0.07200000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.186444098956599,
+        "system_b": 0.19224657287157287,
+        "difference": -0.005802473914973877,
+        "ci_low": -0.027591640130702637,
+        "ci_high": 0.015504529532967014,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.02,
+        "system_b_rate": 0.008,
+        "difference": 0.012,
+        "correct_only_in_a": 3,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 3,
+        "p_value": 0.25,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.25,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.416,
+        "system_b_rate": 0.42,
+        "difference": -0.004,
+        "correct_only_in_a": 45,
+        "correct_only_in_b": 46,
+        "discordant_pairs": 91,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.077935669463161e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.7390490211537188,
+        "p_value": 0.0832620199015193,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.10910368672886965,
+        "significant": false,
+        "mde_80_power": 0.019331944983181883,
+        "n_needed_for_observed_diff": 649
+       },
+       "step_f1": {
+        "t_statistic": 0.5886200274835282,
+        "p_value": 0.5566497554563486,
+        "dof": 249,
+        "mean_difference": 0.006413275613275612,
+        "sd_difference": 0.17227207071994896,
+        "significant": false,
+        "mde_80_power": 0.03052467146754662,
+        "n_needed_for_observed_diff": 5664
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.2964136479908709,
+        "p_value": 0.7671612847534123,
+        "dof": 249,
+        "mean_difference": 0.003086813186813187,
+        "sd_difference": 0.16465774177296216,
+        "significant": false,
+        "mde_80_power": 0.02917549810136331,
+        "n_needed_for_observed_diff": 22334
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.7872278193690138,
+        "p_value": 0.43189718069733785,
+        "dof": 249,
+        "mean_difference": -0.007679041514370644,
+        "sd_difference": 0.1542327445431463,
+        "significant": false,
+        "mde_80_power": 0.027328305958375022,
+        "n_needed_for_observed_diff": 3167
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.1046209160135747,
+        "p_value": 0.9167608399568073,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.6045211188474147,
+        "significant": false,
+        "mde_80_power": 0.1071143364730811,
+        "n_needed_for_observed_diff": 179274
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0025653102453102594,
+       "ordered_step_accuracy": 0.0009260439560439593,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.008133333333333326,
+       "_sum": -0.004641979131979107,
+       "_total_delta_composite": -0.004641979131979057,
+       "_residual": -5.0306980803327406e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4522085588473638,
+        "system_b": 0.45520861173535476,
+        "difference": -0.0030000528879909893,
+        "ci_low": -0.020005605978377545,
+        "ci_high": 0.013295307045948626,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.08555246975246976,
+        "system_b": 0.08126998849104111,
+        "difference": 0.004282481261428647,
+        "ci_low": -0.014940472451525076,
+        "ci_high": 0.02374046827441565,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.06994920634920634,
+        "system_b": 0.07198253968253968,
+        "difference": -0.0020333333333333314,
+        "ci_low": -0.019400436507936523,
+        "ci_high": 0.015133730158730164,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.10547241647241647,
+        "system_b": 0.18228053507895614,
+        "difference": -0.07680811860653967,
+        "ci_low": -0.19395894702665756,
+        "ci_high": 0.20067323903581802,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.0,
+        "difference": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.304,
+        "system_b": 0.264,
+        "difference": 0.03999999999999998,
+        "ci_low": -0.03999999999999998,
+        "ci_high": 0.11600000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1318405205905206,
+        "system_b": 0.13062844662647294,
+        "difference": 0.0012120739640476552,
+        "ci_low": -0.019589956467143944,
+        "ci_high": 0.022260368830730657,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.0,
+        "system_b_rate": 0.0,
+        "difference": 0.0,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 0,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.304,
+        "system_b_rate": 0.264,
+        "difference": 0.04,
+        "correct_only_in_a": 55,
+        "correct_only_in_b": 45,
+        "discordant_pairs": 100,
+        "p_value": 0.36820161732669626,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.5777218104420236e-30,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.0,
+        "significant": false,
+        "degenerate_all_zero_differences": true
+       },
+       "step_f1": {
+        "t_statistic": 0.4381397928024302,
+        "p_value": 0.661664802932892,
+        "dof": 249,
+        "mean_difference": 0.004282481261428632,
+        "sd_difference": 0.15454422361965325,
+        "significant": false,
+        "mde_80_power": 0.027383496544055308,
+        "n_needed_for_observed_diff": 10222
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.23045745819798466,
+        "p_value": 0.8179255450262999,
+        "dof": 249,
+        "mean_difference": -0.0020333333333333323,
+        "sd_difference": 0.13950437156500606,
+        "significant": false,
+        "mde_80_power": 0.024718604080813732,
+        "n_needed_for_observed_diff": 36947
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.35567587780170423,
+        "p_value": 0.7223844432614758,
+        "dof": 249,
+        "mean_difference": -0.0030000528879909096,
+        "sd_difference": 0.1333658088602013,
+        "significant": false,
+        "mde_80_power": 0.023630919878354084,
+        "n_needed_for_observed_diff": 15512
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.04,
+        "sd_difference": 0.6324555320336758,
+        "significant": false,
+        "mde_80_power": 0.11206399999999998,
+        "n_needed_for_observed_diff": 1963
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.001712992504571459,
+       "ordered_step_accuracy": -0.0006099999999999994,
+       "reference_validity_micro": -0.07777777777777778,
+       "step_count_term": -0.00013333333333334085,
+       "_sum": -0.07680811860653966,
+       "_total_delta_composite": -0.07680811860653967,
+       "_residual": 1.3877787807814457e-17,
+       "_share_reference_term": 1.0126244359167984
+      }
+     }
+    }
+   },
+   {
+    "family": "balance_size1000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 1000",
+    "cell_a": "size1000_balanced_trial0__biencoder_plus_ce__raw",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__raw",
+    "fixed": {
+     "size": 1000,
+     "retrieval": "biencoder_plus_ce",
+     "mask": "raw"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5316132147257073,
+       "system_b": 0.5302035628451818,
+       "difference": 0.0014096518805255531,
+       "ci_low": -0.010238045091130929,
+       "ci_high": 0.013215621681712966,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1732798460798461,
+       "system_b": 0.17549110149110148,
+       "difference": -0.002211255411255386,
+       "ci_low": -0.01889029100529103,
+       "ci_high": 0.014663864838864858,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.15338015873015873,
+       "system_b": 0.16043398692810457,
+       "difference": -0.007053828197945838,
+       "ci_low": -0.023731067927170866,
+       "ci_high": 0.009515236928104541,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.3644775012025012,
+       "system_b": 0.21960917635741162,
+       "difference": 0.1448683248450896,
+       "ci_low": -0.007943317580567547,
+       "ci_high": 0.19581113906926412,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.03333333333333333,
+       "system_b": 0.034666666666666665,
+       "difference": -0.0013333333333333322,
+       "ci_low": -0.017333333333333333,
+       "ci_high": 0.014666666666666665,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.44533333333333336,
+       "system_b": 0.4786666666666667,
+       "difference": -0.033333333333333326,
+       "ci_low": -0.07866666666666661,
+       "ci_high": 0.011999999999999955,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.22832414923039923,
+       "system_b": 0.23879718473247885,
+       "difference": -0.01047303550207962,
+       "ci_low": -0.026741354891704178,
+       "ci_high": 0.005991905889249627,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.03333333333333333,
+       "system_b_rate": 0.034666666666666665,
+       "difference": -0.0013333333333333333,
+       "correct_only_in_a": 17,
+       "correct_only_in_b": 18,
+       "discordant_pairs": 35,
+       "p_value": 1.0,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.820766091346741e-11,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.44533333333333336,
+       "system_b_rate": 0.4786666666666667,
+       "difference": -0.03333333333333333,
+       "correct_only_in_a": 133,
+       "correct_only_in_b": 158,
+       "discordant_pairs": 291,
+       "p_value": 0.15933879700399592,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 5.026911708464872e-88,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -0.16892134370431341,
+       "p_value": 0.8659041175833334,
+       "dof": 749,
+       "mean_difference": -0.0013333333333333333,
+       "sd_difference": 0.2161647330424276,
+       "significant": false,
+       "mde_80_power": 0.022113645231270324,
+       "n_needed_for_observed_diff": 206303
+      },
+      "step_f1": {
+       "t_statistic": -0.2557209681400207,
+       "p_value": 0.7982365130385037,
+       "dof": 749,
+       "mean_difference": -0.0022112554112554104,
+       "sd_difference": 0.23681172450566906,
+       "significant": false,
+       "mde_80_power": 0.02422583179327336,
+       "n_needed_for_observed_diff": 90021
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.8305326169152476,
+       "p_value": 0.4065023667781911,
+       "dof": 749,
+       "mean_difference": -0.007053828197945847,
+       "sd_difference": 0.23259416560489005,
+       "significant": false,
+       "mde_80_power": 0.023794375653499126,
+       "n_needed_for_observed_diff": 8535
+      },
+      "rouge_l_f1": {
+       "t_statistic": 0.23343700890570776,
+       "p_value": 0.8154858606324116,
+       "dof": 749,
+       "mean_difference": 0.001409651880525472,
+       "sd_difference": 0.16537611941070837,
+       "significant": false,
+       "mde_80_power": 0.016917971691778298,
+       "n_needed_for_observed_diff": 108028
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -1.4666501313185523,
+       "p_value": 0.14289097507283205,
+       "dof": 749,
+       "mean_difference": -0.03333333333333333,
+       "sd_difference": 0.622419014379786,
+       "significant": false,
+       "mde_80_power": 0.06367344513357791,
+       "n_needed_for_observed_diff": 2737
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.0008845021645021545,
+      "ordered_step_accuracy": -0.0021161484593837515,
+      "reference_validity_micro": 0.15324675324675324,
+      "step_count_term": -0.00537777777777777,
+      "_sum": 0.14486832484508957,
+      "_total_delta_composite": 0.1448683248450896,
+      "_residual": -2.7755575615628914e-17,
+      "_share_reference_term": 1.0578347848684166
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.9090909090909091,
+      "ref_micro_b": 0.14285714285714285,
+      "step_count_term_a": 0.6733333333333333,
+      "step_count_term_b": 0.727111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.587109292033726,
+        "system_b": 0.5957691572119477,
+        "difference": -0.008659865178221704,
+        "ci_low": -0.03446751578254038,
+        "ci_high": 0.018124792032366333,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.2533333333333333,
+        "system_b": 0.2812761904761905,
+        "difference": -0.027942857142857214,
+        "ci_low": -0.06522047619047625,
+        "ci_high": 0.011048095238095215,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.23266666666666666,
+        "system_b": 0.26713333333333333,
+        "difference": -0.03446666666666667,
+        "ci_low": -0.07193499999999996,
+        "ci_high": 0.004666666666666652,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4447333333333333,
+        "system_b": 0.4757171428571429,
+        "difference": -0.03098380952380958,
+        "ci_low": -0.05928166666666661,
+        "ci_high": -0.0018832142857143329,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.072,
+        "system_b": 0.096,
+        "difference": -0.024000000000000007,
+        "ci_low": -0.064,
+        "ci_high": 0.016,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.544,
+        "system_b": 0.66,
+        "difference": -0.11599999999999999,
+        "ci_low": -0.18799999999999994,
+        "ci_high": -0.04400000000000004,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.30591666666666667,
+        "system_b": 0.3446464285714287,
+        "difference": -0.03872976190476202,
+        "ci_low": -0.07410208333333333,
+        "ci_high": -0.002354017857142877,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.072,
+        "system_b_rate": 0.096,
+        "difference": -0.024,
+        "correct_only_in_a": 10,
+        "correct_only_in_b": 16,
+        "discordant_pairs": 26,
+        "p_value": 0.32693958282470703,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.9802322387695312e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.544,
+        "system_b_rate": 0.66,
+        "difference": -0.116,
+        "correct_only_in_a": 30,
+        "correct_only_in_b": 59,
+        "discordant_pairs": 89,
+        "p_value": 0.0027852689963042145,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 3.2311742677852644e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.177606651536316,
+        "p_value": 0.24007777583573772,
+        "dof": 249,
+        "mean_difference": -0.024,
+        "sd_difference": 0.32224114794625297,
+        "significant": false,
+        "mde_80_power": 0.05709750357836397,
+        "n_needed_for_observed_diff": 1415
+       },
+       "step_f1": {
+        "t_statistic": -1.4267095438919977,
+        "p_value": 0.15491630805684545,
+        "dof": 249,
+        "mean_difference": -0.027942857142857148,
+        "sd_difference": 0.3096743597266589,
+        "significant": false,
+        "mde_80_power": 0.05487081018458146,
+        "n_needed_for_observed_diff": 965
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.757385231359906,
+        "p_value": 0.08008106339473507,
+        "dof": 249,
+        "mean_difference": -0.034466666666666666,
+        "sd_difference": 0.3101003925477644,
+        "significant": false,
+        "mde_80_power": 0.054946298404141884,
+        "n_needed_for_observed_diff": 636
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.6530795223525891,
+        "p_value": 0.514307560267385,
+        "dof": 249,
+        "mean_difference": -0.008659865178221747,
+        "sd_difference": 0.2096597524181438,
+        "significant": false,
+        "mde_80_power": 0.03714934774850832,
+        "n_needed_for_observed_diff": 4601
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -3.1275155693171492,
+        "p_value": 0.0019725141956895517,
+        "dof": 249,
+        "mean_difference": -0.116,
+        "sd_difference": 0.5864466546198891,
+        "significant": true,
+        "mde_80_power": 0.1039117448969107,
+        "n_needed_for_observed_diff": 201
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.011177142857142885,
+       "ordered_step_accuracy": -0.010340000000000002,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.009466666666666668,
+       "_sum": -0.030983809523809556,
+       "_total_delta_composite": -0.03098380952380958,
+       "_residual": 2.42861286636753e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5284465330807627,
+        "system_b": 0.5271035505673597,
+        "difference": 0.0013429825134030349,
+        "ci_low": -0.015867501202693673,
+        "ci_high": 0.01946035237029502,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.16711111111111113,
+        "system_b": 0.15237806637806636,
+        "difference": 0.014733044733044764,
+        "ci_low": -0.009931277056277032,
+        "ci_high": 0.03933054834054829,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.14267619047619046,
+        "system_b": 0.13369999999999999,
+        "difference": 0.008976190476190471,
+        "ci_low": -0.014334047619047621,
+        "ci_high": 0.03220583333333334,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.37898063492063494,
+        "system_b": 0.37386122655122656,
+        "difference": 0.005119408369408385,
+        "ci_low": -0.012966268759018792,
+        "ci_high": 0.02332486507936502,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.008,
+        "difference": 0.012,
+        "ci_low": -0.008,
+        "ci_high": 0.032,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.468,
+        "system_b": 0.488,
+        "difference": -0.019999999999999962,
+        "ci_low": -0.09999999999999998,
+        "ci_high": 0.06,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2237257936507937,
+        "system_b": 0.21732653318903322,
+        "difference": 0.006399260461760481,
+        "ci_low": -0.016207835948773477,
+        "ci_high": 0.02915608134920628,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.02,
+        "system_b_rate": 0.008,
+        "difference": 0.012,
+        "correct_only_in_a": 5,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 7,
+        "p_value": 0.453125,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.015625,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.468,
+        "system_b_rate": 0.488,
+        "difference": -0.02,
+        "correct_only_in_a": 50,
+        "correct_only_in_b": 55,
+        "discordant_pairs": 105,
+        "p_value": 0.6964676629916758,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.930380657631324e-32,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.134544520671362,
+        "p_value": 0.2576572211193157,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.16723597545367974,
+        "significant": false,
+        "mde_80_power": 0.029632332083456697,
+        "n_needed_for_observed_diff": 1525
+       },
+       "step_f1": {
+        "t_statistic": 1.1695689791590744,
+        "p_value": 0.2432927861688602,
+        "dof": 249,
+        "mean_difference": 0.014733044733044732,
+        "sd_difference": 0.19917584621245327,
+        "significant": false,
+        "mde_80_power": 0.03529171759820086,
+        "n_needed_for_observed_diff": 1435
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.7533999335336706,
+        "p_value": 0.4519213915176306,
+        "dof": 249,
+        "mean_difference": 0.008976190476190478,
+        "sd_difference": 0.18838073480533915,
+        "significant": false,
+        "mde_80_power": 0.03337894538979456,
+        "n_needed_for_observed_diff": 3458
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.14899305687809525,
+        "p_value": 0.8816797093683828,
+        "dof": 249,
+        "mean_difference": 0.0013429825134031255,
+        "sd_difference": 0.1425195136309689,
+        "significant": false,
+        "mde_80_power": 0.025252853309994428,
+        "n_needed_for_observed_diff": 88394
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.48720521629350755,
+        "p_value": 0.6265415367473112,
+        "dof": 249,
+        "mean_difference": -0.02,
+        "sd_difference": 0.6490648200004749,
+        "significant": false,
+        "mde_80_power": 0.11500697883793712,
+        "n_needed_for_observed_diff": 8267
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.005893217893217906,
+       "ordered_step_accuracy": 0.0026928571428571414,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0034666666666666626,
+       "_sum": 0.005119408369408385,
+       "_total_delta_composite": 0.005119408369408385,
+       "_residual": 0.0,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.47928381906263307,
+        "system_b": 0.467737980756238,
+        "difference": 0.011545838306395051,
+        "ci_low": -0.004996366633395588,
+        "ci_high": 0.028143617000950596,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.0993950937950938,
+        "system_b": 0.09281904761904762,
+        "difference": 0.00657604617604618,
+        "ci_low": -0.015241060606060595,
+        "ci_high": 0.028912323232323248,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08479761904761905,
+        "system_b": 0.08046862745098039,
+        "difference": 0.004328991596638659,
+        "ci_low": -0.017223988095238115,
+        "ci_high": 0.02583731092436973,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3060821717171717,
+        "system_b": 0.1521063025210084,
+        "difference": 0.15397586919616332,
+        "ci_low": 0.0005175641817332894,
+        "ci_high": 0.20588224083514525,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.008,
+        "system_b": 0.0,
+        "difference": 0.008,
+        "ci_low": 0.0,
+        "ci_high": 0.02,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.324,
+        "system_b": 0.288,
+        "difference": 0.03600000000000003,
+        "ci_low": -0.03999999999999998,
+        "ci_high": 0.11200000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.1553299873737374,
+        "system_b": 0.1544185924369748,
+        "difference": 0.000911394936762594,
+        "ci_low": -0.02233298014281468,
+        "ci_high": 0.024221830542823196,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.008,
+        "system_b_rate": 0.0,
+        "difference": 0.008,
+        "correct_only_in_a": 2,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.324,
+        "system_b_rate": 0.288,
+        "difference": 0.036,
+        "correct_only_in_a": 53,
+        "correct_only_in_b": 44,
+        "discordant_pairs": 97,
+        "p_value": 0.4167748410890993,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.262177448353619e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.4170619309433985,
+        "p_value": 0.15771479274702108,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.08926293455821276,
+        "significant": false,
+        "mde_80_power": 0.015816387068615163,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": 0.5804299423228282,
+        "p_value": 0.5621496221426978,
+        "dof": 249,
+        "mean_difference": 0.006576046176046176,
+        "sd_difference": 0.17913689834405916,
+        "significant": false,
+        "mde_80_power": 0.0317410416373111,
+        "n_needed_for_observed_diff": 5825
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.39555993954307445,
+        "p_value": 0.6927683842755089,
+        "dof": 249,
+        "mean_difference": 0.004328991596638658,
+        "sd_difference": 0.17303917875152214,
+        "significant": false,
+        "mde_80_power": 0.030660594374527592,
+        "n_needed_for_observed_diff": 12541
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.3685641175066725,
+        "p_value": 0.1723690431030154,
+        "dof": 249,
+        "mean_difference": 0.011545838306395032,
+        "sd_difference": 0.13339216656778707,
+        "significant": false,
+        "mde_80_power": 0.02363559016739938,
+        "n_needed_for_observed_diff": 1048
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.9135090246149062,
+        "p_value": 0.3618585655063664,
+        "dof": 249,
+        "mean_difference": 0.036,
+        "sd_difference": 0.6231027428221206,
+        "significant": false,
+        "mde_80_power": 0.11040679104677369,
+        "n_needed_for_observed_diff": 2352
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.0026304184704184722,
+       "ordered_step_accuracy": 0.0012986974789915978,
+       "reference_validity_micro": 0.15324675324675324,
+       "step_count_term": -0.003200000000000003,
+       "_sum": 0.1539758691961633,
+       "_total_delta_composite": 0.15397586919616332,
+       "_residual": -2.7755575615628914e-17,
+       "_share_reference_term": 0.9952647388631968
+      }
+     }
+    }
+   },
+   {
+    "family": "balance_size1000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 1000",
+    "cell_a": "size1000_balanced_trial0__biencoder_plus_ce__typed",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "fixed": {
+     "size": 1000,
+     "retrieval": "biencoder_plus_ce",
+     "mask": "typed"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5295583400541953,
+       "system_b": 0.5375348919863999,
+       "difference": -0.00797655193220459,
+       "ci_low": -0.020528894064171938,
+       "ci_high": 0.0045255525228463395,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.18273849113849114,
+       "system_b": 0.1817014541014541,
+       "difference": 0.0010370370370370308,
+       "ci_low": -0.015168349243349217,
+       "ci_high": 0.016982781662781634,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1615867724867725,
+       "system_b": 0.16300634920634918,
+       "difference": -0.0014195767195766817,
+       "ci_low": -0.01760351851851854,
+       "ci_high": 0.014544761904761899,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.34041587264587264,
+       "system_b": 0.1950935975135975,
+       "difference": 0.14532227513227514,
+       "ci_low": -0.20107437301587303,
+       "ci_high": 0.20416286375661374,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.037333333333333336,
+       "system_b": 0.032,
+       "difference": 0.005333333333333336,
+       "ci_low": -0.009333333333333332,
+       "ci_high": 0.02,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.456,
+       "system_b": 0.5093333333333333,
+       "difference": -0.05333333333333329,
+       "ci_low": -0.09733333333333333,
+       "ci_high": -0.009333333333333305,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.23801984080734084,
+       "system_b": 0.24386699689199692,
+       "difference": -0.00584715608465608,
+       "ci_low": -0.021382149332149374,
+       "ci_high": 0.009773483345358333,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.037333333333333336,
+       "system_b_rate": 0.032,
+       "difference": 0.005333333333333333,
+       "correct_only_in_a": 18,
+       "correct_only_in_b": 14,
+       "discordant_pairs": 32,
+       "p_value": 0.5966148958541453,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 4.656612873077393e-10,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.456,
+       "system_b_rate": 0.5093333333333333,
+       "difference": -0.05333333333333334,
+       "correct_only_in_a": 126,
+       "correct_only_in_b": 166,
+       "discordant_pairs": 292,
+       "p_value": 0.022309326098402377,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 2.513455854232436e-88,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 0.7068708823372181,
+       "p_value": 0.47986656758341695,
+       "dof": 749,
+       "mean_difference": 0.005333333333333333,
+       "sd_difference": 0.20662804525928338,
+       "significant": false,
+       "mde_80_power": 0.021138042378068326,
+       "n_needed_for_observed_diff": 11782
+      },
+      "step_f1": {
+       "t_statistic": 0.12653820471738267,
+       "p_value": 0.8993398691442105,
+       "dof": 749,
+       "mean_difference": 0.0010370370370370364,
+       "sd_difference": 0.22444153503763017,
+       "significant": false,
+       "mde_80_power": 0.022960361808925273,
+       "n_needed_for_observed_diff": 367647
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -0.17208897117516125,
+       "p_value": 0.8634140690306712,
+       "dof": 749,
+       "mean_difference": -0.001419576719576721,
+       "sd_difference": 0.22591052352504923,
+       "significant": false,
+       "mde_80_power": 0.02311063928389724,
+       "n_needed_for_observed_diff": 198778
+      },
+      "rouge_l_f1": {
+       "t_statistic": -1.2689940185137387,
+       "p_value": 0.20483739987477184,
+       "dof": 749,
+       "mean_difference": -0.007976551932204595,
+       "sd_difference": 0.17214176586493402,
+       "significant": false,
+       "mde_80_power": 0.01761009710623979,
+       "n_needed_for_observed_diff": 3656
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -2.3478542338100707,
+       "p_value": 0.01914118526959019,
+       "dof": 749,
+       "mean_difference": -0.05333333333333334,
+       "sd_difference": 0.6220971752195233,
+       "significant": true,
+       "mde_80_power": 0.06364052099784398,
+       "n_needed_for_observed_diff": 1068
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": 0.0004148148148148123,
+      "ordered_step_accuracy": -0.0004258730158730045,
+      "reference_validity_micro": 0.15000000000000002,
+      "step_count_term": -0.004666666666666664,
+      "_sum": 0.14532227513227516,
+      "_total_delta_composite": 0.14532227513227514,
+      "_residual": 2.7755575615628914e-17,
+      "_share_reference_term": 1.032188629468312
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.75,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6884444444444444,
+      "step_count_term_b": 0.735111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5881507064505829,
+        "system_b": 0.6194803222315687,
+        "difference": -0.03132961578098581,
+        "ci_low": -0.05868777056795879,
+        "ci_high": -0.0053280303961517755,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.2634666666666667,
+        "system_b": 0.2948,
+        "difference": -0.031333333333333324,
+        "ci_low": -0.0668,
+        "ci_high": 0.003333333333333356,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.24333333333333332,
+        "system_b": 0.2843333333333333,
+        "difference": -0.04100000000000001,
+        "ci_low": -0.07700000000000001,
+        "ci_high": -0.00532500000000009,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4543866666666667,
+        "system_b": 0.49108666666666667,
+        "difference": -0.036699999999999955,
+        "ci_low": -0.06355450000000001,
+        "ci_high": -0.010379000000000017,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.072,
+        "system_b": 0.096,
+        "difference": -0.024000000000000007,
+        "ci_low": -0.06000000000000001,
+        "ci_high": 0.012000000000000004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.596,
+        "system_b": 0.724,
+        "difference": -0.128,
+        "ci_low": -0.20399999999999996,
+        "ci_high": -0.052000000000000046,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3179833333333334,
+        "system_b": 0.3638583333333334,
+        "difference": -0.045875,
+        "ci_low": -0.07944312500000002,
+        "ci_high": -0.012973749999999978,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.072,
+        "system_b_rate": 0.096,
+        "difference": -0.024,
+        "correct_only_in_a": 8,
+        "correct_only_in_b": 14,
+        "discordant_pairs": 22,
+        "p_value": 0.28627872467041016,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.76837158203125e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.596,
+        "system_b_rate": 0.724,
+        "difference": -0.128,
+        "correct_only_in_a": 32,
+        "correct_only_in_b": 64,
+        "discordant_pairs": 96,
+        "p_value": 0.001424496094649118,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 2.524354896707238e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.2808420546501695,
+        "p_value": 0.2014408484526573,
+        "dof": 249,
+        "mean_difference": -0.024,
+        "sd_difference": 0.29626862878409255,
+        "significant": false,
+        "mde_80_power": 0.05249546558522745,
+        "n_needed_for_observed_diff": 1197
+       },
+       "step_f1": {
+        "t_statistic": -1.7751044833826708,
+        "p_value": 0.07710221053732441,
+        "dof": 249,
+        "mean_difference": -0.03133333333333334,
+        "sd_difference": 0.2790954024007411,
+        "significant": false,
+        "mde_80_power": 0.049452563208777965,
+        "n_needed_for_observed_diff": 623
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -2.2417331432850736,
+        "p_value": 0.025859868452716237,
+        "dof": 249,
+        "mean_difference": -0.041,
+        "sd_difference": 0.2891811285729293,
+        "significant": true,
+        "mde_80_power": 0.05123964033991755,
+        "n_needed_for_observed_diff": 391
+       },
+       "rouge_l_f1": {
+        "t_statistic": -2.2773282090161833,
+        "p_value": 0.02361521031262678,
+        "dof": 249,
+        "mean_difference": -0.03132961578098576,
+        "sd_difference": 0.21752012664145143,
+        "significant": true,
+        "mde_80_power": 0.03854211756764217,
+        "n_needed_for_observed_diff": 379
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -3.331289995814189,
+        "p_value": 0.000995667767281996,
+        "dof": 249,
+        "mean_difference": -0.128,
+        "sd_difference": 0.6075297272380271,
+        "significant": true,
+        "mde_80_power": 0.10764742800854678,
+        "n_needed_for_observed_diff": 177
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.01253333333333333,
+       "ordered_step_accuracy": -0.012300000000000002,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.011866666666666671,
+       "_sum": -0.0367,
+       "_total_delta_composite": -0.036699999999999955,
+       "_residual": -4.85722573273506e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5295928029533957,
+        "system_b": 0.5202871082354069,
+        "difference": 0.00930569471798881,
+        "ci_low": -0.009521626398192531,
+        "ci_high": 0.028897026711401753,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.17688282828282828,
+        "system_b": 0.14674285714285712,
+        "difference": 0.03013997113997116,
+        "ci_low": 0.005581291486291508,
+        "ci_high": 0.05499468253968249,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.14967142857142857,
+        "system_b": 0.11846666666666665,
+        "difference": 0.031204761904761916,
+        "ci_low": 0.007275952380952368,
+        "ci_high": 0.055800119047619064,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.18805455988455988,
+        "system_b": 0.36383714285714286,
+        "difference": -0.17578258297258298,
+        "ci_low": -0.19354847186147187,
+        "ci_high": 0.0391470216450216,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.036,
+        "system_b": 0.0,
+        "difference": 0.036,
+        "ci_low": 0.016,
+        "ci_high": 0.06,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.456,
+        "system_b": 0.48,
+        "difference": -0.023999999999999966,
+        "ci_low": -0.10000000000000003,
+        "ci_high": 0.05199999999999999,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.23506819985569988,
+        "system_b": 0.20479642857142857,
+        "difference": 0.030271771284271304,
+        "ci_low": 0.005951429473304447,
+        "ci_high": 0.054559126984127015,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.036,
+        "system_b_rate": 0.0,
+        "difference": 0.036,
+        "correct_only_in_a": 9,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 9,
+        "p_value": 0.00390625,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 0.00390625,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.456,
+        "system_b_rate": 0.48,
+        "difference": -0.024,
+        "correct_only_in_a": 45,
+        "correct_only_in_b": 51,
+        "discordant_pairs": 96,
+        "p_value": 0.6100682661051768,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.524354896707238e-29,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 3.049386034388233,
+        "p_value": 0.002540665782091269,
+        "dof": 249,
+        "mean_difference": 0.036,
+        "sd_difference": 0.186663798027298,
+        "significant": true,
+        "mde_80_power": 0.033074723522249626,
+        "n_needed_for_observed_diff": 212
+       },
+       "step_f1": {
+        "t_statistic": 2.3659322421625526,
+        "p_value": 0.018751318067623014,
+        "dof": 249,
+        "mean_difference": 0.030139971139971137,
+        "sd_difference": 0.20142368347567838,
+        "significant": true,
+        "mde_80_power": 0.0356900090547655,
+        "n_needed_for_observed_diff": 351
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.4986189201491924,
+        "p_value": 0.013113218315826574,
+        "dof": 249,
+        "mean_difference": 0.031204761904761905,
+        "sd_difference": 0.19746532907949363,
+        "significant": true,
+        "mde_80_power": 0.03498863321949108,
+        "n_needed_for_observed_diff": 315
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.9635335210038084,
+        "p_value": 0.3362146525390801,
+        "dof": 249,
+        "mean_difference": 0.009305694717988701,
+        "sd_difference": 0.15270454985512769,
+        "significant": false,
+        "mde_80_power": 0.027057527064296188,
+        "n_needed_for_observed_diff": 2114
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.6116053397718632,
+        "p_value": 0.5413568985917622,
+        "dof": 249,
+        "mean_difference": -0.024,
+        "sd_difference": 0.6204545554846758,
+        "significant": false,
+        "mde_80_power": 0.10993756206425666,
+        "n_needed_for_observed_diff": 5246
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.012055988455988466,
+       "ordered_step_accuracy": 0.009361428571428574,
+       "reference_validity_micro": -0.2,
+       "step_count_term": 0.0028000000000000026,
+       "_sum": -0.17578258297258298,
+       "_total_delta_composite": -0.17578258297258298,
+       "_residual": 0.0,
+       "_share_reference_term": 1.1377691499230858
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4709315107586074,
+        "system_b": 0.47283724549222417,
+        "difference": -0.0019057347336167707,
+        "ci_low": -0.018348301644597255,
+        "ci_high": 0.014823876484184706,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10786597846597848,
+        "system_b": 0.10356150516150515,
+        "difference": 0.004304473304473325,
+        "ci_low": -0.01736186091686092,
+        "ci_high": 0.026642910422910414,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.09175555555555555,
+        "system_b": 0.08621904761904761,
+        "difference": 0.005536507936507937,
+        "ci_low": -0.014990714285714274,
+        "ci_high": 0.026783095238095217,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3288063913863914,
+        "system_b": 0.130356983016983,
+        "difference": 0.1984494083694084,
+        "ci_low": -0.010001220945720946,
+        "ci_high": 0.2160736097791098,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.0,
+        "difference": 0.004,
+        "ci_low": 0.0,
+        "ci_high": 0.012,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.316,
+        "system_b": 0.324,
+        "difference": -0.008000000000000007,
+        "ci_low": -0.08400000000000002,
+        "ci_high": 0.07200000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.16100798923298926,
+        "system_b": 0.16294622877122877,
+        "difference": -0.0019382395382395168,
+        "ci_low": -0.02368811688311687,
+        "ci_high": 0.020683178626928644,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.0,
+        "difference": 0.004,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.316,
+        "system_b_rate": 0.324,
+        "difference": -0.008,
+        "correct_only_in_a": 49,
+        "correct_only_in_b": 51,
+        "discordant_pairs": 100,
+        "p_value": 0.9204107626128213,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.5777218104420236e-30,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": 0.004,
+        "sd_difference": 0.06324555320336758,
+        "significant": false,
+        "mde_80_power": 0.0112064,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": 0.3856353730178528,
+        "p_value": 0.7000959849537177,
+        "dof": 249,
+        "mean_difference": 0.004304473304473301,
+        "sd_difference": 0.17648717832864524,
+        "significant": false,
+        "mde_80_power": 0.031271541081513074,
+        "n_needed_for_observed_diff": 13195
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.5212163113630321,
+        "p_value": 0.6026793305594753,
+        "dof": 249,
+        "mean_difference": 0.005536507936507938,
+        "sd_difference": 0.16795306460362777,
+        "significant": false,
+        "mde_80_power": 0.02975939220773354,
+        "n_needed_for_observed_diff": 7223
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.22701312844425664,
+        "p_value": 0.8205998011986089,
+        "dof": 249,
+        "mean_difference": -0.0019057347336167182,
+        "sd_difference": 0.13273378538992495,
+        "significant": false,
+        "mde_80_power": 0.023518932434833266,
+        "n_needed_for_observed_diff": 38076
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.19961556908234188,
+        "p_value": 0.841944167443241,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.6336735505563561,
+        "significant": false,
+        "mde_80_power": 0.11227981916958926,
+        "n_needed_for_observed_diff": 49246
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.00172178932178933,
+       "ordered_step_accuracy": 0.001660952380952381,
+       "reference_validity_micro": 0.2,
+       "step_count_term": -0.004933333333333345,
+       "_sum": 0.1984494083694084,
+       "_total_delta_composite": 0.1984494083694084,
+       "_residual": 0.0,
+       "_share_reference_term": 1.0078135361719256
+      }
+     }
+    }
+   },
+   {
+    "family": "balance_size1000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 1000",
+    "cell_a": "size1000_balanced_trial0__biencoder_plus_ce__uniform",
+    "cell_b": "size1000_imbalanced_trial0__biencoder_plus_ce__uniform",
+    "fixed": {
+     "size": 1000,
+     "retrieval": "biencoder_plus_ce",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5259928206019984,
+       "system_b": 0.5309588431125554,
+       "difference": -0.004966022510557,
+       "ci_low": -0.017484208784542574,
+       "ci_high": 0.007505936857410957,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.1681929107929108,
+       "system_b": 0.17149318089318089,
+       "difference": -0.003300270100270092,
+       "ci_low": -0.019008406963406978,
+       "ci_high": 0.012751222203722193,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1484761090761091,
+       "system_b": 0.15812698412698412,
+       "difference": -0.00965087505087503,
+       "ci_low": -0.025346300366300402,
+       "ci_high": 0.005807486772486767,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.20558398171432654,
+       "system_b": 0.2565242564842565,
+       "difference": -0.05094027476992993,
+       "ci_low": -0.21740118598068597,
+       "ci_high": -0.01691193049543049,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.036,
+       "system_b": 0.03333333333333333,
+       "difference": 0.0026666666666666644,
+       "ci_low": -0.012,
+       "ci_high": 0.017333333333333336,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4226666666666667,
+       "system_b": 0.5333333333333333,
+       "difference": -0.11066666666666664,
+       "ci_low": -0.15466666666666667,
+       "ci_high": -0.06666666666666671,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.22249721852221854,
+       "system_b": 0.23732198727198728,
+       "difference": -0.014824768749768735,
+       "ci_low": -0.030573844350094366,
+       "ci_high": 0.0008580787730787499,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.036,
+       "system_b_rate": 0.03333333333333333,
+       "difference": 0.0026666666666666666,
+       "correct_only_in_a": 17,
+       "correct_only_in_b": 15,
+       "discordant_pairs": 32,
+       "p_value": 0.860050065908581,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 4.656612873077393e-10,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.4226666666666667,
+       "system_b_rate": 0.5333333333333333,
+       "difference": -0.11066666666666666,
+       "correct_only_in_a": 104,
+       "correct_only_in_b": 187,
+       "discordant_pairs": 291,
+       "p_value": 1.3097679288336827e-06,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 5.026911708464872e-88,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": 0.35334705652808196,
+       "p_value": 0.7239276986936486,
+       "dof": 749,
+       "mean_difference": 0.0026666666666666666,
+       "sd_difference": 0.20667973026745215,
+       "significant": false,
+       "mde_80_power": 0.0211433297527401,
+       "n_needed_for_observed_diff": 47149
+      },
+      "step_f1": {
+       "t_statistic": -0.40801884514183334,
+       "p_value": 0.6833764457751178,
+       "dof": 749,
+       "mean_difference": -0.0033002701002700996,
+       "sd_difference": 0.2215133444570937,
+       "significant": false,
+       "mde_80_power": 0.022660808006803344,
+       "n_needed_for_observed_diff": 35361
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -1.2248823097571016,
+       "p_value": 0.22100463798249464,
+       "dof": 749,
+       "mean_difference": -0.009650875050875054,
+       "sd_difference": 0.21577591262936588,
+       "significant": false,
+       "mde_80_power": 0.02207386891553137,
+       "n_needed_for_observed_diff": 3924
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.7891996764112191,
+       "p_value": 0.43024505329044943,
+       "dof": 749,
+       "mean_difference": -0.00496602251055699,
+       "sd_difference": 0.1723266387081753,
+       "significant": false,
+       "mde_80_power": 0.01762900959215178,
+       "n_needed_for_observed_diff": 9452
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -4.940905796716089,
+       "p_value": 9.597837907692935e-07,
+       "dof": 749,
+       "mean_difference": -0.11066666666666666,
+       "sd_difference": 0.6133959256774854,
+       "significant": true,
+       "mde_80_power": 0.06275038344981197,
+       "n_needed_for_observed_diff": 242
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.0013201080401080369,
+      "ordered_step_accuracy": -0.002895262515262509,
+      "reference_validity_micro": -0.03908045977011494,
+      "step_count_term": -0.007644444444444443,
+      "_sum": -0.05094027476992993,
+      "_total_delta_composite": -0.05094027476992993,
+      "_residual": 0.0,
+      "_share_reference_term": 0.7671819586097748
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.13793103448275862,
+      "ref_micro_b": 0.3333333333333333,
+      "step_count_term_a": 0.6617777777777778,
+      "step_count_term_b": 0.7382222222222222
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5810747688488774,
+        "system_b": 0.6176363641175623,
+        "difference": -0.036561595268684854,
+        "ci_low": -0.061499355001173886,
+        "ci_high": -0.01141459933910909,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.2553857142857143,
+        "system_b": 0.28986666666666666,
+        "difference": -0.034480952380952334,
+        "ci_low": -0.07102523809523806,
+        "ci_high": 0.0013144047619048106,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.2375267399267399,
+        "system_b": 0.286,
+        "difference": -0.04847326007326008,
+        "ci_low": -0.08465485347985345,
+        "ci_high": -0.012873095238095175,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4462123076923077,
+        "system_b": 0.4872133333333334,
+        "difference": -0.0410010256410257,
+        "ci_low": -0.0688429761904762,
+        "ci_high": -0.013558979853479926,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.088,
+        "system_b": 0.088,
+        "difference": 0.0,
+        "ci_low": -0.04,
+        "ci_high": 0.04,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.516,
+        "system_b": 0.724,
+        "difference": -0.20799999999999996,
+        "ci_low": -0.276,
+        "ci_high": -0.136,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.30776538461538466,
+        "system_b": 0.35901666666666665,
+        "difference": -0.05125128205128199,
+        "ci_low": -0.08605372023809517,
+        "ci_high": -0.016948724816849853,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.088,
+        "system_b_rate": 0.088,
+        "difference": 0.0,
+        "correct_only_in_a": 13,
+        "correct_only_in_b": 13,
+        "discordant_pairs": 26,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.9802322387695312e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.516,
+        "system_b_rate": 0.724,
+        "difference": -0.208,
+        "correct_only_in_a": 19,
+        "correct_only_in_b": 71,
+        "discordant_pairs": 90,
+        "p_value": 3.1271822773404575e-08,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 1.6155871338926322e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.32313723196612754,
+        "significant": false,
+        "mde_80_power": 0.05725627957844151,
+        "n_needed_for_observed_diff": null
+       },
+       "step_f1": {
+        "t_statistic": -1.8575538529058955,
+        "p_value": 0.0644129271103432,
+        "dof": 249,
+        "mean_difference": -0.03448095238095238,
+        "sd_difference": 0.2934998230200418,
+        "significant": false,
+        "mde_80_power": 0.05200486437545566,
+        "n_needed_for_observed_diff": 569
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -2.607014295677755,
+        "p_value": 0.009684648767984505,
+        "dof": 249,
+        "mean_difference": -0.048473260073260076,
+        "sd_difference": 0.29398747007129833,
+        "significant": true,
+        "mde_80_power": 0.05209126994293689,
+        "n_needed_for_observed_diff": 289
+       },
+       "rouge_l_f1": {
+        "t_statistic": -2.79306225471873,
+        "p_value": 0.0056267475934482815,
+        "dof": 249,
+        "mean_difference": -0.036561595268684806,
+        "sd_difference": 0.20697339585422694,
+        "significant": true,
+        "mde_80_power": 0.03667335560877517,
+        "n_needed_for_observed_diff": 252
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -5.831956750465564,
+        "p_value": 1.6935579453459e-08,
+        "dof": 249,
+        "mean_difference": -0.208,
+        "sd_difference": 0.5639220089059426,
+        "significant": true,
+        "mde_80_power": 0.09992063126213693,
+        "n_needed_for_observed_diff": 58
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.013792380952380934,
+       "ordered_step_accuracy": -0.014541978021978024,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.012666666666666672,
+       "_sum": -0.04100102564102563,
+       "_total_delta_composite": -0.0410010256410257,
+       "_residual": 6.938893903907228e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5241565821328713,
+        "system_b": 0.5160879867754459,
+        "difference": 0.008068595357425434,
+        "ci_low": -0.011024115706954602,
+        "ci_high": 0.027952113843522933,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.162415873015873,
+        "system_b": 0.13702886002886003,
+        "difference": 0.025387012987012986,
+        "ci_low": 0.0026057431457431513,
+        "ci_high": 0.04890502886002883,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.138,
+        "system_b": 0.1158,
+        "difference": 0.02220000000000001,
+        "ci_low": 0.0010000000000000143,
+        "ci_high": 0.04420000000000002,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3787663492063492,
+        "system_b": 0.3622182106782107,
+        "difference": 0.016548138528138523,
+        "ci_low": -0.0012285252525252462,
+        "ci_high": 0.03463724603174604,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.02,
+        "system_b": 0.012,
+        "difference": 0.008,
+        "ci_low": -0.012,
+        "ci_high": 0.028,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.452,
+        "system_b": 0.496,
+        "difference": -0.043999999999999984,
+        "ci_low": -0.11600000000000005,
+        "ci_high": 0.028099999999998567,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.22345793650793655,
+        "system_b": 0.20277276334776337,
+        "difference": 0.02068517316017318,
+        "ci_low": -0.0015356565656565692,
+        "ci_high": 0.043296557539682534,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.02,
+        "system_b_rate": 0.012,
+        "difference": 0.008,
+        "correct_only_in_a": 4,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 6,
+        "p_value": 0.6875,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.03125,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.452,
+        "system_b_rate": 0.496,
+        "difference": -0.044,
+        "correct_only_in_a": 40,
+        "correct_only_in_b": 51,
+        "discordant_pairs": 91,
+        "p_value": 0.29446978456853307,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 8.077935669463161e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.8159506119058424,
+        "p_value": 0.41530824255993326,
+        "dof": 249,
+        "mean_difference": 0.008,
+        "sd_difference": 0.15502299350114557,
+        "significant": false,
+        "mde_80_power": 0.027468329176994783,
+        "n_needed_for_observed_diff": 2948
+       },
+       "step_f1": {
+        "t_statistic": 2.1065979605809626,
+        "p_value": 0.036153232381907686,
+        "dof": 249,
+        "mean_difference": 0.025387012987012986,
+        "sd_difference": 0.19054604990953203,
+        "significant": true,
+        "mde_80_power": 0.03376261484882515,
+        "n_needed_for_observed_diff": 443
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 1.9877247318193731,
+        "p_value": 0.04793746098173049,
+        "dof": 249,
+        "mean_difference": 0.022199999999999994,
+        "sd_difference": 0.1765902565177656,
+        "significant": true,
+        "mde_80_power": 0.03128980537615596,
+        "n_needed_for_observed_diff": 497
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.8062487397871801,
+        "p_value": 0.4208687830713096,
+        "dof": 249,
+        "mean_difference": 0.008068595357425608,
+        "sd_difference": 0.15823366653856943,
+        "significant": false,
+        "mde_80_power": 0.028037224293002257,
+        "n_needed_for_observed_diff": 3019
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.1538774271113161,
+        "p_value": 0.24965673977218616,
+        "dof": 249,
+        "mean_difference": -0.044,
+        "sd_difference": 0.6029245991740233,
+        "significant": false,
+        "mde_80_power": 0.10683145116080685,
+        "n_needed_for_observed_diff": 1474
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.010154805194805196,
+       "ordered_step_accuracy": 0.006660000000000004,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.00026666666666667064,
+       "_sum": 0.01654813852813853,
+       "_total_delta_composite": 0.016548138528138523,
+       "_residual": 6.938893903907228e-18,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.4727471108242462,
+        "system_b": 0.45915217844465805,
+        "difference": 0.013594932379588143,
+        "ci_low": -0.003872807867725933,
+        "ci_high": 0.031050874909840934,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.08677714507714508,
+        "system_b": 0.087584015984016,
+        "difference": -0.0008068709068709129,
+        "ci_low": -0.020024633422133415,
+        "ci_high": 0.018039373681873683,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.0699015873015873,
+        "system_b": 0.07258095238095237,
+        "difference": -0.002679365079365073,
+        "ci_low": -0.020232857142857143,
+        "ci_high": 0.01445396825396824,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.1366008744512193,
+        "system_b": 0.18680789210789212,
+        "difference": -0.05020701765667282,
+        "ci_low": -0.21859195415695418,
+        "ci_high": -0.013917766855749627,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.0,
+        "system_b": 0.0,
+        "difference": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.3,
+        "system_b": 0.38,
+        "difference": -0.08000000000000002,
+        "ci_low": -0.16399999999999998,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.13626833444333447,
+        "system_b": 0.15017653180153184,
+        "difference": -0.013908197358197372,
+        "ci_low": -0.03515411255411257,
+        "ci_high": 0.007058282134532132,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.0,
+        "system_b_rate": 0.0,
+        "difference": 0.0,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 0,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.3,
+        "system_b_rate": 0.38,
+        "difference": -0.08,
+        "correct_only_in_a": 45,
+        "correct_only_in_b": 65,
+        "discordant_pairs": 110,
+        "p_value": 0.06956519633623019,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.5407439555097887e-33,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 0.0,
+        "p_value": 1.0,
+        "dof": 249,
+        "mean_difference": 0.0,
+        "sd_difference": 0.0,
+        "significant": false,
+        "degenerate_all_zero_differences": true
+       },
+       "step_f1": {
+        "t_statistic": -0.08350711428190428,
+        "p_value": 0.9335154154029807,
+        "dof": 249,
+        "mean_difference": -0.0008068709068709054,
+        "sd_difference": 0.1527743992460399,
+        "significant": false,
+        "mde_80_power": 0.02706990358999123,
+        "n_needed_for_observed_diff": 281388
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.30062844972853664,
+        "p_value": 0.7639486925192726,
+        "dof": 249,
+        "mean_difference": -0.0026793650793650796,
+        "sd_difference": 0.14091973566644103,
+        "significant": false,
+        "mde_80_power": 0.024969390665213094,
+        "n_needed_for_observed_diff": 21712
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.5225008549536785,
+        "p_value": 0.1291525683070296,
+        "dof": 249,
+        "mean_difference": 0.013594932379588228,
+        "sd_difference": 0.14118530973429103,
+        "significant": false,
+        "mde_80_power": 0.025016447400164635,
+        "n_needed_for_observed_diff": 847
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.917101132639467,
+        "p_value": 0.0563694390519833,
+        "dof": 249,
+        "mean_difference": -0.08,
+        "sd_difference": 0.65980403565138,
+        "significant": false,
+        "mde_80_power": 0.11690984694762574,
+        "n_needed_for_observed_diff": 534
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.0003227483627483652,
+       "ordered_step_accuracy": -0.0008038095238095219,
+       "reference_validity_micro": -0.03908045977011494,
+       "step_count_term": -0.009999999999999988,
+       "_sum": -0.05020701765667282,
+       "_total_delta_composite": -0.05020701765667282,
+       "_residual": 0.0,
+       "_share_reference_term": 0.7783864008285883
+      }
+     }
+    }
+   },
+   {
+    "family": "balance_size2000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 2000",
+    "cell_a": "size2000_balanced_trial0__biencoder_only__raw",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_only__raw",
+    "fixed": {
+     "size": 2000,
+     "retrieval": "biencoder_only",
+     "mask": "raw"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.519834172694174,
+       "system_b": 0.5233271649996762,
+       "difference": -0.0034929923055022627,
+       "ci_low": -0.015443480058274244,
+       "ci_high": 0.008857678291531893,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.16260299781631052,
+       "system_b": 0.17804892884892884,
+       "difference": -0.01544593103261832,
+       "ci_low": -0.031508546102733424,
+       "ci_high": 0.0010811242214957082,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.14760017259429023,
+       "system_b": 0.1595999185999186,
+       "difference": -0.011999746005628364,
+       "ci_low": -0.0279692092493563,
+       "ci_high": 0.004312475949975954,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.17438791757147798,
+       "system_b": 0.38861065823065827,
+       "difference": -0.2142227406591803,
+       "ci_low": -0.2256337190565426,
+       "ci_high": -0.004471088431749429,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.037333333333333336,
+       "system_b": 0.04666666666666667,
+       "difference": -0.009333333333333332,
+       "ci_low": -0.024000000000000004,
+       "ci_high": 0.005333333333333336,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.43733333333333335,
+       "system_b": 0.47333333333333333,
+       "difference": -0.035999999999999976,
+       "ci_low": -0.07999999999999996,
+       "ci_high": 0.008000000000000007,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.21798489696434747,
+       "system_b": 0.2357633227883228,
+       "difference": -0.01777842582397532,
+       "ci_low": -0.033664414335091576,
+       "ci_high": -0.0016369651230119743,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.037333333333333336,
+       "system_b_rate": 0.04666666666666667,
+       "difference": -0.009333333333333334,
+       "correct_only_in_a": 13,
+       "correct_only_in_b": 20,
+       "discordant_pairs": 33,
+       "p_value": 0.296206368599087,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 2.3283064365386963e-10,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.43733333333333335,
+       "system_b_rate": 0.47333333333333333,
+       "difference": -0.036,
+       "correct_only_in_a": 130,
+       "correct_only_in_b": 157,
+       "discordant_pairs": 287,
+       "p_value": 0.12470144137133113,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 8.043058733543795e-87,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -1.2189381818128977,
+       "p_value": 0.2232514098912033,
+       "dof": 749,
+       "mean_difference": -0.009333333333333334,
+       "sd_difference": 0.20969386633612874,
+       "significant": false,
+       "mde_80_power": 0.021451675775531927,
+       "n_needed_for_observed_diff": 3962
+      },
+      "step_f1": {
+       "t_statistic": -1.8843042689737093,
+       "p_value": 0.05991086328519107,
+       "dof": 749,
+       "mean_difference": -0.01544593103261834,
+       "sd_difference": 0.22448828959141331,
+       "significant": false,
+       "mde_80_power": 0.022965144798272125,
+       "n_needed_for_observed_diff": 1658
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -1.4671943872704571,
+       "p_value": 0.1427429365926951,
+       "dof": 749,
+       "mean_difference": -0.011999746005628358,
+       "sd_difference": 0.22398298509860673,
+       "significant": false,
+       "mde_80_power": 0.02291345216492523,
+       "n_needed_for_observed_diff": 2735
+      },
+      "rouge_l_f1": {
+       "t_statistic": -0.5636459275265524,
+       "p_value": 0.5731638325343216,
+       "dof": 749,
+       "mean_difference": -0.0034929923055021608,
+       "sd_difference": 0.16971564820056143,
+       "significant": false,
+       "mde_80_power": 0.01736190534727824,
+       "n_needed_for_observed_diff": 18530
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -1.5954006572092754,
+       "p_value": 0.11104449820110676,
+       "dof": 749,
+       "mean_difference": -0.036,
+       "sd_difference": 0.6179642706389924,
+       "significant": false,
+       "mde_80_power": 0.06321772499230585,
+       "n_needed_for_observed_diff": 2313
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.006178372413047329,
+      "ordered_step_accuracy": -0.003599923801688509,
+      "reference_validity_micro": -0.2,
+      "step_count_term": -0.00444444444444444,
+      "_sum": -0.2142227406591803,
+      "_total_delta_composite": -0.2142227406591803,
+      "_residual": 0.0,
+      "_share_reference_term": 0.9336076990920021
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.0,
+      "ref_micro_b": 1.0,
+      "step_count_term_a": 0.6506666666666667,
+      "step_count_term_b": 0.6951111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5645599680995477,
+        "system_b": 0.5905492351780087,
+        "difference": -0.025989267078461054,
+        "ci_low": -0.05161301328470346,
+        "ci_high": -0.00025569413021884487,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.2362745324850588,
+        "system_b": 0.30019740259740263,
+        "difference": -0.06392287011234382,
+        "ci_low": -0.0976488639430745,
+        "ci_high": -0.029390845295055836,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.22721797810033104,
+        "system_b": 0.28255555555555556,
+        "difference": -0.055337577455224524,
+        "ci_low": -0.09090988243782357,
+        "ci_high": -0.019380625583566798,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.43587520642412286,
+        "system_b": 0.48471229437229435,
+        "difference": -0.04883708794817149,
+        "ci_low": -0.0759693638750311,
+        "ci_high": -0.02119366115927419,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.084,
+        "system_b": 0.12,
+        "difference": -0.03599999999999999,
+        "ci_low": -0.076,
+        "ci_high": 0.00399999999999999,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.552,
+        "system_b": 0.664,
+        "difference": -0.11199999999999999,
+        "ci_low": -0.18400000000000005,
+        "ci_high": -0.040000000000000036,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2948440080301536,
+        "system_b": 0.355890367965368,
+        "difference": -0.0610463599352144,
+        "ci_low": -0.09496170484378887,
+        "ci_high": -0.026492076449092697,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.084,
+        "system_b_rate": 0.12,
+        "difference": -0.036,
+        "correct_only_in_a": 8,
+        "correct_only_in_b": 17,
+        "discordant_pairs": 25,
+        "p_value": 0.10775214433670044,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.960464477539063e-08,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.552,
+        "system_b_rate": 0.664,
+        "difference": -0.112,
+        "correct_only_in_a": 30,
+        "correct_only_in_b": 58,
+        "discordant_pairs": 88,
+        "p_value": 0.0037465093469812296,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 6.462348535570529e-27,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.8081514245214716,
+        "p_value": 0.07178940333279377,
+        "dof": 249,
+        "mean_difference": -0.036,
+        "sd_difference": 0.3148021626457253,
+        "significant": false,
+        "mde_80_power": 0.055779399132288944,
+        "n_needed_for_observed_diff": 601
+       },
+       "step_f1": {
+        "t_statistic": -3.6497405152798676,
+        "p_value": 0.00031981830112928734,
+        "dof": 249,
+        "mean_difference": -0.0639228701123438,
+        "sd_difference": 0.27692635035810104,
+        "significant": true,
+        "mde_80_power": 0.049068231606325514,
+        "n_needed_for_observed_diff": 148
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -3.0201449465928905,
+        "p_value": 0.0027895200529822486,
+        "dof": 249,
+        "mean_difference": -0.05533757745522451,
+        "sd_difference": 0.2897092491403568,
+        "significant": true,
+        "mde_80_power": 0.05133321735880753,
+        "n_needed_for_observed_diff": 216
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.9622253231237512,
+        "p_value": 0.05084998448843017,
+        "dof": 249,
+        "mean_difference": -0.02598926707846108,
+        "sd_difference": 0.20941855585558516,
+        "significant": false,
+        "mde_80_power": 0.037106610433048914,
+        "n_needed_for_observed_diff": 510
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -3.0333739410206824,
+        "p_value": 0.002674284386292605,
+        "dof": 249,
+        "mean_difference": -0.112,
+        "sd_difference": 0.5837972911109076,
+        "significant": true,
+        "mde_80_power": 0.1034423075100389,
+        "n_needed_for_observed_diff": 214
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.02556914804493753,
+       "ordered_step_accuracy": -0.016601273236567356,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.006666666666666665,
+       "_sum": -0.04883708794817155,
+       "_total_delta_composite": -0.04883708794817149,
+       "_residual": -6.245004513516506e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5197125765838334,
+        "system_b": 0.5059093683799802,
+        "difference": 0.013803208203853168,
+        "ci_low": -0.005383503589446034,
+        "ci_high": 0.03353611226546048,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.1529126050420168,
+        "system_b": 0.12465079365079365,
+        "difference": 0.028261811391223163,
+        "ci_low": 0.004377497665732955,
+        "ci_high": 0.0525770868347339,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.1263047619047619,
+        "system_b": 0.10033333333333334,
+        "difference": 0.025971428571428548,
+        "ci_low": 0.004200000000000009,
+        "ci_high": 0.04906690476190473,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.36798980392156866,
+        "system_b": 0.3500936507936508,
+        "difference": 0.01789615312791787,
+        "ci_low": 0.0001228267973856434,
+        "ci_high": 0.03625876097105504,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.024,
+        "system_b": 0.008,
+        "difference": 0.016,
+        "ci_low": 0.0,
+        "ci_high": 0.036000000000000004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.432,
+        "system_b": 0.44,
+        "difference": -0.008000000000000007,
+        "ci_low": -0.09199999999999997,
+        "ci_high": 0.07200000000000001,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.2099872549019608,
+        "system_b": 0.18761706349206353,
+        "difference": 0.022370191409897267,
+        "ci_low": 0.00015353349673205322,
+        "ci_high": 0.04532345121381889,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.024,
+        "system_b_rate": 0.008,
+        "difference": 0.016,
+        "correct_only_in_a": 5,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 6,
+        "p_value": 0.21875,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.03125,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.432,
+        "system_b_rate": 0.44,
+        "difference": -0.008,
+        "correct_only_in_a": 52,
+        "correct_only_in_b": 54,
+        "discordant_pairs": 106,
+        "p_value": 0.9226851594412759,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.465190328815662e-32,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.6384859226122093,
+        "p_value": 0.1025832998165287,
+        "dof": 249,
+        "mean_difference": 0.016,
+        "sd_difference": 0.15439999167655055,
+        "significant": false,
+        "mde_80_power": 0.0273579402675217,
+        "n_needed_for_observed_diff": 731
+       },
+       "step_f1": {
+        "t_statistic": 2.2959101229917906,
+        "p_value": 0.022512447756325663,
+        "dof": 249,
+        "mean_difference": 0.028261811391223156,
+        "sd_difference": 0.19463238979472183,
+        "significant": true,
+        "mde_80_power": 0.03448666827187202,
+        "n_needed_for_observed_diff": 373
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 2.2840873573176386,
+        "p_value": 0.023208741885838276,
+        "dof": 249,
+        "mean_difference": 0.025971428571428576,
+        "sd_difference": 0.1797848670519698,
+        "significant": true,
+        "mde_80_power": 0.03185585439742691,
+        "n_needed_for_observed_diff": 377
+       },
+       "rouge_l_f1": {
+        "t_statistic": 1.3985151863372314,
+        "p_value": 0.16320264851263858,
+        "dof": 249,
+        "mean_difference": 0.013803208203853178,
+        "sd_difference": 0.15605685718729245,
+        "significant": false,
+        "mde_80_power": 0.02765151818279226,
+        "n_needed_for_observed_diff": 1004
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.1938829020572596,
+        "p_value": 0.8464256451314969,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.6524098054266716,
+        "significant": false,
+        "mde_80_power": 0.11559967259712674,
+        "n_needed_for_observed_diff": 52201
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.011304724556489266,
+       "ordered_step_accuracy": 0.007791428571428564,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0012000000000000012,
+       "_sum": 0.01789615312791783,
+       "_total_delta_composite": 0.01789615312791787,
+       "_residual": -3.8163916471489756e-17,
+       "_share_reference_term": 0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.475229973399141,
+        "system_b": 0.47352289144103965,
+        "difference": 0.0017070819581013752,
+        "ci_low": -0.014430360202271834,
+        "ci_high": 0.018038946764938942,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.09862185592185592,
+        "system_b": 0.10929859029859029,
+        "difference": -0.010676734376734373,
+        "ci_low": -0.0333913295038295,
+        "ci_high": 0.010994134199134177,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08927777777777778,
+        "system_b": 0.09591086691086691,
+        "difference": -0.006633089133089132,
+        "ci_low": -0.028896660561660573,
+        "ci_high": 0.014418015873015848,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.11929874236874237,
+        "system_b": 0.33102602952602955,
+        "difference": -0.21172728715728717,
+        "ci_low": -0.22892116563991563,
+        "ci_high": 0.0024009228271727957,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.012,
+        "difference": -0.008,
+        "ci_low": -0.02,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.328,
+        "system_b": 0.316,
+        "difference": 0.01200000000000001,
+        "ci_low": -0.064,
+        "ci_high": 0.08800000000000002,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14912342796092798,
+        "system_b": 0.1637825369075369,
+        "difference": -0.014659108946608934,
+        "ci_low": -0.038571179653679635,
+        "ci_high": 0.008938014971139973,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.012,
+        "difference": -0.008,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 2,
+        "discordant_pairs": 2,
+        "p_value": 0.5,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.5,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.328,
+        "system_b_rate": 0.316,
+        "difference": 0.012,
+        "correct_only_in_a": 48,
+        "correct_only_in_b": 45,
+        "discordant_pairs": 93,
+        "p_value": 0.8358461346314852,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.0194839173657902e-28,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.4170619309433983,
+        "p_value": 0.15771479274702116,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.08926293455821277,
+        "significant": false,
+        "mde_80_power": 0.015816387068615167,
+        "n_needed_for_observed_diff": 978
+       },
+       "step_f1": {
+        "t_statistic": -0.9332658885258251,
+        "p_value": 0.35158678708137975,
+        "dof": 249,
+        "mean_difference": -0.010676734376734377,
+        "sd_difference": 0.18088520655367663,
+        "significant": false,
+        "mde_80_power": 0.0320508221693472,
+        "n_needed_for_observed_diff": 2253
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -0.5928849818684521,
+        "p_value": 0.5537962071337629,
+        "dof": 249,
+        "mean_difference": -0.006633089133089131,
+        "sd_difference": 0.1768949309305277,
+        "significant": false,
+        "mde_80_power": 0.03134379025202854,
+        "n_needed_for_observed_diff": 5583
+       },
+       "rouge_l_f1": {
+        "t_statistic": 0.20347763677753938,
+        "p_value": 0.838927911445607,
+        "dof": 249,
+        "mean_difference": 0.0017070819581014175,
+        "sd_difference": 0.13265013358894304,
+        "significant": false,
+        "mde_80_power": 0.023504110277463415,
+        "n_needed_for_observed_diff": 47394
+       },
+       "hop_count_exact_match": {
+        "t_statistic": 0.31052282099234096,
+        "p_value": 0.7564231717553511,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.611023238175408,
+        "significant": false,
+        "mde_80_power": 0.10826643881619644,
+        "n_needed_for_observed_diff": 20351
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.004270693750693749,
+       "ordered_step_accuracy": -0.0019899267399267396,
+       "reference_validity_micro": -0.2,
+       "step_count_term": -0.005466666666666665,
+       "_sum": -0.21172728715728717,
+       "_total_delta_composite": -0.21172728715728717,
+       "_residual": 0.0,
+       "_share_reference_term": 0.9446113568319834
+      }
+     }
+    }
+   },
+   {
+    "family": "balance_size2000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 2000",
+    "cell_a": "size2000_balanced_trial0__biencoder_only__typed",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_only__typed",
+    "fixed": {
+     "size": 2000,
+     "retrieval": "biencoder_only",
+     "mask": "typed"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5173918350863802,
+       "system_b": 0.5310403311127952,
+       "difference": -0.013648496026415047,
+       "ci_low": -0.02505996042177677,
+       "ci_high": -0.0022616216402400195,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.16549053539053538,
+       "system_b": 0.1912138454138454,
+       "difference": -0.02572331002331002,
+       "ci_low": -0.04200493413993416,
+       "ci_high": -0.009628971213971195,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.1437026455026455,
+       "system_b": 0.17263756613756615,
+       "difference": -0.028934920634920647,
+       "ci_low": -0.045100343915343906,
+       "ci_high": -0.013013902116402127,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.31718637288637286,
+       "system_b": 0.22216569689569687,
+       "difference": 0.09502067599067598,
+       "ci_low": -0.17712222101972103,
+       "ci_high": 0.18056918535168542,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.030666666666666665,
+       "system_b": 0.050666666666666665,
+       "difference": -0.02,
+       "ci_low": -0.036,
+       "ci_high": -0.005333333333333329,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4226666666666667,
+       "system_b": 0.468,
+       "difference": -0.04533333333333334,
+       "ci_low": -0.08666666666666673,
+       "ci_high": -0.0040000000000000036,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.21791153753653758,
+       "system_b": 0.24645712111962115,
+       "difference": -0.028545583583083567,
+       "ci_low": -0.04410620860620866,
+       "ci_high": -0.01273388577857327,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.030666666666666665,
+       "system_b_rate": 0.050666666666666665,
+       "difference": -0.02,
+       "correct_only_in_a": 10,
+       "correct_only_in_b": 25,
+       "discordant_pairs": 35,
+       "p_value": 0.01667384780012071,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 5.820766091346741e-11,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.4226666666666667,
+       "system_b_rate": 0.468,
+       "difference": -0.04533333333333334,
+       "correct_only_in_a": 111,
+       "correct_only_in_b": 145,
+       "discordant_pairs": 256,
+       "p_value": 0.038951834162314077,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 1.727233711018889e-77,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -2.5447012246561624,
+       "p_value": 0.011136699797847222,
+       "dof": 749,
+       "mean_difference": -0.02,
+       "sd_difference": 0.21524041887439022,
+       "significant": true,
+       "mde_80_power": 0.022019087921636454,
+       "n_needed_for_observed_diff": 910
+      },
+      "step_f1": {
+       "t_statistic": -3.1552293937116525,
+       "p_value": 0.001667857382857578,
+       "dof": 749,
+       "mean_difference": -0.025723310023310023,
+       "sd_difference": 0.22326803213651247,
+       "significant": true,
+       "mde_80_power": 0.0228403124999194,
+       "n_needed_for_observed_diff": 592
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -3.5682354339969384,
+       "p_value": 0.00038227825580020497,
+       "dof": 749,
+       "mean_difference": -0.02893492063492064,
+       "sd_difference": 0.22207487460567232,
+       "significant": true,
+       "mde_80_power": 0.022718252522925655,
+       "n_needed_for_observed_diff": 463
+      },
+      "rouge_l_f1": {
+       "t_statistic": -2.3312704296377365,
+       "p_value": 0.020003519011408115,
+       "dof": 749,
+       "mean_difference": -0.013648496026415005,
+       "sd_difference": 0.16033294667682077,
+       "significant": true,
+       "mde_80_power": 0.016402055283455962,
+       "n_needed_for_observed_diff": 1084
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -2.1300047434407583,
+       "p_value": 0.03349656878462926,
+       "dof": 749,
+       "mean_difference": -0.04533333333333334,
+       "sd_difference": 0.5828646473682872,
+       "significant": true,
+       "mde_80_power": 0.05962703466167144,
+       "n_needed_for_observed_diff": 1298
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.01028932400932401,
+      "ordered_step_accuracy": -0.008680476190476193,
+      "reference_validity_micro": 0.11785714285714287,
+      "step_count_term": -0.003866666666666663,
+      "_sum": 0.095020675990676,
+      "_total_delta_composite": 0.09502067599067598,
+      "_residual": 1.3877787807814457e-17,
+      "_share_reference_term": 1.2403315555101686
+     },
+     "reference_terms": {
+      "ref_micro_a": 0.7142857142857143,
+      "ref_micro_b": 0.125,
+      "step_count_term_a": 0.6502222222222223,
+      "step_count_term_b": 0.6888888888888889
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5819558117386785,
+        "system_b": 0.6067046545547155,
+        "difference": -0.024748842816036953,
+        "ci_low": -0.048531493177146987,
+        "ci_high": -0.000902845351240548,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.25376507936507936,
+        "system_b": 0.29893333333333333,
+        "difference": -0.04516825396825397,
+        "ci_low": -0.08166722222222228,
+        "ci_high": -0.009488333333333307,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.23537142857142856,
+        "system_b": 0.2848333333333333,
+        "difference": -0.04946190476190476,
+        "ci_low": -0.08815273809523808,
+        "ci_high": -0.01232773809523809,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.4498507936507936,
+        "system_b": 0.4835566666666667,
+        "difference": -0.03370587301587308,
+        "ci_low": -0.06221342063492063,
+        "ci_high": -0.005498345238095276,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.084,
+        "system_b": 0.116,
+        "difference": -0.032,
+        "ci_low": -0.072,
+        "ci_high": 0.0040000000000000036,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.58,
+        "system_b": 0.692,
+        "difference": -0.11199999999999999,
+        "ci_low": -0.18399999999999994,
+        "ci_high": -0.040000000000000036,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3123134920634921,
+        "system_b": 0.3544458333333334,
+        "difference": -0.04213234126984128,
+        "ci_low": -0.07776677579365072,
+        "ci_high": -0.006872931547619065,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.084,
+        "system_b_rate": 0.116,
+        "difference": -0.032,
+        "correct_only_in_a": 8,
+        "correct_only_in_b": 16,
+        "discordant_pairs": 24,
+        "p_value": 0.15158963203430176,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.1920928955078125e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.58,
+        "system_b_rate": 0.692,
+        "difference": -0.112,
+        "correct_only_in_a": 29,
+        "correct_only_in_b": 57,
+        "discordant_pairs": 86,
+        "p_value": 0.003353274658067905,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 2.5849394142282115e-26,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.6384859226122093,
+        "p_value": 0.1025832998165287,
+        "dof": 249,
+        "mean_difference": -0.032,
+        "sd_difference": 0.30879998335310105,
+        "significant": false,
+        "mde_80_power": 0.05471588053504339,
+        "n_needed_for_observed_diff": 731
+       },
+       "step_f1": {
+        "t_statistic": -2.428674366388954,
+        "p_value": 0.015862895071808766,
+        "dof": 249,
+        "mean_difference": -0.04516825396825397,
+        "sd_difference": 0.29405868989549466,
+        "significant": true,
+        "mde_80_power": 0.05210388929398134,
+        "n_needed_for_observed_diff": 333
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -2.5617998376385827,
+        "p_value": 0.011002860954391718,
+        "dof": 249,
+        "mean_difference": -0.04946190476190476,
+        "sd_difference": 0.3052780981556412,
+        "significant": true,
+        "mde_80_power": 0.054091842127949305,
+        "n_needed_for_observed_diff": 299
+       },
+       "rouge_l_f1": {
+        "t_statistic": -2.0066811590197906,
+        "p_value": 0.04586478262272142,
+        "dof": 249,
+        "mean_difference": -0.024748842816037113,
+        "sd_difference": 0.19500535100055968,
+        "significant": true,
+        "mde_80_power": 0.034552752798694984,
+        "n_needed_for_observed_diff": 488
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -3.069762339121852,
+        "p_value": 0.0023795127215092988,
+        "dof": 249,
+        "mean_difference": -0.112,
+        "sd_difference": 0.5768770654085474,
+        "significant": true,
+        "mde_80_power": 0.10221612142448815,
+        "n_needed_for_observed_diff": 209
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.018067301587301587,
+       "ordered_step_accuracy": -0.014838571428571428,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0008000000000000008,
+       "_sum": -0.033705873015873015,
+       "_total_delta_composite": -0.03370587301587308,
+       "_residual": 6.245004513516506e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5086571217607104,
+        "system_b": 0.5162698827976191,
+        "difference": -0.007612761036908666,
+        "ci_low": -0.026181369113090183,
+        "ci_high": 0.011237070508603507,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13869206349206348,
+        "system_b": 0.15734236874236876,
+        "difference": -0.018650305250305282,
+        "ci_low": -0.042127619047619046,
+        "ci_high": 0.004781123321123323,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11366666666666665,
+        "system_b": 0.12926666666666664,
+        "difference": -0.015599999999999989,
+        "ci_low": -0.03773333333333334,
+        "ci_high": 0.006333333333333316,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3555768253968254,
+        "system_b": 0.36878361416361416,
+        "difference": -0.013206788766788768,
+        "ci_low": -0.03177838095238093,
+        "ci_high": 0.005380428571428557,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.016,
+        "difference": -0.012,
+        "ci_low": -0.032,
+        "ci_high": 0.004,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.416,
+        "system_b": 0.428,
+        "difference": -0.01200000000000001,
+        "ci_low": -0.08400000000000002,
+        "ci_high": 0.06,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19447103174603175,
+        "system_b": 0.21097951770451773,
+        "difference": -0.016508485958485974,
+        "ci_low": -0.03972297619047623,
+        "ci_high": 0.006725535714285722,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.016,
+        "difference": -0.012,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 4,
+        "discordant_pairs": 5,
+        "p_value": 0.375,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.0625,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.416,
+        "system_b_rate": 0.428,
+        "difference": -0.012,
+        "correct_only_in_a": 41,
+        "correct_only_in_b": 44,
+        "discordant_pairs": 85,
+        "p_value": 0.8284232741649004,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.169878828456423e-26,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.3438012400514816,
+        "p_value": 0.18023588114803066,
+        "dof": 249,
+        "mean_difference": -0.012,
+        "sd_difference": 0.14119399056577286,
+        "significant": false,
+        "mde_80_power": 0.025017985545773152,
+        "n_needed_for_observed_diff": 1087
+       },
+       "step_f1": {
+        "t_statistic": -1.569324466257532,
+        "p_value": 0.11784222229098434,
+        "dof": 249,
+        "mean_difference": -0.01865030525030525,
+        "sd_difference": 0.18790710562554533,
+        "significant": false,
+        "mde_80_power": 0.03329502363132128,
+        "n_needed_for_observed_diff": 797
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.3869522819745135,
+        "p_value": 0.16669661112187686,
+        "dof": 249,
+        "mean_difference": -0.015600000000000001,
+        "sd_difference": 0.17784148791477034,
+        "significant": false,
+        "mde_80_power": 0.03151150949316014,
+        "n_needed_for_observed_diff": 1021
+       },
+       "rouge_l_f1": {
+        "t_statistic": -0.7912894756995685,
+        "p_value": 0.4295281751268944,
+        "dof": 249,
+        "mean_difference": -0.0076127610369086185,
+        "sd_difference": 0.15211667094354556,
+        "significant": false,
+        "mde_80_power": 0.026953361539590125,
+        "n_needed_for_observed_diff": 3134
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.3248130344795701,
+        "p_value": 0.7455953049812267,
+        "dof": 249,
+        "mean_difference": -0.012,
+        "sd_difference": 0.5841411503516394,
+        "significant": false,
+        "mde_80_power": 0.10350323549627923,
+        "n_needed_for_observed_diff": 18599
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.007460122100122113,
+       "ordered_step_accuracy": -0.004679999999999997,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.0010666666666666825,
+       "_sum": -0.013206788766788793,
+       "_total_delta_composite": -0.013206788766788768,
+       "_residual": -2.42861286636753e-17,
+       "_share_reference_term": -0.0
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.46156257175975196,
+        "system_b": 0.47014645598605115,
+        "difference": -0.008583884226299188,
+        "ci_low": -0.024335539007117064,
+        "ci_high": 0.007371249877679232,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.10401446331446332,
+        "system_b": 0.11736583416583417,
+        "difference": -0.01335137085137085,
+        "ci_low": -0.034638196248196224,
+        "ci_high": 0.007032943722943713,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.08206984126984128,
+        "system_b": 0.10381269841269841,
+        "difference": -0.021742857142857133,
+        "ci_low": -0.040833531746031757,
+        "ci_high": -0.003233015873015882,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.2560216095016095,
+        "system_b": 0.13915680985680987,
+        "difference": 0.11686479964479965,
+        "ci_low": -0.20921081635031638,
+        "ci_high": 0.18952620199245201,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.02,
+        "difference": -0.016,
+        "ci_low": -0.036,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.272,
+        "system_b": 0.284,
+        "difference": -0.011999999999999955,
+        "ci_low": -0.08400000000000002,
+        "ci_high": 0.06,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.14695008880008886,
+        "system_b": 0.17394601232101237,
+        "difference": -0.026995923520923504,
+        "ci_low": -0.04874096642940393,
+        "ci_high": -0.005829804778554827,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.02,
+        "difference": -0.016,
+        "correct_only_in_a": 1,
+        "correct_only_in_b": 5,
+        "discordant_pairs": 6,
+        "p_value": 0.21875,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.03125,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.272,
+        "system_b_rate": 0.284,
+        "difference": -0.012,
+        "correct_only_in_a": 41,
+        "correct_only_in_b": 44,
+        "discordant_pairs": 85,
+        "p_value": 0.8284232741649004,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 5.169878828456423e-26,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.6384859226122093,
+        "p_value": 0.1025832998165287,
+        "dof": 249,
+        "mean_difference": -0.016,
+        "sd_difference": 0.15439999167655052,
+        "significant": false,
+        "mde_80_power": 0.027357940267521696,
+        "n_needed_for_observed_diff": 731
+       },
+       "step_f1": {
+        "t_statistic": -1.2710840499362694,
+        "p_value": 0.20488488912597413,
+        "dof": 249,
+        "mean_difference": -0.01335137085137085,
+        "sd_difference": 0.16608162842587085,
+        "significant": false,
+        "mde_80_power": 0.029427794785935695,
+        "n_needed_for_observed_diff": 1215
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -2.2731816170714296,
+        "p_value": 0.023867633777727913,
+        "dof": 249,
+        "mean_difference": -0.02174285714285714,
+        "sd_difference": 0.15123505947507643,
+        "significant": true,
+        "mde_80_power": 0.026797149912687536,
+        "n_needed_for_observed_diff": 380
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.0738641151843809,
+        "p_value": 0.2839231384051196,
+        "dof": 249,
+        "mean_difference": -0.008583884226299285,
+        "sd_difference": 0.12638761712247584,
+        "significant": false,
+        "mde_80_power": 0.022394462863926663,
+        "n_needed_for_observed_diff": 1702
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.3248130344795701,
+        "p_value": 0.7455953049812267,
+        "dof": 249,
+        "mean_difference": -0.012,
+        "sd_difference": 0.5841411503516394,
+        "significant": false,
+        "mde_80_power": 0.10350323549627923,
+        "n_needed_for_observed_diff": 18599
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.00534054834054834,
+       "ordered_step_accuracy": -0.00652285714285714,
+       "reference_validity_micro": 0.13846153846153847,
+       "step_count_term": -0.009733333333333328,
+       "_sum": 0.11686479964479966,
+       "_total_delta_composite": 0.11686479964479965,
+       "_residual": 1.3877787807814457e-17,
+       "_share_reference_term": 1.1848010597064318
+      }
+     }
+    }
+   },
+   {
+    "family": "balance_size2000",
+    "kind": "pool_balance",
+    "contrast": "balanced vs imbalanced @ size 2000",
+    "cell_a": "size2000_balanced_trial0__biencoder_only__uniform",
+    "cell_b": "size2000_imbalanced_trial0__biencoder_only__uniform",
+    "fixed": {
+     "size": 2000,
+     "retrieval": "biencoder_only",
+     "mask": "uniform"
+    },
+    "sign_convention": "A = balanced, B = imbalanced",
+    "n": 750,
+    "overall": {
+     "bootstrap": {
+      "rouge_l_f1": {
+       "system_a": 0.5166398652512153,
+       "system_b": 0.5235959820198607,
+       "difference": -0.006956116768645382,
+       "ci_low": -0.019070539074938622,
+       "ci_high": 0.004982106033277666,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "step_f1": {
+       "system_a": 0.15718394922307963,
+       "system_b": 0.17253788433788433,
+       "difference": -0.015353935114804707,
+       "ci_low": -0.03124245048832003,
+       "ci_high": -4.531024531026495e-05,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "ordered_step_accuracy": {
+       "system_a": 0.13800283283967493,
+       "system_b": 0.15658306878306877,
+       "difference": -0.018580235943393836,
+       "ci_low": -0.03467570960228852,
+       "ci_high": -0.0032171815903394795,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_score": {
+       "system_a": 0.3664966517633566,
+       "system_b": 0.1835011854811855,
+       "difference": 0.18299546628217112,
+       "ci_low": -0.016323258301385916,
+       "ci_high": 0.1951685196789184,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "exact_match": {
+       "system_a": 0.03333333333333333,
+       "system_b": 0.037333333333333336,
+       "difference": -0.0040000000000000036,
+       "ci_low": -0.017333333333333336,
+       "ci_high": 0.009333333333333332,
+       "significant": false,
+       "n": 750,
+       "underpowered": false
+      },
+      "hop_count_exact_match": {
+       "system_a": 0.4146666666666667,
+       "system_b": 0.472,
+       "difference": -0.05733333333333329,
+       "ci_low": -0.09999999999999998,
+       "ci_high": -0.014666666666666661,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      },
+      "composite_no_ref_renorm": {
+       "system_a": 0.2081208147041957,
+       "system_b": 0.22937648185148188,
+       "difference": -0.02125566714728619,
+       "ci_low": -0.03735239820176962,
+       "ci_high": -0.005822195851361316,
+       "significant": true,
+       "n": 750,
+       "underpowered": false
+      }
+     },
+     "mcnemar": {
+      "exact_match": {
+       "system_a_rate": 0.03333333333333333,
+       "system_b_rate": 0.037333333333333336,
+       "difference": -0.004,
+       "correct_only_in_a": 12,
+       "correct_only_in_b": 15,
+       "discordant_pairs": 27,
+       "p_value": 0.7011080384254456,
+       "significant": false,
+       "n": 750,
+       "min_attainable_p_value": 1.4901161193847656e-08,
+       "min_attainable_p_reaches_alpha": true
+      },
+      "hop_count_exact_match": {
+       "system_a_rate": 0.4146666666666667,
+       "system_b_rate": 0.472,
+       "difference": -0.05733333333333333,
+       "correct_only_in_a": 110,
+       "correct_only_in_b": 153,
+       "discordant_pairs": 263,
+       "p_value": 0.009471324237214309,
+       "significant": true,
+       "n": 750,
+       "min_attainable_p_value": 1.349401336733507e-79,
+       "min_attainable_p_reaches_alpha": true
+      }
+     },
+     "t_test": {
+      "exact_match": {
+       "t_statistic": -0.5770934978764192,
+       "p_value": 0.5640497055730368,
+       "dof": 749,
+       "mean_difference": -0.004,
+       "sd_difference": 0.1898210808198908,
+       "significant": false,
+       "mde_80_power": 0.01941869045698342,
+       "n_needed_for_observed_diff": 17676
+      },
+      "step_f1": {
+       "t_statistic": -1.9090108063692155,
+       "p_value": 0.05664258455941992,
+       "dof": 749,
+       "mean_difference": -0.01535393511480468,
+       "sd_difference": 0.2202632007317905,
+       "significant": false,
+       "mde_80_power": 0.022532918343950586,
+       "n_needed_for_observed_diff": 1616
+      },
+      "ordered_step_accuracy": {
+       "t_statistic": -2.3338215848195034,
+       "p_value": 0.019868690162193513,
+       "dof": 749,
+       "mean_difference": -0.01858023594339384,
+       "sd_difference": 0.2180289705125886,
+       "significant": true,
+       "mde_80_power": 0.02230435666445258,
+       "n_needed_for_observed_diff": 1081
+      },
+      "rouge_l_f1": {
+       "t_statistic": -1.1146293181796645,
+       "p_value": 0.26536682467424644,
+       "dof": 749,
+       "mean_difference": -0.006956116768645452,
+       "sd_difference": 0.17090982646362304,
+       "significant": false,
+       "mde_80_power": 0.01748406974514538,
+       "n_needed_for_observed_diff": 4739
+      },
+      "hop_count_exact_match": {
+       "t_statistic": -2.662232454223173,
+       "p_value": 0.007928937514260371,
+       "dof": 749,
+       "mean_difference": -0.05733333333333333,
+       "sd_difference": 0.5897824570843627,
+       "significant": true,
+       "mde_80_power": 0.060334726372921595,
+       "n_needed_for_observed_diff": 831
+      }
+     },
+     "composite_term_decomposition": {
+      "step_f1": -0.006141574045921883,
+      "ordered_step_accuracy": -0.005574070783018151,
+      "reference_validity_micro": 0.2,
+      "step_count_term": -0.005288888888888888,
+      "_sum": 0.1829954662821711,
+      "_total_delta_composite": 0.18299546628217112,
+      "_residual": -2.7755575615628914e-17,
+      "_share_reference_term": 1.0929232513968878
+     },
+     "reference_terms": {
+      "ref_micro_a": 1.0,
+      "ref_micro_b": 0.0,
+      "step_count_term_a": 0.6222222222222222,
+      "step_count_term_b": 0.6751111111111111
+     }
+    },
+    "per_hop": {
+     "2": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5781508098928904,
+        "system_b": 0.5954771911864707,
+        "difference": -0.01732638129358033,
+        "ci_low": -0.04249287373517443,
+        "ci_high": 0.008558462492584549,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.253352380952381,
+        "system_b": 0.28566060606060606,
+        "difference": -0.032308225108225064,
+        "ci_low": -0.06832508658008651,
+        "ci_high": 0.003339870129870158,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.23393333333333333,
+        "system_b": 0.2674444444444445,
+        "difference": -0.03351111111111116,
+        "ci_low": -0.06985583333333326,
+        "ci_high": 0.0031344444444444167,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.45058761904761907,
+        "system_b": 0.27049757575757577,
+        "difference": 0.1800900432900433,
+        "ci_low": -0.03213408658008658,
+        "ci_high": 0.20688390043290045,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.084,
+        "system_b": 0.104,
+        "difference": -0.01999999999999999,
+        "ci_low": -0.05600000000000001,
+        "ci_high": 0.016000000000000007,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.568,
+        "system_b": 0.632,
+        "difference": -0.06400000000000006,
+        "ci_low": -0.1359999999999999,
+        "ci_high": 0.008000000000000007,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.3132345238095239,
+        "system_b": 0.3381219696969698,
+        "difference": -0.024887445887445903,
+        "ci_low": -0.05878988771645024,
+        "ci_high": 0.009742159090909173,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.084,
+        "system_b_rate": 0.104,
+        "difference": -0.02,
+        "correct_only_in_a": 9,
+        "correct_only_in_b": 14,
+        "discordant_pairs": 23,
+        "p_value": 0.4048728942871094,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 2.384185791015625e-07,
+        "min_attainable_p_reaches_alpha": true
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.568,
+        "system_b_rate": 0.632,
+        "difference": -0.064,
+        "correct_only_in_a": 33,
+        "correct_only_in_b": 49,
+        "discordant_pairs": 82,
+        "p_value": 0.09703091129729906,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 4.1359030627651384e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0427541630420303,
+        "p_value": 0.2980735001716106,
+        "dof": 249,
+        "mean_difference": -0.02,
+        "sd_difference": 0.30326205085032276,
+        "significant": false,
+        "mde_80_power": 0.05373462124240066,
+        "n_needed_for_observed_diff": 1805
+       },
+       "step_f1": {
+        "t_statistic": -1.761792791591808,
+        "p_value": 0.07933143850936047,
+        "dof": 249,
+        "mean_difference": -0.03230822510822512,
+        "sd_difference": 0.28995344681573304,
+        "significant": false,
+        "mde_80_power": 0.05137648643767126,
+        "n_needed_for_observed_diff": 633
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -1.7857402319266154,
+        "p_value": 0.07535824346068414,
+        "dof": 249,
+        "mean_difference": -0.03351111111111111,
+        "sd_difference": 0.29671571525203194,
+        "significant": false,
+        "mde_80_power": 0.05257468427398183,
+        "n_needed_for_observed_diff": 616
+       },
+       "rouge_l_f1": {
+        "t_statistic": -1.3082849476935754,
+        "p_value": 0.19198305317568032,
+        "dof": 249,
+        "mean_difference": -0.017326381293580242,
+        "sd_difference": 0.20939944540690814,
+        "significant": false,
+        "mde_80_power": 0.037103224276691556,
+        "n_needed_for_observed_diff": 1147
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -1.7744815651714652,
+        "p_value": 0.07720536915507988,
+        "dof": 249,
+        "mean_difference": -0.064,
+        "sd_difference": 0.5702673226453612,
+        "significant": false,
+        "mde_80_power": 0.10104494942029692,
+        "n_needed_for_observed_diff": 624
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.012923290043290027,
+       "ordered_step_accuracy": -0.010053333333333346,
+       "reference_validity_micro": 0.2,
+       "step_count_term": 0.003066666666666662,
+       "_sum": 0.1800900432900433,
+       "_total_delta_composite": 0.1800900432900433,
+       "_residual": 0.0,
+       "_share_reference_term": 1.110555566239111
+      }
+     },
+     "3": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.5173086224698142,
+        "system_b": 0.497639707522638,
+        "difference": 0.019668914947176264,
+        "ci_low": 0.0014069951724092783,
+        "ci_high": 0.038292926632353654,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.13418730158730158,
+        "system_b": 0.12493313353313353,
+        "difference": 0.009254168054168052,
+        "ci_low": -0.014679062049062063,
+        "ci_high": 0.033133374403374376,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.11173333333333332,
+        "system_b": 0.10526666666666666,
+        "difference": 0.006466666666666662,
+        "ci_low": -0.01573333333333332,
+        "ci_high": 0.0286,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.3546615873015873,
+        "system_b": 0.1487532534132534,
+        "difference": 0.2059083338883339,
+        "ci_low": -0.007605259684759667,
+        "ci_high": 0.22161475180375179,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.012,
+        "system_b": 0.0,
+        "difference": 0.012,
+        "ci_low": 0.0,
+        "ci_high": 0.028,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.424,
+        "system_b": 0.432,
+        "difference": -0.008000000000000007,
+        "ci_low": -0.08400000000000002,
+        "ci_high": 0.07199999999999995,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.19332698412698415,
+        "system_b": 0.18594156676656676,
+        "difference": 0.007385417360417396,
+        "ci_low": -0.014825761183261194,
+        "ci_high": 0.029635460650460594,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.012,
+        "system_b_rate": 0.0,
+        "difference": 0.012,
+        "correct_only_in_a": 3,
+        "correct_only_in_b": 0,
+        "discordant_pairs": 3,
+        "p_value": 0.25,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 0.25,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.424,
+        "system_b_rate": 0.432,
+        "difference": -0.008,
+        "correct_only_in_a": 49,
+        "correct_only_in_b": 51,
+        "discordant_pairs": 100,
+        "p_value": 0.9204107626128213,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.5777218104420236e-30,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": 1.7390490211537188,
+        "p_value": 0.0832620199015193,
+        "dof": 249,
+        "mean_difference": 0.012,
+        "sd_difference": 0.10910368672886965,
+        "significant": false,
+        "mde_80_power": 0.019331944983181883,
+        "n_needed_for_observed_diff": 649
+       },
+       "step_f1": {
+        "t_statistic": 0.7642541372021767,
+        "p_value": 0.4454394295340299,
+        "dof": 249,
+        "mean_difference": 0.009254168054168057,
+        "sd_difference": 0.19145626746798966,
+        "significant": false,
+        "mde_80_power": 0.03392389515282219,
+        "n_needed_for_observed_diff": 3360
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": 0.5717318336766041,
+        "p_value": 0.5680194074856422,
+        "dof": 249,
+        "mean_difference": 0.006466666666666667,
+        "sd_difference": 0.17883730038480394,
+        "significant": false,
+        "mde_80_power": 0.03168795625184847,
+        "n_needed_for_observed_diff": 6003
+       },
+       "rouge_l_f1": {
+        "t_statistic": 2.0651493892649437,
+        "p_value": 0.039944061980584394,
+        "dof": 249,
+        "mean_difference": 0.019668914947176305,
+        "sd_difference": 0.15059097094991786,
+        "significant": true,
+        "mde_80_power": 0.02668302467727173,
+        "n_needed_for_observed_diff": 461
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -0.19961556908234188,
+        "p_value": 0.841944167443241,
+        "dof": 249,
+        "mean_difference": -0.008,
+        "sd_difference": 0.6336735505563561,
+        "significant": false,
+        "mde_80_power": 0.11227981916958926,
+        "n_needed_for_observed_diff": 49246
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": 0.003701667221667221,
+       "ordered_step_accuracy": 0.0019399999999999986,
+       "reference_validity_micro": 0.2,
+       "step_count_term": 0.0002666666666666817,
+       "_sum": 0.2059083338883339,
+       "_total_delta_composite": 0.2059083338883339,
+       "_residual": 0.0,
+       "_share_reference_term": 0.9713059992436341
+      }
+     },
+     "4": {
+      "n": 250,
+      "bootstrap": {
+       "rouge_l_f1": {
+        "system_a": 0.45446016339094103,
+        "system_b": 0.4776710473504735,
+        "difference": -0.02321088395953247,
+        "ci_low": -0.040959197662175255,
+        "ci_high": -0.0055465677929722144,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "step_f1": {
+        "system_a": 0.08401216512955643,
+        "system_b": 0.10701991341991342,
+        "difference": -0.023007748290356983,
+        "ci_low": -0.042138108413325805,
+        "ci_high": -0.003532842712842717,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "ordered_step_accuracy": {
+        "system_a": 0.06834183185235818,
+        "system_b": 0.09703809523809523,
+        "difference": -0.028696263385737053,
+        "ci_low": -0.047060191957165654,
+        "ci_high": -0.010323741740715415,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_score": {
+        "system_a": 0.2942407489408634,
+        "system_b": 0.3312527272727273,
+        "difference": -0.037011978331863926,
+        "ci_low": -0.05503491848280124,
+        "ci_high": -0.018833624819624854,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "exact_match": {
+        "system_a": 0.004,
+        "system_b": 0.008,
+        "difference": -0.004,
+        "ci_low": -0.012,
+        "ci_high": 0.0,
+        "significant": false,
+        "n": 250,
+        "underpowered": false
+       },
+       "hop_count_exact_match": {
+        "system_a": 0.252,
+        "system_b": 0.352,
+        "difference": -0.09999999999999998,
+        "ci_low": -0.168,
+        "ci_high": -0.028000000000000025,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       },
+       "composite_no_ref_renorm": {
+        "system_a": 0.11780093617607922,
+        "system_b": 0.16406590909090912,
+        "difference": -0.04626497291482991,
+        "ci_low": -0.06879364810350151,
+        "ci_high": -0.023542031024531042,
+        "significant": true,
+        "n": 250,
+        "underpowered": false
+       }
+      },
+      "mcnemar": {
+       "exact_match": {
+        "system_a_rate": 0.004,
+        "system_b_rate": 0.008,
+        "difference": -0.004,
+        "correct_only_in_a": 0,
+        "correct_only_in_b": 1,
+        "discordant_pairs": 1,
+        "p_value": 1.0,
+        "significant": false,
+        "n": 250,
+        "min_attainable_p_value": 1.0,
+        "min_attainable_p_reaches_alpha": false
+       },
+       "hop_count_exact_match": {
+        "system_a_rate": 0.252,
+        "system_b_rate": 0.352,
+        "difference": -0.1,
+        "correct_only_in_a": 28,
+        "correct_only_in_b": 53,
+        "discordant_pairs": 81,
+        "p_value": 0.007275502036308497,
+        "significant": true,
+        "n": 250,
+        "min_attainable_p_value": 8.271806125530277e-25,
+        "min_attainable_p_reaches_alpha": true
+       }
+      },
+      "t_test": {
+       "exact_match": {
+        "t_statistic": -1.0,
+        "p_value": 0.3182813015158006,
+        "dof": 249,
+        "mean_difference": -0.004,
+        "sd_difference": 0.0632455532033676,
+        "significant": false,
+        "mde_80_power": 0.011206400000000002,
+        "n_needed_for_observed_diff": 1963
+       },
+       "step_f1": {
+        "t_statistic": -2.335918875734507,
+        "p_value": 0.020289855834291434,
+        "dof": 249,
+        "mean_difference": -0.023007748290356986,
+        "sd_difference": 0.15573504967396487,
+        "significant": true,
+        "mde_80_power": 0.027594497514386404,
+        "n_needed_for_observed_diff": 360
+       },
+       "ordered_step_accuracy": {
+        "t_statistic": -3.0581783928182964,
+        "p_value": 0.0024699346038599265,
+        "dof": 249,
+        "mean_difference": -0.02869626338573707,
+        "sd_difference": 0.1483653681683962,
+        "significant": true,
+        "mde_80_power": 0.026288672920545916,
+        "n_needed_for_observed_diff": 210
+       },
+       "rouge_l_f1": {
+        "t_statistic": -2.5787091442902885,
+        "p_value": 0.010492177964556605,
+        "dof": 249,
+        "mean_difference": -0.023210883959532417,
+        "sd_difference": 0.14231783367369813,
+        "significant": true,
+        "mde_80_power": 0.025217117892108343,
+        "n_needed_for_observed_diff": 296
+       },
+       "hop_count_exact_match": {
+        "t_statistic": -2.816014258794242,
+        "p_value": 0.005251690892837232,
+        "dof": 249,
+        "mean_difference": -0.1,
+        "sd_difference": 0.5614811164916473,
+        "significant": true,
+        "mde_80_power": 0.09948813260624562,
+        "n_needed_for_observed_diff": 248
+       }
+      },
+      "composite_term_decomposition": {
+       "step_f1": -0.009203099316142794,
+       "ordered_step_accuracy": -0.008608879015721115,
+       "reference_validity_micro": 0.0,
+       "step_count_term": -0.019199999999999995,
+       "_sum": -0.037011978331863905,
+       "_total_delta_composite": -0.037011978331863926,
+       "_residual": 2.0816681711721685e-17,
+       "_share_reference_term": -0.0
+      }
+     }
+    }
+   }
+  ]
+ },
+ "across_pair_summary": {
+  "all_size_pairs": {
+   "exact_match": {
+    "num_pairs": 27,
+    "delta_positive": 19,
+    "delta_negative": 8,
+    "delta_zero": 0,
+    "ci_significant": 5,
+    "t_significant": 6,
+    "mcnemar_significant": 3,
+    "ci_width_min": 0.021333333333333333,
+    "ci_width_max": 0.032
+   },
+   "step_f1": {
+    "num_pairs": 27,
+    "delta_positive": 21,
+    "delta_negative": 6,
+    "delta_zero": 0,
+    "ci_significant": 6,
+    "t_significant": 6,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.025861298238798257,
+    "ci_width_max": 0.03414780588692353
+   },
+   "ordered_step_accuracy": {
+    "num_pairs": 27,
+    "delta_positive": 20,
+    "delta_negative": 7,
+    "delta_zero": 0,
+    "ci_significant": 6,
+    "t_significant": 6,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.025312947191697188,
+    "ci_width_max": 0.033087866479925315
+   },
+   "rouge_l_f1": {
+    "num_pairs": 27,
+    "delta_positive": 15,
+    "delta_negative": 12,
+    "delta_zero": 0,
+    "ci_significant": 3,
+    "t_significant": 3,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.019048432460212206,
+    "ci_width_max": 0.023562407711951887
+   },
+   "hop_count_exact_match": {
+    "num_pairs": 27,
+    "delta_positive": 14,
+    "delta_negative": 13,
+    "delta_zero": 0,
+    "ci_significant": 3,
+    "t_significant": 4,
+    "mcnemar_significant": 3,
+    "ci_width_min": 0.07600000000000001,
+    "ci_width_max": 0.08933333333333332
+   },
+   "composite_score": {
+    "num_pairs": 27,
+    "delta_positive": 16,
+    "delta_negative": 11,
+    "delta_zero": 0,
+    "ci_significant": 2,
+    "t_significant": null,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.02062454379667468,
+    "ci_width_max": 0.41631459707237495
+   },
+   "composite_no_ref_renorm": {
+    "num_pairs": 27,
+    "delta_positive": 18,
+    "delta_negative": 9,
+    "delta_zero": 0,
+    "ci_significant": 5,
+    "t_significant": null,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.025780679745843305,
+    "ci_width_max": 0.03230515055750349
+   }
+  },
+  "by_contrast": {
+   "size_1000_vs_2000": {
+    "exact_match": {
+     "num_pairs": 9,
+     "delta_positive": 6,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 3,
+     "mcnemar_significant": 1,
+     "ci_width_min": 0.024000000000000004,
+     "ci_width_max": 0.032
+    },
+    "step_f1": {
+     "num_pairs": 9,
+     "delta_positive": 7,
+     "delta_negative": 2,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 2,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.027278018463018465,
+     "ci_width_max": 0.032249680134680145
+    },
+    "ordered_step_accuracy": {
+     "num_pairs": 9,
+     "delta_positive": 5,
+     "delta_negative": 4,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 2,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.026801042328042268,
+     "ci_width_max": 0.03094050264550266
+    },
+    "rouge_l_f1": {
+     "num_pairs": 9,
+     "delta_positive": 6,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 1,
+     "t_significant": 1,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.020553873009522567,
+     "ci_width_max": 0.023562407711951887
+    },
+    "hop_count_exact_match": {
+     "num_pairs": 9,
+     "delta_positive": 3,
+     "delta_negative": 6,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": 0,
+     "ci_width_min": 0.07733333333333342,
+     "ci_width_max": 0.08666666666666667
+    },
+    "composite_score": {
+     "num_pairs": 9,
+     "delta_positive": 6,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.1526393637011137,
+     "ci_width_max": 0.41631459707237495
+    },
+    "composite_no_ref_renorm": {
+     "num_pairs": 9,
+     "delta_positive": 5,
+     "delta_negative": 4,
+     "delta_zero": 0,
+     "ci_significant": 1,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.027112322247805784,
+     "ci_width_max": 0.0312257920042633
+    }
+   },
+   "size_1000_vs_8000": {
+    "exact_match": {
+     "num_pairs": 6,
+     "delta_positive": 6,
+     "delta_negative": 0,
+     "delta_zero": 0,
+     "ci_significant": 3,
+     "t_significant": 3,
+     "mcnemar_significant": 2,
+     "ci_width_min": 0.02666666666666667,
+     "ci_width_max": 0.03066666666666667
+    },
+    "step_f1": {
+     "num_pairs": 6,
+     "delta_positive": 6,
+     "delta_negative": 0,
+     "delta_zero": 0,
+     "ci_significant": 4,
+     "t_significant": 4,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.029728915042072916,
+     "ci_width_max": 0.03414780588692353
+    },
+    "ordered_step_accuracy": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 4,
+     "t_significant": 4,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.029903489417989423,
+     "ci_width_max": 0.033087866479925315
+    },
+    "rouge_l_f1": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 2,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.022202678089900032,
+     "ci_width_max": 0.02348670349304326
+    },
+    "hop_count_exact_match": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 2,
+     "mcnemar_significant": 2,
+     "ci_width_min": 0.08266666666666661,
+     "ci_width_max": 0.08933333333333332
+    },
+    "composite_score": {
+     "num_pairs": 6,
+     "delta_positive": 3,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.30527118629968636,
+     "ci_width_max": 0.4115951796041649
+    },
+    "composite_no_ref_renorm": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 4,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.029971601840289366,
+     "ci_width_max": 0.03230515055750349
+    }
+   },
+   "size_2000_vs_4000": {
+    "exact_match": {
+     "num_pairs": 6,
+     "delta_positive": 3,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": 0,
+     "ci_width_min": 0.021333333333333333,
+     "ci_width_max": 0.026666666666666672
+    },
+    "step_f1": {
+     "num_pairs": 6,
+     "delta_positive": 3,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.025861298238798257,
+     "ci_width_max": 0.028110189722558132
+    },
+    "ordered_step_accuracy": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.025312947191697188,
+     "ci_width_max": 0.027410690698190694
+    },
+    "rouge_l_f1": {
+     "num_pairs": 6,
+     "delta_positive": 2,
+     "delta_negative": 4,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.019048432460212206,
+     "ci_width_max": 0.020731670071464644
+    },
+    "hop_count_exact_match": {
+     "num_pairs": 6,
+     "delta_positive": 2,
+     "delta_negative": 4,
+     "delta_zero": 0,
+     "ci_significant": 1,
+     "t_significant": 1,
+     "mcnemar_significant": 1,
+     "ci_width_min": 0.07600000000000001,
+     "ci_width_max": 0.08133333333333331
+    },
+    "composite_score": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.02062454379667468,
+     "ci_width_max": 0.21548976562229194
+    },
+    "composite_no_ref_renorm": {
+     "num_pairs": 6,
+     "delta_positive": 4,
+     "delta_negative": 2,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.025780679745843305,
+     "ci_width_max": 0.02782408766915348
+    }
+   },
+   "size_4000_vs_8000": {
+    "exact_match": {
+     "num_pairs": 6,
+     "delta_positive": 4,
+     "delta_negative": 2,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": 0,
+     "ci_width_min": 0.023999999999999994,
+     "ci_width_max": 0.029333333333333336
+    },
+    "step_f1": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.027868766233766235,
+     "ci_width_max": 0.030925437174338058
+    },
+    "ordered_step_accuracy": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.02666408128908125,
+     "ci_width_max": 0.030818416768416804
+    },
+    "rouge_l_f1": {
+     "num_pairs": 6,
+     "delta_positive": 2,
+     "delta_negative": 4,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.0192295111882188,
+     "ci_width_max": 0.022066990942791926
+    },
+    "hop_count_exact_match": {
+     "num_pairs": 6,
+     "delta_positive": 4,
+     "delta_negative": 2,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 1,
+     "mcnemar_significant": 0,
+     "ci_width_min": 0.07733333333333331,
+     "ci_width_max": 0.08399999999999996
+    },
+    "composite_score": {
+     "num_pairs": 6,
+     "delta_positive": 2,
+     "delta_negative": 4,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.02138707295645539,
+     "ci_width_max": 0.4022461881634161
+    },
+    "composite_no_ref_renorm": {
+     "num_pairs": 6,
+     "delta_positive": 4,
+     "delta_negative": 2,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.026733841195569128,
+     "ci_width_max": 0.030574991427632623
+    }
+   }
+  },
+  "balance_pairs": {
+   "exact_match": {
+    "num_pairs": 9,
+    "delta_positive": 5,
+    "delta_negative": 4,
+    "delta_zero": 0,
+    "ci_significant": 2,
+    "t_significant": 2,
+    "mcnemar_significant": 1,
+    "ci_width_min": 0.02666666666666667,
+    "ci_width_max": 0.032
+   },
+   "step_f1": {
+    "num_pairs": 9,
+    "delta_positive": 3,
+    "delta_negative": 6,
+    "delta_zero": 0,
+    "ci_significant": 2,
+    "t_significant": 1,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.031197140243009767,
+    "ci_width_max": 0.033554155844155886
+   },
+   "ordered_step_accuracy": {
+    "num_pairs": 9,
+    "delta_positive": 2,
+    "delta_negative": 7,
+    "delta_zero": 0,
+    "ci_significant": 2,
+    "t_significant": 2,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.03093889249639247,
+    "ci_width_max": 0.03324630485527541
+   },
+   "rouge_l_f1": {
+    "num_pairs": 9,
+    "delta_positive": 2,
+    "delta_negative": 7,
+    "delta_zero": 0,
+    "ci_significant": 1,
+    "t_significant": 1,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.02279833878153675,
+    "ci_width_max": 0.025054446587018275
+   },
+   "hop_count_exact_match": {
+    "num_pairs": 9,
+    "delta_positive": 0,
+    "delta_negative": 9,
+    "delta_zero": 0,
+    "ci_significant": 4,
+    "t_significant": 4,
+    "mcnemar_significant": 4,
+    "ci_width_min": 0.08266666666666672,
+    "ci_width_max": 0.09066666666666656
+   },
+   "composite_score": {
+    "num_pairs": 9,
+    "delta_positive": 5,
+    "delta_negative": 4,
+    "delta_zero": 0,
+    "ci_significant": 2,
+    "t_significant": null,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.20048925548525548,
+    "ci_width_max": 0.41173716798016796
+   },
+   "composite_no_ref_renorm": {
+    "num_pairs": 9,
+    "delta_positive": 0,
+    "delta_negative": 9,
+    "delta_zero": 0,
+    "ci_significant": 3,
+    "t_significant": null,
+    "mcnemar_significant": null,
+    "ci_width_min": 0.03025859405640654,
+    "ci_width_max": 0.0327332607809538
+   }
+  },
+  "by_balance_family": {
+   "balance_size1000": {
+    "exact_match": {
+     "num_pairs": 6,
+     "delta_positive": 5,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 1,
+     "t_significant": 1,
+     "mcnemar_significant": 0,
+     "ci_width_min": 0.026666666666666672,
+     "ci_width_max": 0.032
+    },
+    "step_f1": {
+     "num_pairs": 6,
+     "delta_positive": 3,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.03162789081289082,
+     "ci_width_max": 0.033554155844155886
+    },
+    "ordered_step_accuracy": {
+     "num_pairs": 6,
+     "delta_positive": 2,
+     "delta_negative": 4,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.03093889249639247,
+     "ci_width_max": 0.03324630485527541
+    },
+    "rouge_l_f1": {
+     "num_pairs": 6,
+     "delta_positive": 2,
+     "delta_negative": 4,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": 0,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.023453666772843895,
+     "ci_width_max": 0.025054446587018275
+    },
+    "hop_count_exact_match": {
+     "num_pairs": 6,
+     "delta_positive": 0,
+     "delta_negative": 6,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 2,
+     "mcnemar_significant": 2,
+     "ci_width_min": 0.08799999999999997,
+     "ci_width_max": 0.09066666666666656
+    },
+    "composite_score": {
+     "num_pairs": 6,
+     "delta_positive": 3,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 1,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.20048925548525548,
+     "ci_width_max": 0.41173716798016796
+    },
+    "composite_no_ref_renorm": {
+     "num_pairs": 6,
+     "delta_positive": 0,
+     "delta_negative": 6,
+     "delta_zero": 0,
+     "ci_significant": 0,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.03025859405640654,
+     "ci_width_max": 0.0327332607809538
+    }
+   },
+   "balance_size2000": {
+    "exact_match": {
+     "num_pairs": 3,
+     "delta_positive": 0,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 1,
+     "t_significant": 1,
+     "mcnemar_significant": 1,
+     "ci_width_min": 0.02666666666666667,
+     "ci_width_max": 0.03066666666666667
+    },
+    "step_f1": {
+     "num_pairs": 3,
+     "delta_positive": 0,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 1,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.031197140243009767,
+     "ci_width_max": 0.03258967032422913
+    },
+    "ordered_step_accuracy": {
+     "num_pairs": 3,
+     "delta_positive": 0,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 2,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.03145852801194904,
+     "ci_width_max": 0.032281685199332256
+    },
+    "rouge_l_f1": {
+     "num_pairs": 3,
+     "delta_positive": 0,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 1,
+     "t_significant": 1,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.02279833878153675,
+     "ci_width_max": 0.02430115834980614
+    },
+    "hop_count_exact_match": {
+     "num_pairs": 3,
+     "delta_positive": 0,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 2,
+     "t_significant": 2,
+     "mcnemar_significant": 2,
+     "ci_width_min": 0.08266666666666672,
+     "ci_width_max": 0.08799999999999997
+    },
+    "composite_score": {
+     "num_pairs": 3,
+     "delta_positive": 2,
+     "delta_negative": 1,
+     "delta_zero": 0,
+     "ci_significant": 1,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.21149177798030433,
+     "ci_width_max": 0.35769140637140645
+    },
+    "composite_no_ref_renorm": {
+     "num_pairs": 3,
+     "delta_positive": 0,
+     "delta_negative": 3,
+     "delta_zero": 0,
+     "ci_significant": 3,
+     "t_significant": null,
+     "mcnemar_significant": null,
+     "ci_width_min": 0.03137232282763539,
+     "ci_width_max": 0.0320274492120796
+    }
+   }
+  }
+ },
+ "holm_by_family": {
+  "size_1000_vs_2000": {
+   "exact_match": {
+    "family_size": 9,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_balanced_trial0__biencoder_only__typed|size1000_balanced_trial0__biencoder_only__typed": 0.7839693747879676,
+     "size2000_balanced_trial0__biencoder_only__uniform|size1000_balanced_trial0__biencoder_only__uniform": 0.7839693747879676,
+     "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.32806150808678014,
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.0035828648615089166,
+     "size2000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.32806150808678014,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 0.7839693747879676
+    },
+    "survivors": [
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed"
+    ]
+   },
+   "step_f1": {
+    "family_size": 9,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_balanced_trial0__biencoder_only__typed|size1000_balanced_trial0__biencoder_only__typed": 1.0,
+     "size2000_balanced_trial0__biencoder_only__uniform|size1000_balanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.2203712739109149,
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.00960564108688543,
+     "size2000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": [
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed"
+    ]
+   },
+   "ordered_step_accuracy": {
+    "family_size": 9,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_balanced_trial0__biencoder_only__typed|size1000_balanced_trial0__biencoder_only__typed": 1.0,
+     "size2000_balanced_trial0__biencoder_only__uniform|size1000_balanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.3047942265610037,
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.0044665590186541365,
+     "size2000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.9771376665973278,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": [
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed"
+    ]
+   },
+   "rouge_l_f1": {
+    "family_size": 9,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_balanced_trial0__biencoder_only__typed|size1000_balanced_trial0__biencoder_only__typed": 1.0,
+     "size2000_balanced_trial0__biencoder_only__uniform|size1000_balanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.10341394915930241,
+     "size2000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.5489253080719575,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.5489253080719575,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match": {
+    "family_size": 9,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_balanced_trial0__biencoder_only__typed|size1000_balanced_trial0__biencoder_only__typed": 1.0,
+     "size2000_balanced_trial0__biencoder_only__uniform|size1000_balanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "exact_match__mcnemar": {
+    "family_size": 9,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_balanced_trial0__biencoder_only__typed|size1000_balanced_trial0__biencoder_only__typed": 1.0,
+     "size2000_balanced_trial0__biencoder_only__uniform|size1000_balanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.4914267659187317,
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.004801690578460693,
+     "size2000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.4914267659187317,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": [
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed"
+    ]
+   },
+   "hop_count_exact_match__mcnemar": {
+    "family_size": 9,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_balanced_trial0__biencoder_only__typed|size1000_balanced_trial0__biencoder_only__typed": 1.0,
+     "size2000_balanced_trial0__biencoder_only__uniform|size1000_balanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size2000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size2000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   }
+  },
+  "size_2000_vs_4000": {
+   "exact_match": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.5374044159082105,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "step_f1": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "ordered_step_accuracy": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw": 0.6533447527703107,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed": 0.7983346266724695,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "rouge_l_f1": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.9256680657480361,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw": 0.10755731775491623,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed": 0.5914680172923816,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "exact_match__mcnemar": {
+    "family_size": 6,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.86077880859375,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match__mcnemar": {
+    "family_size": 6,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw": 0.12825583479665842,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed": 0.6708890960936175,
+     "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   }
+  },
+  "size_4000_vs_8000": {
+   "exact_match": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "step_f1": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed": 0.46752614696634787,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "ordered_step_accuracy": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "rouge_l_f1": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw": 0.9938371854810837,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed": 0.9938371854810837,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform": 0.2854597706268694,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw": 0.9938371854810837,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed": 0.9938371854810837,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform": 0.9938371854810837
+    },
+    "survivors": []
+   },
+   "exact_match__mcnemar": {
+    "family_size": 6,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match__mcnemar": {
+    "family_size": 6,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform": 0.33037753459311986,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   }
+  },
+  "size_1000_vs_8000": {
+   "exact_match": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.23126173860642224,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.014675209886576286,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 0.13522076898028837,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.23126173860642224,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.05247637816797397,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 0.23126173860642224
+    },
+    "survivors": [
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed"
+    ]
+   },
+   "step_f1": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.014251096058450164,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.0024976836796503582,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 0.04425996281512298,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.1432205852830274,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.0014821667113753116,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 0.7032426728219267
+    },
+    "survivors": [
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw",
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed",
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform",
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed"
+    ]
+   },
+   "ordered_step_accuracy": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.03188310298848108,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.0060813812114646594,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 0.08674195580226832,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.26802383430535687,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.0007656555543436353,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 0.9429480623621519
+    },
+    "survivors": [
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw",
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed",
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed"
+    ]
+   },
+   "rouge_l_f1": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.3758971132592147,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.19668781932206694,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.23548943664986735,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.7606599291232451,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.8812964744760158,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.8954133006209701,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 0.1605899649913646,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.8954133006209701,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.8954133006209701,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 0.05078691357341683
+    },
+    "survivors": []
+   },
+   "exact_match__mcnemar": {
+    "family_size": 6,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.33055249555036426,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.022314995527267456,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 0.20040983892977238,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.33055249555036426,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.08062400855123997,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 0.33055249555036426
+    },
+    "survivors": [
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed"
+    ]
+   },
+   "hop_count_exact_match__mcnemar": {
+    "family_size": 6,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 0.9759244308288522,
+     "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.9824879761698971,
+     "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 0.1871239718509152,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.9824879761698971,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.9824879761698971,
+     "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 0.060307337879179496
+    },
+    "survivors": []
+   }
+  },
+  "balance_size1000": {
+   "exact_match": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size1000_balanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.20504886772763836,
+     "size1000_balanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 0.5302122496662126,
+     "size1000_balanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "step_f1": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size1000_balanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size1000_balanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "ordered_step_accuracy": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size1000_balanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size1000_balanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "rouge_l_f1": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size1000_balanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 1.0,
+     "size1000_balanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match": {
+    "family_size": 6,
+    "test": "paired t-test",
+    "adjusted": {
+     "size1000_balanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.4191496214614954,
+     "size1000_balanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.42867292521849615,
+     "size1000_balanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.09570592634795094,
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 5.758702744615761e-06
+    },
+    "survivors": [
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform"
+    ]
+   },
+   "exact_match__mcnemar": {
+    "family_size": 6,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size1000_balanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.3134339153766632,
+     "size1000_balanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 0.7480639219284058,
+     "size1000_balanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 1.0
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match__mcnemar": {
+    "family_size": 6,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size1000_balanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": 1.0,
+     "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": 0.47233666217639847,
+     "size1000_balanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": 1.0,
+     "size1000_balanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": 0.4780163910119878,
+     "size1000_balanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": 0.11154663049201188,
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": 7.858607573002097e-06
+    },
+    "survivors": [
+     "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform"
+    ]
+   }
+  },
+  "balance_size2000": {
+   "exact_match": {
+    "family_size": 3,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 0.4465028197824066,
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 0.03341009939354167,
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.5640497055730368
+    },
+    "survivors": [
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed"
+    ]
+   },
+   "step_f1": {
+    "family_size": 3,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 0.11328516911883985,
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 0.0050035721485727335,
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.11328516911883985
+    },
+    "survivors": [
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed"
+    ]
+   },
+   "ordered_step_accuracy": {
+    "family_size": 3,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 0.1427429365926951,
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 0.0011468347674006148,
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.03973738032438703
+    },
+    "survivors": [
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed",
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform"
+    ]
+   },
+   "rouge_l_f1": {
+    "family_size": 3,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 0.5731638325343216,
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 0.060010557034224345,
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.5307336493484929
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match": {
+    "family_size": 3,
+    "test": "paired t-test",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 0.11104449820110676,
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 0.06699313756925852,
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.023786812542781113
+    },
+    "survivors": [
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform"
+    ]
+   },
+   "exact_match__mcnemar": {
+    "family_size": 3,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 0.592412737198174,
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 0.050021543400362134,
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.7011080384254456
+    },
+    "survivors": []
+   },
+   "hop_count_exact_match__mcnemar": {
+    "family_size": 3,
+    "test": "exact McNemar",
+    "adjusted": {
+     "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": 0.12470144137133113,
+     "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": 0.07790366832462815,
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": 0.028413972711642928
+    },
+    "survivors": [
+     "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform"
+    ]
+   }
+  }
+ },
+ "holm_per_pair_5metric_family": {
+  "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "rouge_l_f1": 1.0,
+    "hop_count_exact_match": 1.0,
+    "exact_match": 1.0,
+    "ordered_step_accuracy": 1.0,
+    "step_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size2000_balanced_trial0__biencoder_only__typed|size1000_balanced_trial0__biencoder_only__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 0.6533078123233063,
+    "ordered_step_accuracy": 1.0,
+    "rouge_l_f1": 1.0,
+    "hop_count_exact_match": 1.0,
+    "step_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size2000_balanced_trial0__biencoder_only__uniform|size1000_balanced_trial0__biencoder_only__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 0.7212145269307885,
+    "hop_count_exact_match": 1.0,
+    "ordered_step_accuracy": 1.0,
+    "rouge_l_f1": 1.0,
+    "step_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "step_f1": 0.1377320461943218,
+    "ordered_step_accuracy": 0.15239711328050184,
+    "exact_match": 0.15239711328050184,
+    "hop_count_exact_match": 1.0,
+    "rouge_l_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "rouge_l_f1": 1.0,
+    "hop_count_exact_match": 1.0,
+    "step_f1": 1.0,
+    "exact_match": 1.0,
+    "ordered_step_accuracy": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "rouge_l_f1": 0.8835327460518615,
+    "hop_count_exact_match": 0.8835327460518615,
+    "step_f1": 0.8835327460518615,
+    "ordered_step_accuracy": 0.8902652630568476,
+    "exact_match": 0.8902652630568476
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "step_f1": 0.017813870073062704,
+    "ordered_step_accuracy": 0.03188310298848108,
+    "rouge_l_f1": 0.28192283494441106,
+    "exact_match": 0.28192283494441106,
+    "hop_count_exact_match": 0.28192283494441106
+   },
+   "survivors": [
+    "ordered_step_accuracy",
+    "step_f1"
+   ]
+  },
+  "size2000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 0.001990480478616065,
+    "ordered_step_accuracy": 0.001990480478616065,
+    "step_f1": 0.0032018803622951434,
+    "rouge_l_f1": 0.02298087759095609,
+    "hop_count_exact_match": 0.7972728224121944
+   },
+   "survivors": [
+    "exact_match",
+    "ordered_step_accuracy",
+    "rouge_l_f1",
+    "step_f1"
+   ]
+  },
+  "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "ordered_step_accuracy": 1.0,
+    "step_f1": 1.0,
+    "exact_match": 1.0,
+    "rouge_l_f1": 1.0,
+    "hop_count_exact_match": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "step_f1": 1.0,
+    "hop_count_exact_match": 1.0,
+    "ordered_step_accuracy": 1.0,
+    "rouge_l_f1": 1.0,
+    "exact_match": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "step_f1": 0.0024976836796503582,
+    "ordered_step_accuracy": 0.0048651049691717276,
+    "exact_match": 0.007337604943288143,
+    "rouge_l_f1": 0.06556260644068898,
+    "hop_count_exact_match": 0.40975792715944076
+   },
+   "survivors": [
+    "exact_match",
+    "ordered_step_accuracy",
+    "step_f1"
+   ]
+  },
+  "size2000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "step_f1": 0.8285791299999397,
+    "hop_count_exact_match": 0.8285791299999397,
+    "ordered_step_accuracy": 0.8285791299999397,
+    "exact_match": 0.8285791299999397,
+    "rouge_l_f1": 0.8285791299999397
+   },
+   "survivors": []
+  },
+  "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 0.4478370132568421,
+    "hop_count_exact_match": 0.9256680657480361,
+    "rouge_l_f1": 1.0,
+    "ordered_step_accuracy": 1.0,
+    "step_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 0.23788314218905784,
+    "step_f1": 0.8069181133727186,
+    "ordered_step_accuracy": 0.8613398870741082,
+    "exact_match": 1.0,
+    "rouge_l_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "step_f1": 0.07376660469187164,
+    "ordered_step_accuracy": 0.1156559410696911,
+    "hop_count_exact_match": 0.1156559410696911,
+    "exact_match": 0.1156559410696911,
+    "rouge_l_f1": 0.6193986736859863
+   },
+   "survivors": []
+  },
+  "size2000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "rouge_l_f1": 0.3430783175449734,
+    "step_f1": 1.0,
+    "exact_match": 1.0,
+    "hop_count_exact_match": 1.0,
+    "ordered_step_accuracy": 1.0
+   },
+   "survivors": []
+  },
+  "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 0.08963109812909686,
+    "ordered_step_accuracy": 0.4355631685135405,
+    "step_f1": 0.5438231132108937,
+    "rouge_l_f1": 0.5438231132108937,
+    "exact_match": 0.6701073444572928
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 1.0,
+    "hop_count_exact_match": 1.0,
+    "rouge_l_f1": 1.0,
+    "step_f1": 1.0,
+    "ordered_step_accuracy": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "rouge_l_f1": 0.23548943664986735,
+    "step_f1": 0.2864411705660548,
+    "exact_match": 0.2864411705660548,
+    "ordered_step_accuracy": 0.2864411705660548,
+    "hop_count_exact_match": 0.29847110020699
+   },
+   "survivors": []
+  },
+  "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 0.2050384425542376,
+    "rouge_l_f1": 0.28275972162438484,
+    "ordered_step_accuracy": 0.41877328568456906,
+    "step_f1": 0.41877328568456906,
+    "hop_count_exact_match": 0.618765195187742
+   },
+   "survivors": []
+  },
+  "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 0.5914680172923816,
+    "ordered_step_accuracy": 0.6386677013379756,
+    "exact_match": 0.9529003751586707,
+    "step_f1": 0.9529003751586707,
+    "rouge_l_f1": 0.9529003751586707
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "step_f1": 0.38960512247195656,
+    "ordered_step_accuracy": 0.6781755327456055,
+    "hop_count_exact_match": 0.7194607066726377,
+    "exact_match": 1.0,
+    "rouge_l_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "ordered_step_accuracy": 0.0006380462952863628,
+    "step_f1": 0.0009881111409168744,
+    "exact_match": 0.031485826900784386,
+    "rouge_l_f1": 0.5071066194154967,
+    "hop_count_exact_match": 0.8560625550157991
+   },
+   "survivors": [
+    "exact_match",
+    "ordered_step_accuracy",
+    "step_f1"
+   ]
+  },
+  "size2000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 0.7172871226301867,
+    "exact_match": 0.7172871226301867,
+    "step_f1": 1.0,
+    "rouge_l_f1": 1.0,
+    "ordered_step_accuracy": 1.0
+   },
+   "survivors": []
+  },
+  "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "ordered_step_accuracy": 1.0,
+    "step_f1": 1.0,
+    "hop_count_exact_match": 1.0,
+    "exact_match": 1.0,
+    "rouge_l_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "ordered_step_accuracy": 1.0,
+    "hop_count_exact_match": 1.0,
+    "step_f1": 1.0,
+    "rouge_l_f1": 1.0,
+    "exact_match": 1.0
+   },
+   "survivors": []
+  },
+  "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 0.042322427977847354,
+    "exact_match": 0.7124128653936715,
+    "step_f1": 1.0,
+    "rouge_l_f1": 1.0,
+    "ordered_step_accuracy": 1.0
+   },
+   "survivors": [
+    "hop_count_exact_match"
+   ]
+  },
+  "size1000_balanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 1.0,
+    "ordered_step_accuracy": 1.0,
+    "hop_count_exact_match": 1.0,
+    "rouge_l_f1": 1.0,
+    "step_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 0.17087405643969864,
+    "hop_count_exact_match": 0.4191496214614954,
+    "rouge_l_f1": 1.0,
+    "ordered_step_accuracy": 1.0,
+    "step_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size1000_balanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "exact_match": 0.5302122496662126,
+    "rouge_l_f1": 1.0,
+    "ordered_step_accuracy": 1.0,
+    "hop_count_exact_match": 1.0,
+    "step_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size1000_balanced_trial0__biencoder_plus_ce__raw|size1000_imbalanced_trial0__biencoder_plus_ce__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 0.7144548753641602,
+    "ordered_step_accuracy": 1.0,
+    "step_f1": 1.0,
+    "rouge_l_f1": 1.0,
+    "exact_match": 1.0
+   },
+   "survivors": []
+  },
+  "size1000_balanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 0.09570592634795094,
+    "rouge_l_f1": 0.8193495994990874,
+    "exact_match": 1.0,
+    "ordered_step_accuracy": 1.0,
+    "step_f1": 1.0
+   },
+   "survivors": []
+  },
+  "size1000_balanced_trial0__biencoder_plus_ce__uniform|size1000_imbalanced_trial0__biencoder_plus_ce__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 4.7989189538464675e-06,
+    "ordered_step_accuracy": 0.8840185519299786,
+    "rouge_l_f1": 1.0,
+    "step_f1": 1.0,
+    "exact_match": 1.0
+   },
+   "survivors": [
+    "hop_count_exact_match"
+   ]
+  },
+  "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw": {
+   "family_size": 5,
+   "adjusted": {
+    "step_f1": 0.2995543164259553,
+    "hop_count_exact_match": 0.44417799280442705,
+    "ordered_step_accuracy": 0.44417799280442705,
+    "exact_match": 0.4465028197824066,
+    "rouge_l_f1": 0.5731638325343216
+   },
+   "survivors": []
+  },
+  "size2000_balanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed": {
+   "family_size": 5,
+   "adjusted": {
+    "ordered_step_accuracy": 0.0019113912790010249,
+    "step_f1": 0.006671429531430312,
+    "exact_match": 0.03341009939354167,
+    "rouge_l_f1": 0.04000703802281623,
+    "hop_count_exact_match": 0.04000703802281623
+   },
+   "survivors": [
+    "exact_match",
+    "hop_count_exact_match",
+    "ordered_step_accuracy",
+    "rouge_l_f1",
+    "step_f1"
+   ]
+  },
+  "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform": {
+   "family_size": 5,
+   "adjusted": {
+    "hop_count_exact_match": 0.03964468757130185,
+    "ordered_step_accuracy": 0.07947476064877405,
+    "step_f1": 0.16992775367825977,
+    "rouge_l_f1": 0.5307336493484929,
+    "exact_match": 0.5640497055730368
+   },
+   "survivors": [
+    "hop_count_exact_match"
+   ]
+  }
+ },
+ "verdict_agreement": {
+  "overall_ci_vs_t_checked": 180,
+  "overall_ci_vs_t_disagree": [
+   {
+    "pair": "size2000_imbalanced_trial0__biencoder_only__raw|size1000_imbalanced_trial0__biencoder_only__raw",
+    "metric": "exact_match",
+    "ci_significant": false,
+    "t_significant": true,
+    "ci": [
+     0.0,
+     0.032
+    ],
+    "t_p": 0.04542783048444692
+   },
+   {
+    "pair": "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform",
+    "metric": "hop_count_exact_match",
+    "ci_significant": false,
+    "t_significant": true,
+    "ci": [
+     0.0,
+     0.08266666666666661
+    ],
+    "t_p": 0.04757662843781157
+   },
+   {
+    "pair": "size2000_balanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform",
+    "metric": "step_f1",
+    "ci_significant": true,
+    "t_significant": false,
+    "ci": [
+     -0.03124245048832003,
+     -4.531024531026495e-05
+    ],
+    "t_p": 0.05664258455941992
+   }
+  ],
+  "overall_ci_vs_mcnemar_checked": 72,
+  "overall_ci_vs_mcnemar_disagree": [
+   {
+    "pair": "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform",
+    "metric": "exact_match",
+    "ci_significant": true,
+    "mcnemar_significant": false,
+    "mcnemar_p": 0.050102459732443094,
+    "discordant": 32
+   },
+   {
+    "pair": "size2000_imbalanced_trial0__biencoder_plus_ce__typed|size1000_imbalanced_trial0__biencoder_plus_ce__typed",
+    "metric": "exact_match",
+    "ci_significant": true,
+    "mcnemar_significant": false,
+    "mcnemar_p": 0.06142834573984146,
+    "discordant": 29
+   },
+   {
+    "pair": "size1000_balanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed",
+    "metric": "exact_match",
+    "ci_significant": true,
+    "mcnemar_significant": false,
+    "mcnemar_p": 0.052238985896110535,
+    "discordant": 27
+   }
+  ],
+  "per_hop_ci_vs_t_checked": 540,
+  "per_hop_ci_vs_t_disagree": [
+   {
+    "pair": "size8000_imbalanced_trial0__biencoder_only__typed|size1000_imbalanced_trial0__biencoder_only__typed",
+    "hop": "3",
+    "metric": "rouge_l_f1",
+    "ci_significant": false,
+    "t_significant": true,
+    "ci": [
+     -0.038103823872285156,
+     7.573233806335223e-05
+    ],
+    "t_p": 0.04538578470223929
+   },
+   {
+    "pair": "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform",
+    "hop": "2",
+    "metric": "exact_match",
+    "ci_significant": false,
+    "t_significant": true,
+    "ci": [
+     0.0,
+     0.064
+    ],
+    "t_p": 0.04528026312539455
+   },
+   {
+    "pair": "size8000_imbalanced_trial0__biencoder_only__uniform|size1000_imbalanced_trial0__biencoder_only__uniform",
+    "hop": "2",
+    "metric": "exact_match",
+    "ci_significant": false,
+    "t_significant": true,
+    "ci": [
+     0.0,
+     0.08
+    ],
+    "t_p": 0.049662775646749154
+   },
+   {
+    "pair": "size2000_balanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw",
+    "hop": "2",
+    "metric": "rouge_l_f1",
+    "ci_significant": true,
+    "t_significant": false,
+    "ci": [
+     -0.05161301328470346,
+     -0.00025569413021884487
+    ],
+    "t_p": 0.05084998448843017
+   }
+  ]
+ },
+ "row_order_sensitivity": {
+  "pair": "size2000_balanced_trial0__biencoder_only__raw|size1000_balanced_trial0__biencoder_only__raw",
+  "orders": [
+   "v1 file order (used)",
+   "reversed"
+  ],
+  "per_statistic": {
+   "rouge_l_f1": {
+    "difference_file_order": -0.003892536068579755,
+    "difference_reversed": -0.003892536068579644,
+    "abs_point_delta": 1.1102230246251565e-16,
+    "ci_file_order": [
+     -0.01567861956350817,
+     0.007883788148443718
+    ],
+    "ci_reversed": [
+     -0.015407106820491106,
+     0.007620529691593839
+    ],
+    "verdict_identical": true
+   },
+   "step_f1": {
+    "difference_file_order": 0.0012643438776565874,
+    "difference_reversed": 0.0012643438776565874,
+    "abs_point_delta": 0.0,
+    "ci_file_order": [
+     -0.014243761004790407,
+     0.016739803948774546
+    ],
+    "ci_reversed": [
+     -0.013982316714073682,
+     0.01691354489593652
+    ],
+    "verdict_identical": true
+   },
+   "ordered_step_accuracy": {
+    "difference_file_order": -0.0012985287044110505,
+    "difference_reversed": -0.0012985287044110227,
+    "abs_point_delta": 2.7755575615628914e-17,
+    "ci_file_order": [
+     -0.016576746031746022,
+     0.014118389992360576
+    ],
+    "ci_reversed": [
+     -0.016522798503239674,
+     0.014238756047873708
+    ],
+    "verdict_identical": true
+   },
+   "composite_score": {
+    "difference_file_order": -0.0018393766158162073,
+    "difference_reversed": -0.0018393766158162073,
+    "abs_point_delta": 0.0,
+    "ci_file_order": [
+     -0.20998523863947088,
+     0.2063293584329041
+    ],
+    "ci_reversed": [
+     -0.2100105295374846,
+     0.20624046836757443
+    ],
+    "verdict_identical": true
+   },
+   "exact_match": {
+    "difference_file_order": -0.0013333333333333322,
+    "difference_reversed": -0.0013333333333333322,
+    "abs_point_delta": 0.0,
+    "ci_file_order": [
+     -0.017333333333333333,
+     0.013333333333333336
+    ],
+    "ci_reversed": [
+     -0.017333333333333333,
+     0.014666666666666665
+    ],
+    "verdict_identical": true
+   },
+   "hop_count_exact_match": {
+    "difference_file_order": -0.010666666666666658,
+    "difference_reversed": -0.010666666666666658,
+    "abs_point_delta": 0.0,
+    "ci_file_order": [
+     -0.053333333333333344,
+     0.033333333333333326
+    ],
+    "ci_reversed": [
+     -0.0546666666666667,
+     0.033333333333333326
+    ],
+    "verdict_identical": true
+   },
+   "composite_no_ref_renorm": {
+    "difference_file_order": -0.0022992207697702938,
+    "difference_reversed": -0.0022992207697702938,
+    "abs_point_delta": 0.0,
+    "ci_file_order": [
+     -0.01800991259371289,
+     0.013215879410550411
+    ],
+    "ci_reversed": [
+     -0.017672382426977055,
+     0.013708156617312017
+    ],
+    "verdict_identical": true
+   }
+  }
+ },
+ "composite_reference_term_diagnostics": {
+  "what": "the composite's reference_validity_micro term rests on a handful of [#k] references per cell; these figures quantify how much of every composite difference it produces",
+  "reference_volume_per_cell": {
+   "n_predictions": 750,
+   "reference_total_count_min": 0,
+   "reference_total_count_max": 29,
+   "reference_total_count_median": 4,
+   "items_emitting_at_least_one_reference_min": 0,
+   "items_emitting_at_least_one_reference_max": 5,
+   "items_emitting_at_least_one_reference_median": 2,
+   "cells_with_zero_references": 3
+  },
+  "over_the_27_size_pairs": {
+   "median_abs_reference_contribution_over_abs_delta_composite": 1.0005723498189523,
+   "pairs_where_reference_term_exceeds_50pct_of_delta": 20,
+   "pairs_where_reference_term_exceeds_90pct_of_delta": 16,
+   "composite_ci_straddles_zero": 25,
+   "composite_ci_width_min": 0.02062454379667468,
+   "composite_ci_width_max": 0.41631459707237495,
+   "composite_ci_width_median": 0.21615190209790217,
+   "composite_no_ref_ci_width_min": 0.025780679745843305,
+   "composite_no_ref_ci_width_max": 0.03230515055750349,
+   "composite_no_ref_ci_width_median": 0.028611071999658944,
+   "max_abs_residual_of_four_term_decomposition": 5.551115123125783e-17
+  },
+  "aggregate_per_size_cell_means": {
+   "1000": {
+    "num_cells_all": 12,
+    "num_cells_imbalanced": 6,
+    "mean_composite_all_cells": 0.2321842171239128,
+    "mean_composite_imbalanced_only": 0.21378043731393784,
+    "mean_composite_no_ref_imbalanced_only": 0.23118057309744877,
+    "mean_step_f1_imbalanced_only": 0.16975526483225142,
+    "mean_exact_match_imbalanced_only": 0.03155555555555556,
+    "mean_hop_em_imbalanced_only": 0.48355555555555557,
+    "mean_reference_validity_micro_imbalanced_only": 0.14417989417989419,
+    "total_references_emitted_imbalanced_only": 41
+   },
+   "2000": {
+    "num_cells_all": 9,
+    "num_cells_imbalanced": 6,
+    "mean_composite_all_cells": 0.2706659141721374,
+    "mean_composite_imbalanced_only": 0.2629870475546715,
+    "mean_composite_no_ref_imbalanced_only": 0.24019214277667275,
+    "mean_step_f1_imbalanced_only": 0.18164820898371623,
+    "mean_exact_match_imbalanced_only": 0.043555555555555556,
+    "mean_hop_em_imbalanced_only": 0.4848888888888889,
+    "mean_reference_validity_micro_imbalanced_only": 0.3541666666666667,
+    "total_references_emitted_imbalanced_only": 29
+   },
+   "4000": {
+    "num_cells_all": 6,
+    "num_cells_imbalanced": 6,
+    "mean_composite_all_cells": 0.31050220781721816,
+    "mean_composite_imbalanced_only": 0.31050220781721816,
+    "mean_composite_no_ref_imbalanced_only": 0.24229442643818938,
+    "mean_step_f1_imbalanced_only": 0.18412751005253586,
+    "mean_exact_match_imbalanced_only": 0.04555555555555556,
+    "mean_hop_em_imbalanced_only": 0.4811111111111111,
+    "mean_reference_validity_micro_imbalanced_only": 0.5833333333333334,
+    "total_references_emitted_imbalanced_only": 13
+   },
+   "8000": {
+    "num_cells_all": 6,
+    "num_cells_imbalanced": 6,
+    "mean_composite_all_cells": 0.2295199819602864,
+    "mean_composite_imbalanced_only": 0.2295199819602864,
+    "mean_composite_no_ref_imbalanced_only": 0.2465229933233739,
+    "mean_step_f1_imbalanced_only": 0.1896921838319155,
+    "mean_exact_match_imbalanced_only": 0.04688888888888889,
+    "mean_hop_em_imbalanced_only": 0.49333333333333335,
+    "mean_reference_validity_micro_imbalanced_only": 0.1615079365079365,
+    "total_references_emitted_imbalanced_only": 37
+   }
+  },
+  "aggregate_8000_minus_4000_composite_decomposition": {
+   "level": "cell-mean over the 6 imbalanced cells at each size \u2014 NOT a per-item statistic and carries no CI",
+   "delta_composite": -0.08098222585693177,
+   "contribution_reference_validity_micro": -0.08436507936507938,
+   "contribution_reference_share_pct": 104.17727899221241,
+   "contribution_step_f1": 0.0022258695117518545,
+   "contribution_ordered_step_accuracy": 0.0011273543667661367,
+   "contribution_step_count_term": 2.9629629629635003e-05,
+   "sum_of_contributions": -0.08098222585693175
+  }
+ },
+ "power": {
+  "formula": "paired two-sided t-test, alpha=0.05, 80% power: n = ((z_{1-a/2}+z_{0.8}) * sd(diff) / diff)^2 with the 2.8016 constant, and MDE = 2.8016 * sd(diff) / sqrt(n)",
+  "per_metric": {
+   "exact_match": {
+    "n": 750,
+    "median_mde_80_power": 0.01905797331823066,
+    "min_mde": 0.015382357994988136,
+    "max_mde": 0.022386185414391312,
+    "median_sd_of_per_item_difference": 0.18629500797270335
+   },
+   "step_f1": {
+    "n": 750,
+    "median_mde_80_power": 0.020908742721722103,
+    "min_mde": 0.018588899262871897,
+    "max_mde": 0.024094591429246047,
+    "median_sd_of_per_item_difference": 0.2043866011878776
+   },
+   "ordered_step_accuracy": {
+    "n": 750,
+    "median_mde_80_power": 0.020481997794117704,
+    "min_mde": 0.018248285226028043,
+    "max_mde": 0.023305292102377192,
+    "median_sd_of_per_item_difference": 0.200215095206477
+   },
+   "rouge_l_f1": {
+    "n": 750,
+    "median_mde_80_power": 0.014888441785156447,
+    "min_mde": 0.01373590473098613,
+    "max_mde": 0.016886409941159225,
+    "median_sd_of_per_item_difference": 0.14553711114778467
+   },
+   "hop_count_exact_match": {
+    "n": 750,
+    "median_mde_80_power": 0.058084891393519904,
+    "min_mde": 0.05492570755863936,
+    "max_mde": 0.0634064883999793,
+    "median_sd_of_per_item_difference": 0.5677899283707263
+   }
+  },
+  "adjacent_step_pairs_n_needed": {
+   "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw|step_f1": {
+    "observed_difference": -0.0018460824578471638,
+    "sd_difference": 0.18821050708241194,
+    "n_needed_for_80_power_at_observed_difference": 81583
+   },
+   "size4000_imbalanced_trial0__biencoder_only__raw|size2000_imbalanced_trial0__biencoder_only__raw|ordered_step_accuracy": {
+    "observed_difference": 0.0004148629148629149,
+    "sd_difference": 0.18390043636324854,
+    "n_needed_for_80_power_at_observed_difference": 1542299
+   },
+   "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw|step_f1": {
+    "observed_difference": 0.00885046805046805,
+    "sd_difference": 0.19736913310621682,
+    "n_needed_for_80_power_at_observed_difference": 3904
+   },
+   "size8000_imbalanced_trial0__biencoder_only__raw|size4000_imbalanced_trial0__biencoder_only__raw|ordered_step_accuracy": {
+    "observed_difference": 0.005225348725348725,
+    "sd_difference": 0.18731657657911555,
+    "n_needed_for_80_power_at_observed_difference": 10087
+   },
+   "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed|step_f1": {
+    "observed_difference": -0.004621647747963537,
+    "sd_difference": 0.19730972443352351,
+    "n_needed_for_80_power_at_observed_difference": 14306
+   },
+   "size4000_imbalanced_trial0__biencoder_only__typed|size2000_imbalanced_trial0__biencoder_only__typed|ordered_step_accuracy": {
+    "observed_difference": -0.006915987715987717,
+    "sd_difference": 0.19402066579322994,
+    "n_needed_for_80_power_at_observed_difference": 6178
+   },
+   "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed|step_f1": {
+    "observed_difference": 0.008155900744136038,
+    "sd_difference": 0.21589420110463672,
+    "n_needed_for_80_power_at_observed_difference": 5500
+   },
+   "size8000_imbalanced_trial0__biencoder_only__typed|size4000_imbalanced_trial0__biencoder_only__typed|ordered_step_accuracy": {
+    "observed_difference": 0.007063654863654864,
+    "sd_difference": 0.21363477322061908,
+    "n_needed_for_80_power_at_observed_difference": 7180
+   },
+   "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform|step_f1": {
+    "observed_difference": -0.00011604691604691789,
+    "sd_difference": 0.19054401029000892,
+    "n_needed_for_80_power_at_observed_difference": 21160974
+   },
+   "size4000_imbalanced_trial0__biencoder_only__uniform|size2000_imbalanced_trial0__biencoder_only__uniform|ordered_step_accuracy": {
+    "observed_difference": 0.0010169312169312176,
+    "sd_difference": 0.18475382884991115,
+    "n_needed_for_80_power_at_observed_difference": 259070
+   },
+   "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform|step_f1": {
+    "observed_difference": 0.009195286195286196,
+    "sd_difference": 0.1970816537658678,
+    "n_needed_for_80_power_at_observed_difference": 3606
+   },
+   "size8000_imbalanced_trial0__biencoder_only__uniform|size4000_imbalanced_trial0__biencoder_only__uniform|ordered_step_accuracy": {
+    "observed_difference": 0.0073904761904761895,
+    "sd_difference": 0.19000193055887318,
+    "n_needed_for_80_power_at_observed_difference": 5188
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw|step_f1": {
+    "observed_difference": 0.00945970064793594,
+    "sd_difference": 0.1936082603274075,
+    "n_needed_for_80_power_at_observed_difference": 3288
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__raw|size2000_imbalanced_trial0__biencoder_plus_ce__raw|ordered_step_accuracy": {
+    "observed_difference": 0.01101024784182679,
+    "sd_difference": 0.1878548986064832,
+    "n_needed_for_80_power_at_observed_difference": 2285
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw|step_f1": {
+    "observed_difference": 0.0021513623631270705,
+    "sd_difference": 0.1953143563755981,
+    "n_needed_for_80_power_at_observed_difference": 64693
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__raw|size4000_imbalanced_trial0__biencoder_plus_ce__raw|ordered_step_accuracy": {
+    "observed_difference": 0.0015587301587301585,
+    "sd_difference": 0.18383680955928414,
+    "n_needed_for_80_power_at_observed_difference": 109179
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed|step_f1": {
+    "observed_difference": 0.005346347533304055,
+    "sd_difference": 0.18505736403052425,
+    "n_needed_for_80_power_at_observed_difference": 9404
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__typed|size2000_imbalanced_trial0__biencoder_plus_ce__typed|ordered_step_accuracy": {
+    "observed_difference": 0.009445286195286196,
+    "sd_difference": 0.1837676710576144,
+    "n_needed_for_80_power_at_observed_difference": 2972
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed|step_f1": {
+    "observed_difference": 0.013248899248899252,
+    "sd_difference": 0.2055380588563879,
+    "n_needed_for_80_power_at_observed_difference": 1890
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__typed|size4000_imbalanced_trial0__biencoder_plus_ce__typed|ordered_step_accuracy": {
+    "observed_difference": 0.010361640211640212,
+    "sd_difference": 0.20637531564291353,
+    "n_needed_for_80_power_at_observed_difference": 3114
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform|step_f1": {
+    "observed_difference": 0.006653535353535352,
+    "sd_difference": 0.18170972739623953,
+    "n_needed_for_80_power_at_observed_difference": 5855
+   },
+   "size4000_imbalanced_trial0__biencoder_plus_ce__uniform|size2000_imbalanced_trial0__biencoder_plus_ce__uniform|ordered_step_accuracy": {
+    "observed_difference": 0.006682641432641431,
+    "sd_difference": 0.17838016587099903,
+    "n_needed_for_80_power_at_observed_difference": 5593
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform|step_f1": {
+    "observed_difference": -0.008213873925638632,
+    "sd_difference": 0.20445450906127363,
+    "n_needed_for_80_power_at_observed_difference": 4864
+   },
+   "size8000_imbalanced_trial0__biencoder_plus_ce__uniform|size4000_imbalanced_trial0__biencoder_plus_ce__uniform|ordered_step_accuracy": {
+    "observed_difference": -0.00905276281452752,
+    "sd_difference": 0.200215095206477,
+    "n_needed_for_80_power_at_observed_difference": 3840
+   }
+  }
+ },
+ "independence_caveat": "The 27 size pairs and 9 balance pairs share the identical 750 eval items and their pools are largely nested, so they are not independent. Sign counts across pairs are descriptive; no across-pair test was run and none is claimed.",
+ "unmeasured": [
+  "any v2 run \u2014 nothing here was executed on v2 code or v2 models",
+  "within-cell seed variance: only trial0 exists in the sweep, so pool-draw variance is unmeasured",
+  "pool sizes outside {1000, 2000, 4000, 8000}",
+  "balanced pools at sizes 4000 and 8000 (cells absent) and balanced+CE at 2000 (cell absent)",
+  "any guided (hop-forced) condition",
+  "MetaQA",
+  "the v1 predictions' own provenance (decoder, prompt revision, whether the 750 draw is reproducible)"
+ ]
+}

--- a/docs/analysis/2026-08-20-v1-pool-size-significance.json
+++ b/docs/analysis/2026-08-20-v1-pool-size-significance.json
@@ -40,7 +40,7 @@
   "v1_repo": "/cta/users/fyilmaz/Thesis---QA",
   "v1_head_commit": "a020fd6",
   "v1_head_does_not_pin_these_files": "runs/ is gitignored and untracked in v1; git ls-files runs/ returns 0 files",
-  "statistics_computed_from": "the 33 eval_per_item.json files listed below; no statistic in this file is computed from any aggregate CSV",
+  "statistics_computed_from": "the 33 eval_per_item.json files listed below, for every statistic in the note's sections 4, 5 and 7; section 6's pool-composition figures are the one exception - its nesting overlaps come from the six pool.jsonl files and its exemplar counts from the six pool stats.json files, both hashed here. No statistic is computed from any aggregate CSV.",
   "per_item_files": {
    "size1000_balanced_trial0__biencoder_only__raw": {
     "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/eval/size1000_balanced_trial0__biencoder_only__raw/eval_per_item.json",
@@ -571,6 +571,38 @@
    "size8000_imbalanced_trial0_poolseed42": {
     "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size8000_imbalanced_trial0_poolseed42/stats.json",
     "sha256": "6bfa4d2f6affa00f1009b7a1cbd3881ef89516eb6cff503646cf3340fa4759f5",
+    "mtime_utc": "2026-04-20T09:12:47Z"
+   }
+  },
+  "pool_jsonl_files_used_for_nesting_only": {
+   "size1000_balanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size1000_balanced_trial0_poolseed42/pool.jsonl",
+    "sha256": "11f4b75ff560963a345bb942b8f66a989de9d597197eafd164b44f3e88b4246b",
+    "mtime_utc": "2026-04-20T17:56:47Z"
+   },
+   "size1000_imbalanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size1000_imbalanced_trial0_poolseed42/pool.jsonl",
+    "sha256": "c450adc74ae43f3a7a04f45eb34886003934f327cde06ba878442dfa3f3ef9f4",
+    "mtime_utc": "2026-04-20T01:37:46Z"
+   },
+   "size2000_balanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size2000_balanced_trial0_poolseed42/pool.jsonl",
+    "sha256": "8d28780cc8b0e5fc24b1600b7e7227edb972f6ed93bed46752fb1a02e9ed34e7",
+    "mtime_utc": "2026-04-20T20:30:46Z"
+   },
+   "size2000_imbalanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size2000_imbalanced_trial0_poolseed42/pool.jsonl",
+    "sha256": "cc3646625d759a1b58179b18c25f83d255db24f05acc08b666985af2e58d6646",
+    "mtime_utc": "2026-04-20T04:12:07Z"
+   },
+   "size4000_imbalanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size4000_imbalanced_trial0_poolseed42/pool.jsonl",
+    "sha256": "9c594903a034ceb5fd1e5c7a82cb3db9e080d33a4a4ea39e9d7f4639e935be44",
+    "mtime_utc": "2026-04-20T06:42:23Z"
+   },
+   "size8000_imbalanced_trial0_poolseed42": {
+    "path": "/cta/users/fyilmaz/Thesis---QA/runs/pool_sweep/pools/size8000_imbalanced_trial0_poolseed42/pool.jsonl",
+    "sha256": "cca90df030e4e5aa7748b41a1426a6a3c9444a2d439d4e6403208fa3f11d2e77",
     "mtime_utc": "2026-04-20T09:12:47Z"
    }
   },

--- a/docs/analysis/2026-08-20-v1-pool-size-significance.md
+++ b/docs/analysis/2026-08-20-v1-pool-size-significance.md
@@ -37,9 +37,13 @@ entry.
 
 ## 1. Method — what was run
 
-House protocol is ADR 0009 as amended 2026-08-20 (paired bootstrap + exact McNemar, with a paired
-t-test alongside per issue #30), implemented in `scripts/musique_decompositions_evaluator.py`
-`--compare` and documented in `docs/METRICS.md` §5. Parameters are v2's own
+House protocol is ADR 0009 as amended 2026-08-20: **paired bootstrap + exact McNemar**, implemented
+in `scripts/musique_decompositions_evaluator.py` `--compare` and documented in `docs/METRICS.md` §5,
+**plus a paired t-test reported alongside** per the ADR 0009 amendment (issue #30). Be precise about
+the second one: at this note's base SHA `50daea7` the t-test is **not** in the committed evaluator and
+is not in `docs/METRICS.md` — its implementation was in progress in a separate lane at the time of
+writing, and every t-test figure below comes from `scipy.stats.ttest_rel` in this session's harness
+(§1, last paragraph). Parameters are v2's own
 (`configs/musique_eval.json`): **10,000 bootstrap resamples, chunk size 1,000, α = 0.05, seed 42**,
 `numpy.random.default_rng`, one index matrix applied to both systems, percentile CI of (A − B),
 composite recomputed on every resample with weights 0.4 / 0.3 / 0.2 / 0.1 and step-count scale 3.0.
@@ -82,8 +86,13 @@ does not perturb the RNG stream, so those four columns are exactly what `--compa
 All paths under `/cta/users/fyilmaz/Thesis---QA` (read-only; not modified). v1 HEAD is `a020fd6` with
 a clean tree, but the run files are untracked, so that SHA does **not** pin them.
 
-**Statistics are computed only from the 33 `runs/pool_sweep/eval/<cell>/eval_per_item.json` files**
-below (sha256 first 12 hex; full hashes in the JSON companion):
+**Every statistic in §4, §5 and §7 is computed from the 33
+`runs/pool_sweep/eval/<cell>/eval_per_item.json` files** below (sha256 first 12 hex; full hashes in
+the JSON companion). **§6 is the one exception:** its nesting overlaps come from the six
+`runs/pool_sweep/pools/*/pool.jsonl` files (pool item ids) and its exemplar counts from the six
+`stats.json` beside them — all twelve hashed in the companion under
+`inputs.pool_jsonl_files_used_for_nesting_only` and
+`inputs.pool_stats_files_used_for_composition_only`.
 
 | cell | sha256[:12] | mtime (UTC) |
 |---|---|---|
@@ -122,10 +131,11 @@ below (sha256 first 12 hex; full hashes in the JSON companion):
 | `size8000_imbalanced_trial0__biencoder_plus_ce__uniform` | `c5ccdb504f23` | 2026-04-20T11:44:19Z |
 
 The 33 `eval_metrics.json` and 33 `eval_config.json` files beside them are used **only** for
-provenance and cross-checking; their hashes are in the JSON companion. Also hashed there: the eval
+provenance and cross-checking; their hashes are in the JSON companion. Also hashed there: the six
+`pool.jsonl` files and the six pool `stats.json` files behind §6; the eval
 sample `runs/pool_sweep/dev_sample/dev_sample_250per_hop_seed42.jsonl`
-(sha256 `3ec876260e74c274…`, mtime 2026-04-20T01:37:46Z) and its stats file; the six pool
-`stats.json` files; and both copies of the aggregate CSV — `runs/pool_sweep/summary/all_runs.csv` and
+(sha256 `3ec876260e74c274…`, mtime 2026-04-20T01:37:46Z) and its stats file; and both copies of the
+aggregate CSV — `runs/pool_sweep/summary/all_runs.csv` and
 `handoff/results_analysis/pool_sweep_summary/all_runs.csv`, which are **byte-identical** (sha256
 `89c5e923ddbb…`, verified) and are used **only as a cross-check**. **No statistic in this note is
 computed from an aggregate CSV.**
@@ -228,6 +238,11 @@ five real per-item metrics (EM, step F1, ordered accuracy, ROUGE-L, hop EM):
 | 4000 vs 8000 | 6 | **0** | 5 / 1 | 0 | 0 |
 | 1000 vs 8000 | 6 | **6** | **6 / 0** | 4 | **4** |
 
+The third column counts **CI-significance only**, as its heading says. Read with the t-test the one
+change is 4000 vs 8000, where 1 of the 30 metric-cells is t-significant uncorrected (hop EM,
+p = 0.0476) on a CI whose lower bound is exactly 0.0 — §4.2 and §4.4. It survives no correction, and
+no 4000-vs-8000 cell is McNemar-significant.
+
 Across all 27 size pairs: step F1 favours the larger pool in **21/27** (6 CI-significant, 6
 t-significant), ordered accuracy in **20/27** (6/6), EM in **19/27** (5 CI-sig, 6 t-sig, 3
 McNemar-sig), ROUGE-L in **15/27** (3/3), hop EM in **14/27** (3 CI-sig, 4 t-sig, 3 McNemar-sig).
@@ -261,8 +276,15 @@ p = 0.0005**).
   `size2000_balanced_BE_uniform` vs `size2000_imbalanced` step F1 (CI [−0.0312, −0.0000], t p = 0.0566).
 - **Overall rows, CI vs exact McNemar:** 72 comparisons, **3 disagreements**, all EM with McNemar
   p just above α (0.0501, 0.0614, 0.0522 on 32 / 29 / 27 discordant pairs).
-- **Per-hop rows, CI vs t:** 540 comparisons, **4 disagreements**, all with a p between 0.045 and
-  0.051 or a CI endpoint within 1e-4 of 0.
+- **Per-hop rows, CI vs t:** 540 comparisons, **4 disagreements**, each with a t-test p between
+  **0.0453 and 0.0508**; two of the four have a CI endpoint of **exactly 0.0** and the other two have
+  an endpoint **7.6e-05** and **2.6e-04** from 0.
+
+**Why these near-misses matter for reading the tables.** `significant` in the bootstrap column is
+`ci_low > 0 or ci_high < 0` — a strict inequality, so a CI endpoint that lands on exactly 0.0 reads
+as *not* significant. Three of the seven disagreements above are that knife-edge (endpoint exactly
+0.0), including the one 4000-vs-8000 cell §4.4 and §7 name explicitly. Where a claim below turns on
+this, the test basis is stated rather than the word "significant" alone.
 
 None of these disagreements changes a conclusion in §9; each is a cell that should not be leaned on.
 Full lists are in the JSON under `verdict_agreement`.
@@ -314,8 +336,12 @@ Consequences, all measured:
   Decomposing that 4000→8000 cell-mean drop of **−0.0810** (imbalanced-only, 6 cells each side):
   reference term **−0.0844 = 104.2% of it**, step F1 **+0.0022**, ordered accuracy **+0.0011**,
   step-count term **+0.0000**. Mean `reference_validity_micro` falls 0.5833 → 0.1615 between those
-  size groups — on **13 total references at 4000 and 37 at 8000**. Per-item, **no metric in any of the
-  six 4000-vs-8000 pairs is significant by any test**, and step F1 favours 8000 in 5 of 6.
+  size groups — on **13 total references at 4000 and 37 at 8000**. Per-item, across the six
+  4000-vs-8000 pairs, **0 of 30 metric-cells are CI-significant, 0 of 12 are McNemar-significant, and
+  nothing survives Holm** (smallest Holm-adjusted p **0.2855**); **1 of 30 is t-significant
+  uncorrected** — `biencoder_only` / `uniform` hop EM, **+0.0413**, t = 1.984, **p = 0.0476**, whose CI
+  **[0.0000, +0.0827]** misses only on the strict knife-edge of §4.2 and whose McNemar is 138/107,
+  p = 0.0551. Step F1 favours 8000 in 5 of 6.
 - Reading the same size axis on the reference-free diagnostic **reverses the direction**: cell means
   rise monotonically 0.2312 → 0.2402 → 0.2423 → 0.2465 from 1000 to 8000 (§4.1).
 
@@ -341,7 +367,9 @@ structural", but three significant cells out of 81 do not establish it.
 ### 4.6 Power at n = 750
 
 Minimum detectable difference (paired, α = 0.05 two-sided, 80% power, from the observed per-item
-difference SDs), median over the 27 size pairs:
+difference SDs), median over the 27 size pairs. The constant used is **2.8016**, a rounding of
+z₀.₉₇₅ + z₀.₈ = 1.95996 + 0.84162 = 2.80158 (also disclosed in the companion under `power.formula`);
+at these SDs the rounding moves an MDE by less than 1e-5.
 
 | metric | median sd(diff) | median MDE at n = 750 |
 |---|---|---|
@@ -422,9 +450,10 @@ the same masked MuSiQue **train** file, with input buckets 2hop 14376 / 3hop 438
 - **Confirmed as arithmetic:** the per-size mean composites (0.232 / 0.271 / 0.311 / 0.230) and the
   best-cell table recompute exactly from the per-item files (§3).
 - **Not supported as an interpretation:** FINDINGS' "larger pool is not always better (8000 drops vs
-  4000)". That drop is **104.2% the reference-validity term** on 13 vs 37 references (§4.4); no
-  4000-vs-8000 metric is significant by any test in any of the 6 matched pairs; and on the
-  reference-free diagnostic the size trend is monotone **upward** through 8000. The "8000 drops"
+  4000)". That drop is **104.2% the reference-validity term** on 13 vs 37 references (§4.4); across
+  the 6 matched 4000-vs-8000 pairs no metric is CI- or McNemar-significant and none survives Holm
+  (smallest adjusted p 0.2855, with one cell t-significant uncorrected at p = 0.0476 — §4.4); and on
+  the reference-free diagnostic the size trend is monotone **upward** through 8000. The "8000 drops"
   reading is an artifact of the composite, not a pool-size finding.
 - **Confirmed, and now with a significance verdict:** "exact match stays ~3–5% across the board — pool
   size alone does not solve gold-plan matching." EM ranges 0.0267–0.0533 across the 33 cells, and the
@@ -433,8 +462,9 @@ the same masked MuSiQue **train** file, with input buckets 2hop 14376 / 3hop 438
 - **Newly measured (the §6 gap of the masking/retrieval note):** the pool-size axis. **1000 is
   measurably worse than 8000** on step-level metrics (6/6 pairs positive on step F1, 4 CI-significant,
   4 Holm-surviving), and worse than 2000 in the imbalanced/typed cell (Holm-surviving on 4 of 5
-  metrics). **Above 1000, no adjacent doubling is significant on anything** (2000 vs 4000: 1 of 30
-  metric-cells; 4000 vs 8000: 0 of 30).
+  metrics). **Above 1000, no adjacent doubling survives correction on anything** — 2000 vs 4000:
+  1 of 30 metric-cells CI-significant, 0 Holm survivors; 4000 vs 8000: **0 of 30 CI-significant,
+  1 of 30 t-significant uncorrected** (p = 0.0476), 0 Holm survivors.
 - **Also newly measured:** balanced vs imbalanced (§5), which `docs/prior-work.md` does not discuss.
 
 ## 8. Unmeasured / out of scope
@@ -454,9 +484,10 @@ is Jahid's call with his supervisor.
 
 1. **If the thesis states a pool-size conclusion from v1, the defensible one is "1000 is too small;
    2000 and above are indistinguishable at n = 750" — not "4000 is best".** Measured: 6/6 pairs
-   favour 8000 over 1000 on step F1 with 4 CI-significant and 4 Holm-surviving; 0 of 6 pairs show any
-   significant 4000-vs-8000 difference; 1 of 6 shows any significant 2000-vs-4000 difference (hop EM,
-   CE + raw). This ranks first because "4000 was best, 8000 dropped" is the sentence most likely to be
+   favour 8000 over 1000 on step F1 with 4 CI-significant and 4 Holm-surviving; **0 of 6 pairs show a
+   CI- or McNemar-significant 4000-vs-8000 difference and none survives Holm** (one cell is
+   t-significant uncorrected, p = 0.0476 — §4.4); 1 of 6 shows a CI-significant 2000-vs-4000
+   difference, which does not survive Holm either (hop EM, CE + raw). This ranks first because "4000 was best, 8000 dropped" is the sentence most likely to be
    carried into the thesis from `docs/prior-work.md` §4, and §4.4 shows it is the reference term.
 2. **If any composite number is quoted on the size axis, it needs the §4.4 caveat attached or it
    should not be quoted.** The reference term produces a median **100.1%** of |Δcomposite| across the

--- a/docs/analysis/2026-08-20-v1-pool-size-significance.md
+++ b/docs/analysis/2026-08-20-v1-pool-size-significance.md
@@ -1,0 +1,493 @@
+# Did v1's few-shot pool size measurably affect decomposition quality?
+
+**Date:** 2026-08-20 · **Author:** analyst agent session · **Scope:** issue #6 item 4, the *pool-size*
+half left unmeasured by
+[`2026-08-20-v1-masking-and-retrieval-significance.md`](2026-08-20-v1-masking-and-retrieval-significance.md)
+§6 · **Runs:** none — this is a re-analysis of existing v1 artifacts under
+[ADR 0020](../adr/0020-prior-work-re-analysis-convention.md), so there is no `experiments/log.md`
+entry.
+
+---
+
+## Prior-work caveat — read this before quoting any number below
+
+**Every input to this note is a v1 artifact** produced in the predecessor repo
+(`/cta/users/fyilmaz/Thesis---QA`, read-only here and unmodified) **before v2's rules existed**.
+
+- v1's `runs/` is gitignored and **untracked** — `git ls-files runs/` in v1 returns **0 files** (ran;
+  observed 0). The 33 per-item files this note analyses therefore **carry no commit SHA**; their only
+  provenance is path + mtime + content hash (§2). This is the ADR 0005 situation.
+- Consequently **these are citable prior work, not v2 experimental claims.** Nothing here may be
+  reported as a v2 measurement, and none of it satisfies Gate 2 (committed code + committed config +
+  fixed seed). Anything the thesis wants to *assert* has to be re-run in v2 first (ADR 0001); which
+  baselines and when is Jahid's call with his supervisor.
+- What is new and reproducible here is the **statistics**: the battery was computed in this session
+  from v1's per-item scores using v2's committed protocol code (§1). The verdicts are properties of
+  v1's numbers and inherit v1's provenance gap.
+- **The harness that produced these figures is not committed** (analyst output is analysis, not code),
+  so the figures are **not re-derivable from committed code** until the `--compare` shim in §9 item 6(b)
+  lands. Every statistic below is emitted machine-readably beside this note in
+  [`2026-08-20-v1-pool-size-significance.json`](2026-08-20-v1-pool-size-significance.json)
+  (statistics only — no dataset content, no per-item rows), which also carries the sha256 + mtime of
+  every input file, the alignment order, the seed/resample parameters and the Holm-adjusted p-values.
+- **This note decides nothing.** ADR 0006 already fixed pool size at 2000; §9 states what v1's own
+  sweep does and does not say about that dimension, as conditionals.
+
+---
+
+## 1. Method — what was run
+
+House protocol is ADR 0009 as amended 2026-08-20 (paired bootstrap + exact McNemar, with a paired
+t-test alongside per issue #30), implemented in `scripts/musique_decompositions_evaluator.py`
+`--compare` and documented in `docs/METRICS.md` §5. Parameters are v2's own
+(`configs/musique_eval.json`): **10,000 bootstrap resamples, chunk size 1,000, α = 0.05, seed 42**,
+`numpy.random.default_rng`, one index matrix applied to both systems, percentile CI of (A − B),
+composite recomputed on every resample with weights 0.4 / 0.3 / 0.2 / 0.1 and step-count scale 3.0.
+Those weights and that scale are identical in v1
+(`Thesis---QA/scripts/musique_decompositions_evaluator.py:411-416`), so the composite compared here is
+the same quantity v1 reported.
+
+v1's per-item files are bare JSON lists with no `item_id` and no stamped composite weights, so v2's
+`--compare` refuses them by design (`_load_per_item` / `_require_matching_weights`). The battery was
+run from a session-local harness that **imports v2's own functions** (`_statistic_arrays`,
+`_paired_bootstrap`, `_mcnemar_exact_p`) and re-implements only the alignment step plus two extra
+bootstrap columns and one diagnostic.
+
+**Validation (ran; observed).** For the four statistics v2's protocol covers (`rouge_l_f1`,
+`step_f1`, `ordered_step_accuracy`, `composite_score`) the harness's difference, CI low and CI high
+were compared against v2's `_paired_bootstrap` called directly on the same rows, at **zero tolerance**
+(exact float equality). Result: **bit-identical on 3/3 spot-checked pairs, 12 fields each** — one
+pool-size pair in the balanced arm, one balance pair, one pool-size pair in the imbalanced arm
+(`validation_against_committed_paired_bootstrap` in the JSON). Adding statistics to the same bootstrap
+does not perturb the RNG stream, so those four columns are exactly what `--compare` would print.
+
+- **Bootstrap columns:** the four house statistics, plus the means of `exact_match` and
+  `hop_count_exact_match`, plus one **diagnostic** — `composite_no_ref_renorm`, the composite with the
+  `reference_validity_micro` term dropped and the remaining weights renormalized to sum to 1
+  (0.5 / 0.375 / 0.125). It is **constructed for this note and is not a house metric**; §4.4 is why it
+  is here.
+- **Exact McNemar** (two-sided, integer binomial on discordant pairs) on the two binary per-item
+  metrics `exact_match` and `hop_count_exact_match`.
+- **Paired t-test:** `scipy.stats.ttest_rel` (scipy 1.17.1 present; no fallback needed) over per-item
+  differences, for those same five per-item metrics. The composite and the composite-without-reference
+  diagnostic **have no per-item value** (a micro rate and an MAE term), so neither a t-test nor
+  McNemar is reported for them — only the bootstrap, which recomputes them.
+- **Per gold hop (2/3/4):** the whole battery re-run on each 250-item subset, seed 42 on that subset.
+  All strata are far above `min_items_for_significance_claim` = 30.
+- **No multiplicity correction in the headline**, per ADR 0009. Holm-Bonferroni is computed within the
+  stated families and reported in §4.3 and §5.
+
+## 2. Inputs — paths and content hashes
+
+All paths under `/cta/users/fyilmaz/Thesis---QA` (read-only; not modified). v1 HEAD is `a020fd6` with
+a clean tree, but the run files are untracked, so that SHA does **not** pin them.
+
+**Statistics are computed only from the 33 `runs/pool_sweep/eval/<cell>/eval_per_item.json` files**
+below (sha256 first 12 hex; full hashes in the JSON companion):
+
+| cell | sha256[:12] | mtime (UTC) |
+|---|---|---|
+| `size1000_balanced_trial0__biencoder_only__raw` | `ee64da7b422f` | 2026-04-20T18:24:03Z |
+| `size1000_balanced_trial0__biencoder_only__typed` | `43231fdbb102` | 2026-04-20T18:49:53Z |
+| `size1000_balanced_trial0__biencoder_only__uniform` | `5792aa706a92` | 2026-04-20T19:16:08Z |
+| `size1000_balanced_trial0__biencoder_plus_ce__raw` | `2e5530974c1e` | 2026-04-20T19:41:03Z |
+| `size1000_balanced_trial0__biencoder_plus_ce__typed` | `f911796f96a4` | 2026-04-20T20:05:27Z |
+| `size1000_balanced_trial0__biencoder_plus_ce__uniform` | `4c3fc18b7138` | 2026-04-20T20:30:46Z |
+| `size1000_imbalanced_trial0__biencoder_only__raw` | `7144c097bfe4` | 2026-04-20T02:32:52Z |
+| `size1000_imbalanced_trial0__biencoder_only__typed` | `e353c76ae359` | 2026-04-20T02:58:15Z |
+| `size1000_imbalanced_trial0__biencoder_only__uniform` | `9547be04e6ea` | 2026-04-20T02:05:33Z |
+| `size1000_imbalanced_trial0__biencoder_plus_ce__raw` | `648a213520d0` | 2026-04-20T03:23:36Z |
+| `size1000_imbalanced_trial0__biencoder_plus_ce__typed` | `bd2f1d6fd499` | 2026-04-20T03:47:31Z |
+| `size1000_imbalanced_trial0__biencoder_plus_ce__uniform` | `c1e6f9759385` | 2026-04-20T04:12:07Z |
+| `size2000_balanced_trial0__biencoder_only__raw` | `70e58b63076c` | 2026-04-20T20:57:38Z |
+| `size2000_balanced_trial0__biencoder_only__typed` | `5fad3c5f009e` | 2026-04-20T21:24:18Z |
+| `size2000_balanced_trial0__biencoder_only__uniform` | `dc5abb6406e0` | 2026-04-20T21:51:10Z |
+| `size2000_imbalanced_trial0__biencoder_only__raw` | `b2bfd5eda5d8` | 2026-04-20T04:37:19Z |
+| `size2000_imbalanced_trial0__biencoder_only__typed` | `b054f418dd52` | 2026-04-20T05:02:19Z |
+| `size2000_imbalanced_trial0__biencoder_only__uniform` | `543f4cfc77c7` | 2026-04-20T05:27:50Z |
+| `size2000_imbalanced_trial0__biencoder_plus_ce__raw` | `e06ffc80a9c1` | 2026-04-20T05:53:28Z |
+| `size2000_imbalanced_trial0__biencoder_plus_ce__typed` | `fd64acc34395` | 2026-04-20T06:17:55Z |
+| `size2000_imbalanced_trial0__biencoder_plus_ce__uniform` | `21fd8dd22295` | 2026-04-20T06:42:23Z |
+| `size4000_imbalanced_trial0__biencoder_only__raw` | `a53aabd9f3cc` | 2026-04-20T07:07:32Z |
+| `size4000_imbalanced_trial0__biencoder_only__typed` | `3a0fb90b6f0c` | 2026-04-20T07:33:32Z |
+| `size4000_imbalanced_trial0__biencoder_only__uniform` | `6ac7af550531` | 2026-04-20T07:58:55Z |
+| `size4000_imbalanced_trial0__biencoder_plus_ce__raw` | `1ab9623bce72` | 2026-04-20T08:23:25Z |
+| `size4000_imbalanced_trial0__biencoder_plus_ce__typed` | `5444b2e2a60e` | 2026-04-20T08:48:29Z |
+| `size4000_imbalanced_trial0__biencoder_plus_ce__uniform` | `18451b8cfe7b` | 2026-04-20T09:12:47Z |
+| `size8000_imbalanced_trial0__biencoder_only__raw` | `0c5bf23b087a` | 2026-04-20T09:38:25Z |
+| `size8000_imbalanced_trial0__biencoder_only__typed` | `2a2dd118ee32` | 2026-04-20T10:04:36Z |
+| `size8000_imbalanced_trial0__biencoder_only__uniform` | `18fcac5e0213` | 2026-04-20T10:29:56Z |
+| `size8000_imbalanced_trial0__biencoder_plus_ce__raw` | `fb5399e1ddc2` | 2026-04-20T10:54:19Z |
+| `size8000_imbalanced_trial0__biencoder_plus_ce__typed` | `a0df3f17bbd7` | 2026-04-20T11:19:06Z |
+| `size8000_imbalanced_trial0__biencoder_plus_ce__uniform` | `c5ccdb504f23` | 2026-04-20T11:44:19Z |
+
+The 33 `eval_metrics.json` and 33 `eval_config.json` files beside them are used **only** for
+provenance and cross-checking; their hashes are in the JSON companion. Also hashed there: the eval
+sample `runs/pool_sweep/dev_sample/dev_sample_250per_hop_seed42.jsonl`
+(sha256 `3ec876260e74c274…`, mtime 2026-04-20T01:37:46Z) and its stats file; the six pool
+`stats.json` files; and both copies of the aggregate CSV — `runs/pool_sweep/summary/all_runs.csv` and
+`handoff/results_analysis/pool_sweep_summary/all_runs.csv`, which are **byte-identical** (sha256
+`89c5e923ddbb…`, verified) and are used **only as a cross-check**. **No statistic in this note is
+computed from an aggregate CSV.**
+
+Each cell's `eval_config.json` records `seed: 42`, `limit: null`, gold
+`MusiQue/Data/dev_data/musique_ans_v1.0_dev_clean.jsonl`, and a predictions path
+`runs/pool_sweep/decomposer/<cell>/results.json`.
+
+## 3. Grid map, pairability, and item-set verification
+
+**The grid is incomplete, and the shape matters for what is comparable.** The full
+`size{1000,2000,4000,8000} × {balanced,imbalanced} × {biencoder_only,biencoder_plus_ce} ×
+{raw,typed,uniform}` cross is 48 cells; **33 exist** (ran; observed):
+
+- **imbalanced arm: complete** — all 4 sizes × both retrieval variants × 3 mask modes = 24 cells.
+- **balanced arm: 9 cells** — size 1000 with both retrieval variants (6), size 2000 with
+  `biencoder_only` only (3). There is **no balanced cell at 4000 or 8000** and no
+  `size2000_balanced__biencoder_plus_ce`. The 15 absent cells are listed in the JSON (`grid.cells_absent`).
+- **`trial0` only** — the sweep has no repeated trial, so **pool-draw variance is unmeasured** and no
+  statistic below separates a size effect from a single-draw effect.
+
+**Pairability (ran; observed).** All 33 cells hold **750 rows each**, and the **normalized question
+sequence is identical across all 33 cells, order included** (True), as are `gold_steps` (True) and
+`gold_hop_count` (True). Gold hop distribution is **250 / 250 / 250** for hops 2 / 3 / 4. The
+sequence is **identical, order included, to the committed eval sample**
+`runs/pool_sweep/dev_sample/dev_sample_250per_hop_seed42.jsonl` (750 rows) — so the cells do share the
+eval sample the brief names, and the comparison is a genuine paired comparison on the full 750.
+
+**Alignment (ADR 0020 condition 3).** One normalized question appears **twice** (rows 370 and 376,
+with identical gold) — a genuinely duplicated eval item, which is why keying by question text is not
+usable and why v2's `--compare` would abort on these files. Alignment is therefore **positional (row
+index), in v1 file order**, and for **every one of the 750 rows of every one of the 36 pairs** the
+row's normalized question **and** `gold_steps` were asserted equal between the two cells (all
+assertions passed). This is a documented deviation from v2's id-based alignment, forced by v1's file
+format; it is safe here only because the 33 sequences are literally identical.
+
+**Aggregate cross-check (ran; observed).** Re-aggregating the per-item rows of all 33 cells reproduced
+each cell's committed `eval_metrics.json` to a maximum absolute delta of **1.2e-15** across EM, step
+F1, ordered accuracy, ROUGE-L F1, hop EM, `reference_validity_micro`, `step_count_abs_error_mae` and
+composite. The same recomputation agrees with `all_runs.csv` to the same 1.2e-15, with **0
+disagreements** over 33 cells. v1's per-size mean-composite figures quoted in `docs/prior-work.md` §4
+(1000: 0.232, 2000: 0.271, 4000: 0.311, 8000: 0.230) recompute as **0.2322 / 0.2707 / 0.3105 /
+0.2295** — they are correct as stated. §4.4 is about what they mean, not whether they are right.
+
+**Read CI bounds to three significant figures, not to the last digit.** The bootstrap resamples row
+indices, so endpoints depend on the order the aligned matrices were built in. Re-running one battery
+in reversed row order (recorded in the JSON under `row_order_sensitivity`) gave point estimates
+identical to ≤ **1.1e-16**, **every significance verdict identical (7/7 statistics)**, and CI endpoints
+moving in the third or fourth decimal (e.g. exact match [−0.0173, +0.0133] in file order vs
+[−0.0173, +0.0147] reversed).
+
+## 4. Primary — pool-size pairs, n = 750 each
+
+**27 matched pool-size pairs** exist, holding balance, retrieval variant and mask mode fixed and
+varying only size: 24 in the imbalanced arm (6 fixed combinations × 4 contrasts) and 3 in the balanced
+arm (1000 vs 2000, `biencoder_only`, 3 mask modes — the only cross-size contrast the balanced arm
+supports). Differences are **(larger pool) − (smaller pool)**, so **positive favours the larger pool**.
+`*` = 95% bootstrap CI excludes 0. `retr` is the retrieval variant: **BE** = `biencoder_only`,
+**CE** = `biencoder_plus_ce`. `compNR` is the §1 diagnostic, not a house metric.
+
+| contrast | balance | retr | mask | EM | step F1 | ord acc | ROUGE-L | hop EM | composite | compNR |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 2000 vs 1000 | balanced | BE | raw | −0.0013 | +0.0013 | −0.0013 | −0.0039 | −0.0107 | −0.0018 | −0.0023 |
+| 2000 vs 1000 | balanced | BE | typed | −0.0107 | −0.0041 | −0.0068 | −0.0050 | −0.0147 | +0.0714 | −0.0059 |
+| 2000 vs 1000 | balanced | BE | uniform | −0.0107 | −0.0031 | −0.0061 | +0.0035 | −0.0200 | +0.1954 | −0.0057 |
+| 2000 vs 1000 | imbal | BE | raw | +0.0160 | **+0.0181\*** | **+0.0164\*** | −0.0020 | +0.0107 | **+0.2112\*** | +0.0140 |
+| 2000 vs 1000 | imbal | BE | typed | **+0.0240\*** | **+0.0241\*** | **+0.0247\*** | **+0.0134\*** | −0.0053 | **+0.0411\*** | **+0.0202\*** |
+| 2000 vs 1000 | imbal | BE | uniform | +0.0053 | +0.0097 | +0.0084 | +0.0042 | +0.0280 | −0.0695 | +0.0103 |
+| 2000 vs 1000 | imbal | CE | raw | +0.0027 | +0.0036 | −0.0003 | +0.0099 | −0.0053 | −0.0280 | +0.0007 |
+| 2000 vs 1000 | imbal | CE | typed | **+0.0147\*** | +0.0110 | +0.0110 | +0.0096 | +0.0107 | +0.0072 | +0.0090 |
+| 2000 vs 1000 | imbal | CE | uniform | +0.0093 | +0.0048 | +0.0018 | +0.0021 | −0.0307 | +0.1333 | −0.0001 |
+| 4000 vs 2000 | imbal | BE | raw | −0.0013 | −0.0018 | +0.0004 | +0.0051 | −0.0107 | +0.0021 | +0.0027 |
+| 4000 vs 2000 | imbal | BE | typed | −0.0040 | −0.0046 | −0.0069 | −0.0023 | +0.0027 | +0.1695 | −0.0069 |
+| 4000 vs 2000 | imbal | BE | uniform | +0.0093 | −0.0001 | +0.0010 | −0.0009 | −0.0240 | +0.1982 | −0.0023 |
+| 4000 vs 2000 | imbal | CE | raw | +0.0027 | +0.0095 | +0.0110 | +0.0060 | **+0.0467\*** | +0.0093 | +0.0116 |
+| 4000 vs 2000 | imbal | CE | typed | +0.0067 | +0.0053 | +0.0094 | −0.0012 | −0.0320 | +0.1030 | +0.0038 |
+| 4000 vs 2000 | imbal | CE | uniform | −0.0013 | +0.0067 | +0.0067 | −0.0003 | −0.0053 | −0.1970 | +0.0038 |
+| 8000 vs 4000 | imbal | BE | raw | −0.0013 | +0.0089 | +0.0052 | +0.0067 | +0.0267 | −0.1970 | +0.0038 |
+| 8000 vs 4000 | imbal | BE | typed | +0.0013 | +0.0082 | +0.0071 | +0.0016 | +0.0213 | −0.1936 | +0.0079 |
+| 8000 vs 4000 | imbal | BE | uniform | +0.0013 | +0.0092 | +0.0074 | −0.0004 | +0.0413 | −0.1735 | +0.0123 |
+| 8000 vs 4000 | imbal | CE | raw | +0.0080 | +0.0022 | +0.0016 | −0.0039 | −0.0187 | −0.0008 | −0.0010 |
+| 8000 vs 4000 | imbal | CE | typed | −0.0027 | +0.0132 | +0.0104 | −0.0020 | +0.0253 | +0.0289 | +0.0111 |
+| 8000 vs 4000 | imbal | CE | uniform | +0.0013 | −0.0082 | −0.0091 | −0.0026 | −0.0227 | +0.0502 | −0.0087 |
+| 8000 vs 1000 | imbal | BE | raw | +0.0133 | **+0.0251\*** | **+0.0221\*** | +0.0098 | +0.0267 | +0.0164 | **+0.0205\*** |
+| 8000 vs 1000 | imbal | BE | typed | **+0.0213\*** | **+0.0277\*** | **+0.0249\*** | **+0.0127\*** | +0.0187 | +0.0170 | **+0.0212\*** |
+| 8000 vs 1000 | imbal | BE | uniform | **+0.0160\*** | **+0.0187\*** | **+0.0168\*** | +0.0028 | **+0.0453\*** | −0.0448 | **+0.0203\*** |
+| 8000 vs 1000 | imbal | CE | raw | +0.0133 | +0.0152 | +0.0123 | **+0.0120\*** | +0.0227 | −0.0195 | +0.0113 |
+| 8000 vs 1000 | imbal | CE | typed | **+0.0187\*** | **+0.0296\*** | **+0.0308\*** | +0.0064 | +0.0040 | +0.1390 | **+0.0238\*** |
+| 8000 vs 1000 | imbal | CE | uniform | +0.0093 | +0.0033 | −0.0006 | −0.0008 | **−0.0587\*** | −0.0136 | −0.0050 |
+
+### 4.1 The pattern: the 1000-vs-8000 extremes separate; the adjacent steps above 1000 do not
+
+Counting how many of the pairs in each contrast family show **any** CI-significant difference on the
+five real per-item metrics (EM, step F1, ordered accuracy, ROUGE-L, hop EM):
+
+| contrast | pairs | pairs with ≥1 CI-significant metric | step F1 sign (+/−) | step F1 CI-sig | step F1 Holm survivors |
+|---|---|---|---|---|---|
+| 1000 vs 2000 | 9 | **3** (all three in the imbalanced arm) | 7 / 2 | 2 | 1 |
+| 2000 vs 4000 | 6 | **1** (hop EM only, CE + raw) | 3 / 3 | 0 | 0 |
+| 4000 vs 8000 | 6 | **0** | 5 / 1 | 0 | 0 |
+| 1000 vs 8000 | 6 | **6** | **6 / 0** | 4 | **4** |
+
+Across all 27 size pairs: step F1 favours the larger pool in **21/27** (6 CI-significant, 6
+t-significant), ordered accuracy in **20/27** (6/6), EM in **19/27** (5 CI-sig, 6 t-sig, 3
+McNemar-sig), ROUGE-L in **15/27** (3/3), hop EM in **14/27** (3 CI-sig, 4 t-sig, 3 McNemar-sig).
+
+Cell-mean absolute values line up with that reading. Averaged over the **6 imbalanced cells at each
+size** (a cell-mean, not a per-item statistic, and carrying no CI):
+
+| size | mean step F1 | mean EM | mean hop EM | mean compNR |
+|---|---|---|---|---|
+| 1000 | 0.1698 | 0.0316 | 0.4836 | 0.2312 |
+| 2000 | 0.1816 | 0.0436 | 0.4849 | 0.2402 |
+| 4000 | 0.1841 | 0.0456 | 0.4811 | 0.2423 |
+| 8000 | 0.1897 | 0.0469 | 0.4933 | 0.2465 |
+
+Step F1, EM and the reference-free diagnostic are **weakly monotone increasing in pool size**; hop EM
+is **not** monotone (4000 < 1000 < 2000 < 8000). The increments above 1000 are 0.002–0.006 step F1 per
+doubling — below what n = 750 can resolve (§4.5).
+
+The two largest single effects in the whole table are both **`typed` at 8000 vs 1000**: step F1
+**+0.0277** with `biencoder_only` (CI [+0.0122, +0.0431], t = 3.496, p = 0.0005) and **+0.0296** with
+`biencoder_plus_ce` (CI [+0.0141, +0.0457], t = 3.683, p = 0.0002), with ordered accuracy +0.0249 and
++0.0308 respectively. The largest EM effect is **+0.0240** at 2000 vs 1000, imbalanced / BE / typed
+(0.0507 vs 0.0267; CI [+0.0107, +0.0373]; t = 3.557, p = 0.0004; **McNemar 22/4 discordant,
+p = 0.0005**).
+
+### 4.2 The three tests agree almost everywhere
+
+- **Overall rows, CI vs paired t:** 180 comparisons (36 pairs × 5 metrics), **3 disagreements**, all
+  borderline — `size2000_imbal_BE_raw` vs `size1000` EM (CI [0.0000, +0.0320], t p = 0.0454);
+  `size8000_imbal_BE_uniform` vs `size4000` hop EM (CI [0.0000, +0.0827], t p = 0.0476);
+  `size2000_balanced_BE_uniform` vs `size2000_imbalanced` step F1 (CI [−0.0312, −0.0000], t p = 0.0566).
+- **Overall rows, CI vs exact McNemar:** 72 comparisons, **3 disagreements**, all EM with McNemar
+  p just above α (0.0501, 0.0614, 0.0522 on 32 / 29 / 27 discordant pairs).
+- **Per-hop rows, CI vs t:** 540 comparisons, **4 disagreements**, all with a p between 0.045 and
+  0.051 or a CI endpoint within 1e-4 of 0.
+
+None of these disagreements changes a conclusion in §9; each is a cell that should not be leaned on.
+Full lists are in the JSON under `verdict_agreement`.
+
+### 4.3 Under Holm correction, only the 1000-vs-8000 family holds up
+
+Holm-Bonferroni within each **contrast × metric** family (family = every fixed combination on which
+that contrast exists — 9 tests for 1000 vs 2000, 6 for the others):
+
+| family | metric | family size | survivors at α = 0.05 | smallest adjusted p |
+|---|---|---|---|---|
+| 1000 vs 2000 | EM (t) | 9 | 1 (imbal BE typed, 0.0036) | 0.0036 |
+| 1000 vs 2000 | EM (McNemar) | 9 | 1 (imbal BE typed, 0.0048) | 0.0048 |
+| 1000 vs 2000 | step F1 | 9 | 1 (imbal BE typed, 0.0096) | 0.0096 |
+| 1000 vs 2000 | ord acc | 9 | 1 (imbal BE typed, 0.0045) | 0.0045 |
+| 1000 vs 2000 | ROUGE-L / hop EM | 9 | 0 | 0.1034 / 1.0000 |
+| 2000 vs 4000 | all five metrics | 6 | **0** | 0.1076 (hop EM) |
+| 4000 vs 8000 | all five metrics | 6 | **0** | 0.2855 (hop EM) |
+| 1000 vs 8000 | step F1 | 6 | **4** (BE raw 0.0143, BE typed 0.0025, BE uniform 0.0443, CE typed 0.0015) | 0.0015 |
+| 1000 vs 8000 | ord acc | 6 | **3** (BE raw 0.0319, BE typed 0.0061, CE typed 0.0008) | 0.0008 |
+| 1000 vs 8000 | EM (t) | 6 | 1 (BE typed 0.0147) | 0.0147 |
+| 1000 vs 8000 | EM (McNemar) | 6 | 1 (BE typed 0.0223) | 0.0223 |
+| 1000 vs 8000 | ROUGE-L / hop EM | 6 | 0 | 0.1967 / 0.0508 |
+
+Within-pair Holm across each pair's own five-metric family is also in the JSON
+(`holm_per_pair_5metric_family`): the 2000-vs-1000 imbalanced/BE/typed pair keeps **4 of 5** metrics
+(smallest adjusted p 0.0020), and both typed 8000-vs-1000 pairs keep **3 of 5** (smallest 0.0025 and
+0.0006). So the headline effects here are, unlike v1's masking effects, **not fragile under
+correction**.
+
+### 4.4 The composite is not usable for reading the size trend — and v1's "8000 drops vs 4000" is the reference term
+
+The composite's `reference_validity_micro` term is decided by a handful of `[#k]` references per cell.
+Measured over the 33 cells (750 predictions each): **median 4 references per cell** (min 0, max 29),
+**median 2 items** emitting any reference (min 0, max 5), and **3 cells emit none at all** — which
+score 1.0 on that term by the micro convention when the denominator is empty.
+
+Consequences, all measured:
+
+- Over the 27 size pairs, the **median share of |Δcomposite| produced by the 0.2-weighted reference
+  term is 100.1%**; the term exceeds 50% of the difference in **20/27** pairs and exceeds 90% in
+  **16/27**. (The four weighted term contributions sum to Δcomposite exactly — max residual
+  5.6e-17.)
+- **25 of 27 composite CIs straddle 0**, with widths from 0.0206 to 0.4163 (median 0.2162) on a
+  0-to-1 scale. The reference-free diagnostic's CIs are 0.0258–0.0323 wide (median 0.0286) — an order
+  of magnitude tighter, because it is not resampling three-item terms.
+- **v1's headline size trend is that term.** `docs/prior-work.md` §4 reports mean composite by size
+  with "size 4000 highest at 0.311 … 8000: 0.230" and reads it as *larger is not always better*.
+  Decomposing that 4000→8000 cell-mean drop of **−0.0810** (imbalanced-only, 6 cells each side):
+  reference term **−0.0844 = 104.2% of it**, step F1 **+0.0022**, ordered accuracy **+0.0011**,
+  step-count term **+0.0000**. Mean `reference_validity_micro` falls 0.5833 → 0.1615 between those
+  size groups — on **13 total references at 4000 and 37 at 8000**. Per-item, **no metric in any of the
+  six 4000-vs-8000 pairs is significant by any test**, and step F1 favours 8000 in 5 of 6.
+- Reading the same size axis on the reference-free diagnostic **reverses the direction**: cell means
+  rise monotonically 0.2312 → 0.2402 → 0.2423 → 0.2465 from 1000 to 8000 (§4.1).
+
+### 4.5 Per-hop, and where the size effect lives
+
+Per gold hop (n = 250 each), across all 27 size pairs × 3 strata: CI-significant cells are
+**EM 10/81, step F1 10/81, ordered accuracy 9/81, ROUGE-L 8/81, hop EM 4/81, composite 10/81,
+compNR 12/81**. Excluding the composite column, that is 53 significant cells, of which **7 favour the
+smaller pool** and 46 the larger. The 1000-vs-8000 family holds **23 of the 53**, concentrated in
+**hop 2** (e.g. imbalanced BE raw: step F1 +0.0604 CI [+0.0235, +0.0986]; imbalanced BE typed: EM
++0.0520 CI [+0.0160, +0.0920], step F1 +0.0511) and, for **typed only**, also in **hop 4** (BE typed:
+step F1 +0.0369, hop EM +0.0920 CI [+0.0160, +0.1720]; CE typed: step F1 +0.0339, ordered accuracy
++0.0329). Within this family the only significant hop-4 effect **against** the larger pool is
+`8000 vs 1000, imbalanced CE uniform` hop EM **−0.0880** (CI [−0.1680, −0.0080]); across all 27 pairs
+there are three more negative significant hop-4 cells, all in other families and all listed in the
+JSON.
+
+Suggestive, not established: the imbalanced pool's 4-hop exemplar count grows 81 → 126 → 245 → 495
+across the four sizes (pool `stats.json`, §6), and the only sizeable hop-4 gains appear with `typed`
+masking. That is consistent with "more deep exemplars help deep questions when the retrieval text is
+structural", but three significant cells out of 81 do not establish it.
+
+### 4.6 Power at n = 750
+
+Minimum detectable difference (paired, α = 0.05 two-sided, 80% power, from the observed per-item
+difference SDs), median over the 27 size pairs:
+
+| metric | median sd(diff) | median MDE at n = 750 |
+|---|---|---|
+| exact match | 0.1863 | 0.0191 |
+| step F1 | 0.2044 | 0.0209 |
+| ordered step accuracy | 0.2002 | 0.0205 |
+| ROUGE-L F1 | 0.1455 | 0.0149 |
+| hop-count EM | 0.5678 | 0.0581 |
+
+n = 750 buys about **2 points** of step F1 / ordered accuracy and about **6 points** of hop EM. The
+adjacent-step differences above 1000 are 0.000–0.013, i.e. **below the detection threshold**: the n
+required for 80% power at each observed 2000-vs-4000 or 4000-vs-8000 step-level difference ranges from
+**1,890** (8000 vs 4000, CE typed, step F1) to over **20 million** (4000 vs 2000, BE uniform, step F1
++0.0001), with most between 3,000 and 15,000 (all 24 values in the JSON under
+`power.adjacent_step_pairs_n_needed`). **"2000, 4000 and 8000 are indistinguishable here" is a
+statement about power at n = 750, not a demonstration that they are equal.**
+
+## 5. Secondary — balanced vs imbalanced pools, where both exist
+
+**9 matched pairs**: size 1000 × both retrieval variants × 3 mask modes (6), size 2000 ×
+`biencoder_only` × 3 mask modes (3). Differences are **balanced − imbalanced**.
+
+| pair | EM | step F1 | ord acc | ROUGE-L | hop EM | composite | compNR |
+|---|---|---|---|---|---|---|---|
+| 1000, BE, raw | +0.0080 | +0.0014 | +0.0057 | −0.0016 | −0.0147 | −0.0012 | −0.0015 |
+| 1000, BE, typed | **+0.0147\*** | +0.0026 | +0.0026 | +0.0047 | −0.0360 | +0.0647 | −0.0024 |
+| 1000, BE, uniform | +0.0120 | −0.0026 | −0.0041 | −0.0062 | −0.0093 | −0.0820 | −0.0052 |
+| 1000, CE, raw | −0.0013 | −0.0022 | −0.0071 | +0.0014 | −0.0333 | +0.1449 | −0.0105 |
+| 1000, CE, typed | +0.0053 | +0.0010 | −0.0014 | −0.0080 | **−0.0533\*** | +0.1453 | −0.0058 |
+| 1000, CE, uniform | +0.0027 | −0.0033 | −0.0097 | −0.0050 | **−0.1107\*** | **−0.0509\*** | −0.0148 |
+| 2000, BE, raw | −0.0093 | −0.0154 | −0.0120 | −0.0035 | −0.0360 | **−0.2142\*** | **−0.0178\*** |
+| 2000, BE, typed | **−0.0200\*** | **−0.0257\*** | **−0.0289\*** | **−0.0136\*** | **−0.0453\*** | +0.0950 | **−0.0285\*** |
+| 2000, BE, uniform | −0.0040 | **−0.0154\*** | **−0.0186\*** | −0.0070 | **−0.0573\*** | +0.1830 | **−0.0213\*** |
+
+**Hop-count EM favours the imbalanced pool in 9/9 pairs** — 4 CI-significant, 4 t-significant, 4
+McNemar-significant; the largest is `1000 CE uniform` at **−0.1107** (0.4227 vs 0.5333; CI [−0.1547,
+−0.0667]; t = −4.941, p ≈ 0.0000; McNemar 104/187, p ≈ 0.0000), which survives Holm within its
+6-test family (adjusted p ≈ 0.0000 by both tests). The reference-free diagnostic also favours the
+imbalanced pool in **9/9** (3 CI-significant). At size 2000 the imbalanced pool wins on the step-level
+metrics as well: the `typed` pair is significant on **all five** metrics uncorrected, and **survives
+Holm on all five within its own five-metric family** (adjusted p 0.0019–0.0400). Under the
+across-mask family instead (3 tests per metric, comparing the three mask modes at size 2000) it keeps
+**3 of 5** — EM 0.0334, step F1 0.0050, ordered accuracy 0.0011 — while ROUGE-L (0.0600) and hop EM
+(0.0670) fall out and hop EM's surviving cell in that family is `uniform` instead (0.0238; McNemar
+0.0284). Which family is the right one is the open question ADR 0009 already flags.
+
+This is the direction that needs stating carefully. The eval set is **hop-balanced** (250/250/250),
+while the imbalanced pool follows the MuSiQue train distribution (about 71% 2-hop) and so holds far
+fewer deep exemplars — 81 4-hop items at size 1000 against 333 in the balanced pool. **The pool with
+fewer deep exemplars nonetheless predicts hop count better on a hop-balanced eval set, in 9 of 9
+matched pairs.** These runs measure that; they do not explain it, and the balanced arm is only 9 cells
+at two sizes with non-nested pools (§6), so it is a **suggestive pattern, not an established
+mechanism**.
+
+## 6. Confounds in the pool construction itself
+
+From the six pool `stats.json` files (hashed in the JSON companion), all `poolseed42`, all drawn from
+the same masked MuSiQue **train** file, with input buckets 2hop 14376 / 3hop 4387 / 4hop 1175:
+
+- **"balanced"** = equal 2/3/4-hop exemplars (e.g. 334/333/333 at size 1000); **"imbalanced"** = the
+  train distribution (709/210/81 at 1000; 5788/1717/495 at 8000).
+- **Nesting, by pool item id (ran; observed):** imbalanced **1000 ⊂ 2000 ⊂ 4000** exactly
+  (1000/1000 and 2000/2000 overlap), but **4000 ⊄ 8000** — only **3484 of 4000** items survive into
+  the 8000 pool, and only **982 of 1000** of the size-1000 items. The balanced pools are **not**
+  nested at all (682/1000 overlap between 1000 and 2000). Balanced and imbalanced pools at the same
+  size barely overlap (**50/1000** at size 1000, **198/2000** at size 2000).
+- Therefore: the **1000→2000 and 2000→4000 imbalanced contrasts add exemplars and keep the old ones**
+  — a clean size manipulation. The **4000→8000 and 1000→8000 contrasts also change which exemplars
+  are available**, and the **balanced 1000→2000 contrast is a different draw** as well as a larger one.
+  The balanced arm's three cross-size pairs (all non-significant, all slightly negative on the
+  step-level metrics) should not be read as evidence that a larger balanced pool does not help.
+- The 27 size pairs and 9 balance pairs share the **identical 750 eval items** and largely nested
+  pools, so they are **not independent**. Sign counts in §4.1 and §5 are descriptive; **no across-pair
+  test was run and none is claimed.**
+
+## 7. What this confirms and what it does not support in `docs/prior-work.md`
+
+- **Confirmed as arithmetic:** the per-size mean composites (0.232 / 0.271 / 0.311 / 0.230) and the
+  best-cell table recompute exactly from the per-item files (§3).
+- **Not supported as an interpretation:** FINDINGS' "larger pool is not always better (8000 drops vs
+  4000)". That drop is **104.2% the reference-validity term** on 13 vs 37 references (§4.4); no
+  4000-vs-8000 metric is significant by any test in any of the 6 matched pairs; and on the
+  reference-free diagnostic the size trend is monotone **upward** through 8000. The "8000 drops"
+  reading is an artifact of the composite, not a pool-size finding.
+- **Confirmed, and now with a significance verdict:** "exact match stays ~3–5% across the board — pool
+  size alone does not solve gold-plan matching." EM ranges 0.0267–0.0533 across the 33 cells, and the
+  largest matched-pair EM gain anywhere is **+0.0240** (2000 vs 1000, imbalanced BE typed). Even the
+  1000→8000 eightfold increase moves EM by at most +0.0213.
+- **Newly measured (the §6 gap of the masking/retrieval note):** the pool-size axis. **1000 is
+  measurably worse than 8000** on step-level metrics (6/6 pairs positive on step F1, 4 CI-significant,
+  4 Holm-surviving), and worse than 2000 in the imbalanced/typed cell (Holm-surviving on 4 of 5
+  metrics). **Above 1000, no adjacent doubling is significant on anything** (2000 vs 4000: 1 of 30
+  metric-cells; 4000 vs 8000: 0 of 30).
+- **Also newly measured:** balanced vs imbalanced (§5), which `docs/prior-work.md` does not discuss.
+
+## 8. Unmeasured / out of scope
+
+Stated so it is not read into the note: any **v2** run (nothing here was executed on v2 code or v2
+models); **within-cell seed variance** — only `trial0` exists, so a "size effect" here is one pool draw
+per size; pool sizes outside {1000, 2000, 4000, 8000}; **balanced pools at 4000 and 8000** and
+`size2000_balanced__biencoder_plus_ce` (cells absent); any guided (hop-forced) condition; MetaQA;
+end-to-end answer accuracy. The v1 predictions' own provenance (which decoder, which prompt revision)
+is not established by this note. No model was run and no v1 file was modified.
+
+## 9. Ranked takeaways for issue #6 item 4 — options, not decisions
+
+Ranked by how much each would change how the pool-size dimension is written up or re-run. These are
+**conditionals**; ADR 0006 already fixed pool size at 2000, and which baselines the thesis leans on
+is Jahid's call with his supervisor.
+
+1. **If the thesis states a pool-size conclusion from v1, the defensible one is "1000 is too small;
+   2000 and above are indistinguishable at n = 750" — not "4000 is best".** Measured: 6/6 pairs
+   favour 8000 over 1000 on step F1 with 4 CI-significant and 4 Holm-surviving; 0 of 6 pairs show any
+   significant 4000-vs-8000 difference; 1 of 6 shows any significant 2000-vs-4000 difference (hop EM,
+   CE + raw). This ranks first because "4000 was best, 8000 dropped" is the sentence most likely to be
+   carried into the thesis from `docs/prior-work.md` §4, and §4.4 shows it is the reference term.
+2. **If any composite number is quoted on the size axis, it needs the §4.4 caveat attached or it
+   should not be quoted.** The reference term produces a median **100.1%** of |Δcomposite| across the
+   27 pairs, 25 of 27 composite CIs straddle 0 (widths up to 0.4163), and the 4000→8000 aggregate drop
+   decomposes to **104.2%** that term on 13 vs 37 references. This is direct input to issue #29 and to
+   #6 item 5, and it is the same defect the masking note found on a different axis — so it is a
+   property of the metric, not of one comparison.
+3. **ADR 0006's choice of 2000 is not contradicted by v1's own sweep, and the evidence for it is
+   "on the plateau", not "optimal".** No metric in any matched pair shows 4000 or 8000 significantly
+   beating 2000; the cell-mean step F1 gain from 2000 to 8000 is +0.008 against a median MDE of
+   0.021. If the thesis wants to *claim* 2000 is sufficient rather than merely chosen, that claim
+   needs either a v2 re-run or the power statement in §4.6 stated alongside it — the options the
+   evidence leaves open, not a recommendation between them.
+4. **The balanced-vs-imbalanced result is the most surprising thing in this note and it is currently
+   undecided in the repo.** Hop-count EM favours the *imbalanced* (train-distribution) pool in **9/9**
+   matched pairs — 4 significant by all three tests, one surviving Holm at p ≈ 0.0000 with 104/187
+   discordant pairs — on a hop-balanced eval set, and at size 2000 the imbalanced pool wins on all
+   five metrics uncorrected (`typed`; 3 of 5 survive Holm across the mask family, all 5 across the
+   metric family — §5). If v2's few-shot pool construction is going to be
+   described in the thesis, this is a decision point that has evidence attached; whether to act on it
+   is a supervisor question, and the balanced arm's 9 cells at 2 sizes with non-nested pools (§6) are
+   thin ground for acting.
+5. **If a v2 pool-size re-run is ever scheduled, n = 750 will not settle the 2000-vs-4000-vs-8000
+   question.** The observed adjacent-step differences need roughly **2,000–15,000** items for 80%
+   power (§4.6). The cheap alternative the data supports is to re-run only the **extreme** contrast
+   (smallest vs largest), which is the one v1 can already detect.
+6. **Two follow-ups the same battery would answer, both unmeasured today:** (a) whether the size
+   effect is a *pool-draw* effect — no repeated trial exists in the sweep, so a second draw at one
+   size would separate the two, and until then every §4 number is one draw per size; (b) the
+   `--compare` shim that accepts v1-format per-item files (carried over from the masking note's
+   §7.6(b)), which would make §4 and §5 re-derivable from committed code instead of from a
+   session-local harness. As of `main` at `50daea7` no such shim is committed; uncommitted
+   work-in-progress toward one was present in the shared working tree while this note was written,
+   and it is another lane's to land, so this note claims nothing about it beyond that.

--- a/docs/analysis/2026-08-20-v1-pool-size-significance.md
+++ b/docs/analysis/2026-08-20-v1-pool-size-significance.md
@@ -282,7 +282,7 @@ p = 0.0005**).
 
 **Why these near-misses matter for reading the tables.** `significant` in the bootstrap column is
 `ci_low > 0 or ci_high < 0` — a strict inequality, so a CI endpoint that lands on exactly 0.0 reads
-as *not* significant. Three of the seven disagreements above are that knife-edge (endpoint exactly
+as *not* significant. Four of the seven disagreements above are that knife-edge (endpoint exactly
 0.0), including the one 4000-vs-8000 cell §4.4 and §7 name explicitly. Where a claim below turns on
 this, the test basis is stated rather than the word "significant" alone.
 

--- a/docs/prior-work.md
+++ b/docs/prior-work.md
@@ -79,7 +79,7 @@ FINDINGS' conclusions: typed masking is the best average retrieval mode in this 
 
 **Significance check (2026-08-20):** over the 15 matched cell pairs, +CE raises ROUGE-L F1 in 15/15 (5 survive Holm) and shows no significant effect on exact match (0/15 by any test, signs split 7/8) — see `docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md`.
 
-**Pool-size significance check (2026-08-20):** the per-size mean composites above recompute exactly from the per-item files, but the "8000 drops vs 4000" reading is **104% the reference-validity term** (13 vs 37 references) and no metric in any of the six matched 4000-vs-8000 pairs is significant by any test. Over 27 matched pool-size pairs, 1000 is measurably worse than 8000 on step-level metrics (6/6 pairs, 4 Holm-surviving) while no adjacent doubling above 1000 is significant — see `docs/analysis/2026-08-20-v1-pool-size-significance.md` before citing any pool-size number here.
+**Pool-size significance check (2026-08-20):** the per-size mean composites above recompute exactly from the per-item files, but the "8000 drops vs 4000" reading is **104% the reference-validity term** (13 vs 37 references) and across the six matched 4000-vs-8000 pairs no metric is CI- or McNemar-significant and none survives Holm (smallest adjusted p 0.2855; one cell is t-significant uncorrected at p = 0.0476). Over 27 matched pool-size pairs, 1000 is measurably worse than 8000 on step-level metrics (6/6 pairs, 4 Holm-surviving) while no adjacent doubling above 1000 is significant — see `docs/analysis/2026-08-20-v1-pool-size-significance.md` before citing any pool-size number here.
 
 ## 5. MetaQA KG compile/execute charts (FINDINGS §6)
 

--- a/docs/prior-work.md
+++ b/docs/prior-work.md
@@ -79,6 +79,8 @@ FINDINGS' conclusions: typed masking is the best average retrieval mode in this 
 
 **Significance check (2026-08-20):** over the 15 matched cell pairs, +CE raises ROUGE-L F1 in 15/15 (5 survive Holm) and shows no significant effect on exact match (0/15 by any test, signs split 7/8) — see `docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md`.
 
+**Pool-size significance check (2026-08-20):** the per-size mean composites above recompute exactly from the per-item files, but the "8000 drops vs 4000" reading is **104% the reference-validity term** (13 vs 37 references) and no metric in any of the six matched 4000-vs-8000 pairs is significant by any test. Over 27 matched pool-size pairs, 1000 is measurably worse than 8000 on step-level metrics (6/6 pairs, 4 Holm-surviving) while no adjacent doubling above 1000 is significant — see `docs/analysis/2026-08-20-v1-pool-size-significance.md` before citing any pool-size number here.
+
 ## 5. MetaQA KG compile/execute charts (FINDINGS §6)
 
 `Thesis---QA/handoff/results_analysis/metaqa_kg_decomposition/` holds charts on whether decompositions execute on the MetaQA KG, split into compile fail / exec fail / success (taxonomy in §7 below). FINDINGS marks the chart counts as run-specific and says to read the PNGs rather than quote totals — so no numbers are carried here.


### PR DESCRIPTION
Answers the **pool-size half of issue #6 item 4**, which `docs/analysis/2026-08-20-v1-masking-and-retrieval-significance.md` §6 explicitly left unmeasured. Docs-only diff; a prior-work re-analysis under [ADR 0020](docs/adr/0020-prior-work-re-analysis-convention.md), all six conditions observed.

**Prior work, not v2 evidence.** v1's `runs/` is gitignored and untracked (`git ls-files runs/` returns 0), so the 33 input per-item files carry no commit SHA; inputs are pinned by sha256 + mtime instead. Gate 2 is not satisfied and there is no `experiments/log.md` entry because nothing was run. Findings are stated as conditionals — ADR 0006 already fixed pool size at 2000, and which baselines the thesis leans on stays Jahid's call with his supervisor.

## What was run

Battery per ADR 0009 as amended: paired bootstrap (10,000 resamples, chunk 1,000, alpha 0.05, seed 42), exact McNemar on the binary metrics, two-sided paired t-test on all five per-item metrics, Holm-Bonferroni reported within each comparison family. The harness imports v2's committed `_statistic_arrays` / `_paired_bootstrap` / `_mcnemar_exact_p`; it is **bit-identical to `_paired_bootstrap` at zero tolerance on 3/3 spot-checked pairs, 12 fields each**.

Pairability was verified first: all 33 cells hold 750 rows with an **identical normalized-question sequence, order included**, identical `gold_steps` and `gold_hop_count`, and that sequence matches the committed eval sample `dev_sample_250per_hop_seed42.jsonl` exactly. One question text is duplicated (rows 370/376, identical gold), so alignment is **positional in v1 file order**, with question text *and* gold asserted equal per row for all 750 rows of all 36 pairs. Re-aggregating the per-item rows reproduces every cell's committed `eval_metrics.json` and `all_runs.csv` to <= 1.2e-15 with 0 disagreements.

**Grid actually present:** 33 of 48 cells. The imbalanced arm is complete (4 sizes x 2 retrieval x 3 masks); the balanced arm has 9 cells (size 1000 both retrieval variants, size 2000 `biencoder_only` only) — no balanced cell exists at 4000 or 8000. `trial0` only, so pool-draw variance is unmeasured. That yields **27 matched pool-size pairs** and **9 balanced-vs-imbalanced pairs**, n = 750 each.

## Headline findings (counts stated)

- **The extremes separate; the adjacent doublings above 1000 do not.** 1000 vs 8000: all 6/6 pairs show at least one significant metric, and step F1 favours 8000 in 6/6 (4 CI-significant, **4 Holm-surviving**). 2000 vs 4000: 1 of 30 metric-cells significant. **4000 vs 8000: 0 of 30.** 1000 vs 2000: 3 of 9 pairs, all three in the imbalanced arm.
- **v1's "8000 drops vs 4000" is the composite's reference term, not a pool-size finding.** The -0.0810 cell-mean drop decomposes to **104.2%** reference-validity term (13 vs 37 references across the 6 cells each side); on the reference-free diagnostic the size trend runs monotonically *upward* through 8000. Median share of |delta composite| from that term across the 27 pairs: **100.1%**; **25 of 27 composite CIs straddle 0**, widths up to 0.4163.
- **Balanced vs imbalanced (new — `docs/prior-work.md` does not discuss it):** hop-count EM favours the *imbalanced* train-distribution pool in **9/9** matched pairs (4 significant by all three tests; largest -0.1107, McNemar 104/187, p ~ 0.0000) on a hop-balanced eval set. Suggestive, not an established mechanism — 9 cells at 2 sizes with non-nested pools.
- **Power:** median MDE at n = 750 is about 0.021 step F1; the observed adjacent-step differences would need roughly 2,000-15,000 items. "2000, 4000 and 8000 are indistinguishable" is a statement about power, not about equality.

## Files

- `docs/analysis/2026-08-20-v1-pool-size-significance.md` — the note; the no-SHA caveat leads it.
- `docs/analysis/2026-08-20-v1-pool-size-significance.json` — machine-readable companion: every reported statistic, plus sha256 + mtime of every input file. Statistics only; no dataset content and no per-item rows.
- `docs/prior-work.md` §4 — one pointer paragraph so the "8000 drops" sentence is not quoted uncritically.

**Do not merge on my say-so** — review is dispatched separately. Nothing in `/cta/users/fyilmaz/Thesis---QA` was modified.

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)