### PR TITLE
Hop-matched few-shot retrieval: candidate filter before top-k, gold + predictions hop sources (Refs #15)

### DIFF
--- a/MusiQue/scripts/check_question_similarity.py
+++ b/MusiQue/scripts/check_question_similarity.py
@@ -19,6 +19,18 @@ Ported from v1. Adapted for v2: embedding model registry, NER model, top-k, devi
 query glob and cache directory come from ``configs/similarity.json`` /
 ``configs/paths.json``; the embedding model's parameter count is asserted against the
 ceiling; the run writes the standard trail.
+
+**Hop-matched retrieval** (issue #15, ADR 0022) is an opt-in candidate filter: with
+``--hop-match`` the top-k for each query is computed over the pool rows in that query's
+hop bucket only, where the hop comes from the query id (``--hop-source gold``) or from a
+predictions JSONL (``--hop-source predictions``, the future router's interface). The knobs
+live in ``hop_match`` in ``configs/similarity.json`` and default to **off**, which is the
+mixed condition and the behaviour this script had before the flag existed.
+
+``--dry-run`` loads the pool and the queries, resolves and validates the hop side (bucket
+sizes, unparseable ids, missing predictions) and writes the run trail **without loading the
+embedding model** — the preflight for a hop-matched run, and the only part of this script a
+machine without model weights can execute.
 """
 from __future__ import annotations
 
@@ -41,6 +53,7 @@ from _prep_common import (
 
 import numpy as np
 
+import hop_matching
 from model_size import assert_within_ceiling, load_limits
 from pool_embeddings import needs_e5_prefix
 from run_artifacts import now_iso, write_run_artifacts
@@ -202,12 +215,25 @@ def _top_k_from_scores(
     scores: np.ndarray,
     pool_rows: list[dict[str, Any]],
     top_k: int,
+    allowed_indices: list[list[int]] | None = None,
 ) -> list[list[dict[str, Any]]]:
-    """Top-k neighbours from a (num_queries x num_pool) similarity matrix."""
+    """Top-k neighbours from a (num_queries x num_pool) similarity matrix.
+
+    ``allowed_indices[i]`` restricts query ``i`` to a subset of the pool (hop-matched
+    retrieval, ADR 0022): the ranking then happens *inside* the subset, so the query still
+    gets ``top_k`` neighbours. ``None`` is the unfiltered path, byte-for-byte the code that
+    ran before hop matching existed — the mixed condition is not a special case of the
+    filter, it is the absence of it.
+    """
     all_neighbours: list[list[dict[str, Any]]] = []
     for i in range(scores.shape[0]):
         row_scores = scores[i]
-        top_idx = np.argsort(row_scores)[::-1][:top_k]
+        if allowed_indices is None:
+            top_idx = np.argsort(row_scores)[::-1][:top_k]
+        else:
+            allowed = allowed_indices[i]
+            local = np.argsort(row_scores[allowed])[::-1][:top_k]
+            top_idx = [allowed[int(j)] for j in local]
         neighbours: list[dict[str, Any]] = []
         for j in top_idx:
             prow = pool_rows[int(j)]
@@ -243,7 +269,193 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--out", type=Path, default=None, help="Output JSONL path (default: stdout).")
     p.add_argument("--run-dir", type=Path, default=None)
     p.add_argument("--seed", type=int, default=None)
+
+    hop = p.add_mutually_exclusive_group()
+    hop.add_argument(
+        "--hop-match",
+        dest="hop_match",
+        action="store_true",
+        default=None,
+        help="Restrict each query's candidates to the pool rows of its hop depth "
+        "(hop-matched retrieval, issue #15). Default: hop_match.enabled in the config.",
+    )
+    hop.add_argument(
+        "--no-hop-match",
+        dest="hop_match",
+        action="store_false",
+        help="Force the mixed condition even if the config enables hop matching.",
+    )
+    p.add_argument(
+        "--hop-source",
+        choices=list(hop_matching.HOP_SOURCES),
+        default=None,
+        help="Where a query's hop depth comes from: 'gold' (parsed from the query id) or "
+        "'predictions' (a JSONL from --hop-predictions).",
+    )
+    p.add_argument(
+        "--hop-predictions",
+        type=Path,
+        default=None,
+        help="JSONL of hop predictions (one object per query: query id + predicted hop). "
+        "Required by --hop-source predictions.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the pool, the queries and the hop filter and write the run trail "
+        "without loading the embedding model or computing any top-k.",
+    )
     return p.parse_args()
+
+
+def _build_hop_filters(
+    *,
+    query_files: list[Path],
+    n_per_file: int | None,
+    pool_rows: list[dict[str, Any]],
+    pool_buckets: dict[int, list[int]],
+    predicted_hops: dict[str, int] | None,
+    hop_settings: hop_matching.HopMatchSettings,
+    top_k: int,
+) -> tuple[dict[str, hop_matching.HopFilter], list[dict[str, Any]], int]:
+    """Build every query file's hop filter up front, before any embedding is paid for.
+
+    Returns ``({query file: filter}, per-file summaries, total queries)``; the filter map
+    is empty when hop matching is off. Doing this as a pre-pass matters for more than
+    speed: the output JSONL is opened for writing later, so an infeasible hop bucket in the
+    *third* query file would otherwise leave a truncated artifact at a path the sweep's
+    skip-if-exists logic would then treat as done.
+    """
+    filters: dict[str, hop_matching.HopFilter] = {}
+    per_file: list[dict[str, Any]] = []
+    total_queries = 0
+    for qpath in query_files:
+        query_rows = _load_jsonl(qpath, limit=n_per_file)
+        total_queries += len(query_rows)
+        entry: dict[str, Any] = {"query_file": str(qpath), "queries": len(query_rows)}
+        if not query_rows:
+            print(f"  {qpath}: 0 queries loaded (empty file or n=0)")
+            per_file.append(entry)
+            continue
+        hop_filter = hop_matching.build_hop_filter(
+            query_rows=query_rows,
+            pool_buckets=pool_buckets,
+            settings=hop_settings,
+            top_k=top_k,
+            predicted_hops=predicted_hops,
+        )
+        if hop_filter is not None:
+            filters[str(qpath)] = hop_filter
+            entry["hop_match"] = hop_filter.summary()
+            print(
+                f"  {qpath}: {len(query_rows)} queries, hop counts "
+                f"{entry['hop_match']['query_hop_counts']}, candidates per query "
+                f"{entry['hop_match']['candidates_per_query_min']}"
+                f"..{entry['hop_match']['candidates_per_query_max']} "
+                f"(need >= {hop_filter.min_candidates})"
+            )
+        else:
+            print(f"  {qpath}: {len(query_rows)} queries, mixed (all {len(pool_rows)} pool rows)")
+        per_file.append(entry)
+    return filters, per_file, total_queries
+
+
+def _dry_run(
+    args: argparse.Namespace,
+    cfg: dict[str, Any],
+    *,
+    query_files: list[Path],
+    n_per_file: int | None,
+    pool_rows: list[dict[str, Any]],
+    pool_path: Path,
+    pool_buckets: dict[int, list[int]],
+    predicted_hops: dict[str, int] | None,
+    hop_settings: hop_matching.HopMatchSettings,
+    top_k: int,
+    modes: list[str],
+    embed_key: str,
+    model_id: str,
+    device: str,
+    seed: int,
+    seeded: Any,
+    run_dir: Path,
+) -> None:
+    """Preflight: validate the hop filter and write the trail, loading no model.
+
+    This is what the smoke test can run (no weights on the machine) and what an
+    experiment should run before it spends GPU time: every hop-side failure mode — an
+    unparseable pool or query id, a query with no prediction, a bucket too small for
+    ``top_k`` — is raised here, before the first embedding.
+
+    Because no model is loaded, the parameter-count assertion in ``src/model_size.py`` is
+    **not** exercised by a dry run (same caveat as the router/decomposer dry runs).
+    """
+    print("\n=== DRY RUN: no model is loaded and no top-k is computed ===")
+    _, per_file, total_queries = _build_hop_filters(
+        query_files=query_files,
+        n_per_file=n_per_file,
+        pool_rows=pool_rows,
+        pool_buckets=pool_buckets,
+        predicted_hops=predicted_hops,
+        hop_settings=hop_settings,
+        top_k=top_k,
+    )
+
+    dest = str(args.out) if args.out else "stdout"
+    print(f"\nDry run OK: {total_queries} queries over {len(query_files)} file(s); "
+          f"nothing written to {dest}")
+
+    metrics = {
+        "script": Path(__file__).name,
+        "created_utc": now_iso(),
+        "dry_run": True,
+        "seed": seed,
+        "seeded": seeded,
+        "embed_model": embed_key,
+        "embed_model_id": model_id,
+        "model_size": None,
+        "device": device,
+        "modes": modes,
+        "top_k": top_k,
+        "num_queries_per_file": n_per_file,
+        "pool_file": str(pool_path),
+        "pool_rows": len(pool_rows),
+        "query_files": [str(p) for p in query_files],
+        "total_queries": total_queries,
+        "total_written": 0,
+        "output": dest,
+        "hop_match": hop_settings.as_record(top_k),
+        "hop_match_per_query_file": per_file,
+    }
+    write_run_artifacts(
+        run_dir,
+        config_snapshot={
+            "script": Path(__file__).name,
+            "config_path": cfg.get("_config_path"),
+            "dry_run": True,
+            "pool_file": str(args.pool_file),
+            "query_files": [str(p) for p in query_files],
+            "mode": args.mode,
+            "top_k": top_k,
+            "n": n_per_file,
+            "embed_model": embed_key,
+            "device": device,
+            "seed": seed,
+            "hop_match": hop_settings.as_record(top_k),
+            "out": dest,
+        },
+        metrics=metrics,
+        note_title="Bi-encoder question similarity (dry run)",
+        note_lines=[
+            "- Dry run: the hop filter and the inputs were validated; **no model was loaded**, "
+            "no top-k was computed and no output JSONL was written.",
+            f"- Pool: `{pool_path}` ({len(pool_rows)} rows)",
+            f"- Query files: {len(query_files)} ({total_queries} queries, n={n_per_file} each)",
+            f"- Modes: {', '.join(modes)}; top-k: {top_k}",
+            f"- Hop matching: {hop_settings.as_record(top_k)}",
+        ],
+        prefix="similarity_",
+    )
 
 
 def main() -> None:
@@ -265,6 +477,12 @@ def main() -> None:
     cache_enabled = bool(require(cfg, "bi_encoder.cache_enabled")) and not args.no_cache
     cache_dir = args.cache_dir or dataset_path(paths_cfg, require(cfg, "bi_encoder.cache_dir_key"))
     run_dir = args.run_dir or run_dir_for(paths_cfg, require(cfg, "bi_encoder.run_subdir"))
+    hop_settings = hop_matching.settings_from_config(
+        cfg,
+        enabled=args.hop_match,
+        hop_source=args.hop_source,
+        predictions_file=args.hop_predictions,
+    )
 
     if args.query_file is not None:
         query_files = [args.query_file.resolve()]
@@ -288,6 +506,67 @@ def main() -> None:
         print(f"Cache : {cache_dir}  (rebuild={args.rebuild_cache})")
     else:
         print("Cache : disabled")
+
+    # Hop-matched retrieval (issue #15, ADR 0022). The pool buckets are computed once: the
+    # pool is the same for every query file, and an unparseable pool id must stop the run
+    # before any embedding work is paid for.
+    pool_buckets: dict[int, list[int]] = {}
+    predicted_hops: dict[str, int] | None = None
+    if hop_settings.enabled:
+        pool_buckets = hop_matching.group_pool_by_hop(pool_rows)
+        print(
+            f"Hop   : matched on {hop_settings.hop_source}; pool buckets "
+            f"{ {h: len(v) for h, v in sorted(pool_buckets.items())} }"
+        )
+        if hop_settings.hop_source == "predictions":
+            predicted_hops = hop_matching.load_predicted_hops(
+                hop_settings.predictions_file,
+                id_field=hop_settings.predictions_id_field,
+                hop_field=hop_settings.predictions_hop_field,
+            )
+            print(
+                f"        predictions: {len(predicted_hops)} from "
+                f"{hop_settings.predictions_file}"
+            )
+    else:
+        print("Hop   : mixed (no hop constraint)")
+
+    if args.dry_run:
+        _dry_run(
+            args,
+            cfg,
+            query_files=query_files,
+            n_per_file=n_per_file,
+            pool_rows=pool_rows,
+            pool_path=pool_path,
+            pool_buckets=pool_buckets,
+            predicted_hops=predicted_hops,
+            hop_settings=hop_settings,
+            top_k=top_k,
+            modes=modes,
+            embed_key=embed_key,
+            model_id=model_id,
+            device=device,
+            seed=seed,
+            seeded=seeded,
+            run_dir=run_dir,
+        )
+        return
+
+    # Validate the hop side of every query file before a single vector is computed, so an
+    # infeasible bucket costs no embedding time and leaves no half-written output.
+    hop_filters: dict[str, hop_matching.HopFilter] = {}
+    hop_summaries: list[dict[str, Any]] = []
+    if hop_settings.enabled:
+        hop_filters, hop_summaries, _ = _build_hop_filters(
+            query_files=query_files,
+            n_per_file=n_per_file,
+            pool_rows=pool_rows,
+            pool_buckets=pool_buckets,
+            predicted_hops=predicted_hops,
+            hop_settings=hop_settings,
+            top_k=top_k,
+        )
 
     from sentence_transformers import SentenceTransformer
 
@@ -355,6 +634,18 @@ def main() -> None:
             raw_questions = [r["question"] for r in query_rows]
             print(f"  Loaded {len(query_rows)} queries")
 
+            # Built (and validated) in the pre-pass above; None is the mixed condition.
+            # A missing or mis-sized filter while matching is on would silently serve this
+            # file as mixed, so it is a refusal rather than a fallback.
+            hop_filter = hop_filters.get(str(qpath))
+            if hop_settings.enabled and hop_filter is None:
+                raise SystemExit(f"Internal error: no hop filter was built for {qpath}")
+            if hop_filter is not None and len(hop_filter.allowed) != len(query_rows):
+                raise SystemExit(
+                    f"Internal error: hop filter for {qpath} covers {len(hop_filter.allowed)} "
+                    f"queries but {len(query_rows)} were loaded"
+                )
+
             masked: dict[str, list[str]] = {}
             if any(m in modes for m in ("typed", "uniform")):
                 missing = [
@@ -391,7 +682,12 @@ def main() -> None:
                 print(f"  Mode {mode}: embedding {len(q_texts)} queries ...")
                 q_emb = _embed(q_texts, embed_model, model_id, prefix="query")
                 scores = np.dot(q_emb, pool_emb_by_mode[mode].T)
-                results_by_mode[mode] = _top_k_from_scores(scores, pool_rows, top_k)
+                results_by_mode[mode] = _top_k_from_scores(
+                    scores,
+                    pool_rows,
+                    top_k,
+                    allowed_indices=hop_filter.allowed if hop_filter is not None else None,
+                )
 
             for i, qrow in enumerate(query_rows):
                 result: dict[str, Any] = {
@@ -403,6 +699,15 @@ def main() -> None:
                     result["query_question_masked_typed"] = query_texts_by_mode["typed"][i]
                 if "uniform" in modes:
                     result["query_question_masked_uniform"] = query_texts_by_mode["uniform"][i]
+                if hop_filter is not None:
+                    # Per-row provenance, so a later reader can tell which condition
+                    # produced this row without consulting the metrics JSON. Absent in the
+                    # mixed condition, which keeps that output byte-identical.
+                    result["hop_match"] = {
+                        "hop_source": hop_filter.settings.hop_source,
+                        "query_hop": hop_filter.query_hops[i],
+                        "pool_candidates": len(hop_filter.allowed[i]),
+                    }
                 for mode in modes:
                     result[f"{mode}_top_k"] = results_by_mode[mode][i]
                 out_handle.write(json.dumps(result, ensure_ascii=False) + "\n")
@@ -436,6 +741,8 @@ def main() -> None:
         "cache_enabled": cache_enabled,
         "cache_hits_per_mode": cache_hits,
         "query_files_masked_on_the_fly": masked_on_the_fly_files,
+        "hop_match": hop_settings.as_record(top_k),
+        "hop_match_per_query_file": hop_summaries,
     }
     write_run_artifacts(
         run_dir,
@@ -452,6 +759,7 @@ def main() -> None:
             "device": device,
             "seed": seed,
             "cache_enabled": cache_enabled,
+            "hop_match": hop_settings.as_record(top_k),
             "out": dest,
         },
         metrics=metrics,
@@ -463,6 +771,7 @@ def main() -> None:
             f"- Modes: {', '.join(modes)}; top-k: {top_k}",
             f"- Rows written: {total_written} -> `{dest}`",
             f"- Cache hits per mode: {cache_hits}",
+            f"- Hop matching: {hop_settings.as_record(top_k)}",
         ],
         prefix="similarity_",
     )

--- a/configs/similarity.json
+++ b/configs/similarity.json
@@ -25,6 +25,16 @@
     "run_subdir": "musique_similarity"
   },
 
+  "hop_match": {
+    "_note": "Hop-matched few-shot retrieval (issue #15, ADR 0022), a candidate filter applied in check_question_similarity.py BEFORE top-k selection: the top-k is computed over the query's hop bucket only, so truncate/rerank/decomposer inherit it. 'enabled': false is the mixed condition and is the retrieval behaviour that predates the flag - the pool sweep passes no hop flag and is therefore unaffected. Toggle per run with --hop-match / --no-hop-match, --hop-source, --hop-predictions.",
+    "enabled": false,
+    "hop_source": "gold",
+    "predictions_file": null,
+    "predictions_id_field": "query_id",
+    "predictions_hop_field": "predicted_hop",
+    "min_candidates": "top_k"
+  },
+
   "truncate": {
     "k": 5,
     "run_subdir": "musique_truncate"

--- a/docs/adr/0022-hop-matched-retrieval-the-implementers-design.md
+++ b/docs/adr/0022-hop-matched-retrieval-the-implementers-design.md
@@ -62,7 +62,10 @@ mixed being the literal absence of the filter. Knobs live in `hop_match` in
    accepts an integer instead, which deliberately admits a smaller in-bucket candidate set
    for someone who wants it; nothing in the repo sets it that way. **The default is a
    comparability argument, not a measured one** — no evidence says 20 in-bucket candidates
-   beats 12.
+   beats 12. The *effective* floor is never below 1 whatever the config says: a query with
+   an empty candidate set is not a hop-matched query but a broken one, so `min_candidates: 0`
+   still refuses a hop the pool cannot serve (PR #39 review finding 1, which found that
+   combination raising a bare `KeyError` instead).
 
 5. **The hop source is pluggable, and the router's side of it is an interface, not a
    router.** `gold` parses the coarse hop depth from the query id (`2hop__…` / `3hop1__…` /
@@ -84,14 +87,26 @@ mixed being the literal absence of the filter. Knobs live in `hop_match` in
    `MusiQue/scripts/score_similarity_results.py`,
    `components/decomposer/run_decomposer.py`); `src/hop_matching.py` is the fourth.
    Consolidating them would mean editing `run_decomposer.py`, which was **frozen** for the
-   queued exp-004/exp-005 launch at the time of writing. The regexes agree today; the
-   duplication is a real (small) drift risk and the obvious cleanup once the freeze lifts.
+   queued exp-004/exp-005 launch at the time of writing. The four agree **on well-formed
+   ids only**: `score_similarity_results.py` additionally requires the `__` separator
+   (`^(\d+)hop(?:\d+)?__`), so it returns None for a malformed id like `2hopfoo` where the
+   other three return 2. No such id exists in MuSiQue, so the copies agree on every id the
+   pipeline has actually seen — but they are not the same rule, which is the drift risk, and
+   consolidating them is the obvious cleanup once the freeze lifts.
 
 7. **A matched row carries its own provenance**: when the filter is on, each output row gets
    `hop_match = {hop_source, query_hop, pool_candidates}`, so a later reader can tell which
    condition produced a file from the file itself. The field is **absent** when matching is
-   off, which is what keeps the mixed output byte-identical. Downstream stages pass it
-   through untouched.
+   off, which is what keeps the mixed **retrieval JSONL** byte-identical. Downstream stages
+   pass it through untouched.
+
+   To be precise about the scope of that guarantee: byte-identity holds for the retrieval
+   output — the artifact the rest of the pipeline consumes. The **run trail does gain a
+   key**: `similarity_metrics.json` and `similarity_config.json` now carry
+   `hop_match: {"enabled": false}` (plus `hop_match_per_query_file: []`) on a mixed run. That
+   is deliberate — a run record should state which condition produced it rather than leave a
+   reader to infer "mixed" from silence — but it means a diff of two trails across this
+   commit is not empty, and nothing downstream reads those keys.
 
 8. **`--dry-run` is the preflight, and it is the only part a machine without weights can
    run.** It loads the pool and the queries, resolves and validates the whole hop side, and
@@ -125,12 +140,13 @@ mixed being the literal absence of the filter. Knobs live in `hop_match` in
 
 ## What was verified (and what was not)
 
-Ran on 2026-08-21, CPU only, on this branch:
+Ran on 2026-08-21, CPU only, on this branch (counts as of the PR #39 review fix pass):
 
-- `tests/test_hop_matching.py` — **33 tests, all passing**: the three hop buckets, both hop
+- `tests/test_hop_matching.py` — **38 tests, all passing**: the three hop buckets, both hop
   sources, a prediction that disagrees with gold, and every failure mode in item 3.
-- Full suite `python -m unittest discover -s tests` and `scripts/smoke_test.py`
-  (**37/37 stages**, including the new `similarity_hop_match_dryrun`).
+- Full suite `python -m unittest discover -s tests` (**310 tests, OK**) and
+  `scripts/smoke_test.py` (**37/37 stages**, including the new
+  `similarity_hop_match_dryrun`).
 - **Mixed-condition regression, byte level.** The same 9 queries × 45-row throwaway pool
   through the real bi-encoder (`intfloat/e5-small-v2`, CPU, top-k 20, mode `raw`) at
   `origin/main` and on this branch with the feature off (both by config default and by an
@@ -176,6 +192,33 @@ step (this repo sets no torch determinism flags; same caveat as ADR 0021 item 7)
 - `configs/similarity.json` now requires a `hop_match` block: a config without it is refused
   loudly by `require()`, in this repo's no-silent-default style. `configs/similarity_probe.json`
   does **not** need one — the probes never call this script.
+
+### Two conventions this establishes, reusable beyond hop matching
+
+Recorded here at the PR #39 review's request (2026-08-21): both were written as facts about
+this one script, and both are general rules the next change of the same shape should reuse.
+
+- **A behaviour-preserving change proves it against a verbatim copy of the pre-change
+  function.** When a feature is added *inside* an existing function and the old behaviour has
+  to survive untouched under a flag, the guard is: copy the pre-change function body verbatim
+  into the test file, marked as the frozen reference, and assert the live function equals it on
+  input designed to expose ordering and tie-breaking (here a seeded score matrix rounded to two
+  decimals, so ties actually occur). It is stronger than a golden output file — it re-derives
+  the expectation, so it also covers inputs no fixture happens to contain — and it works with
+  no model weights, which is what let this guard live in the ordinary suite. It is *weaker*
+  than an end-to-end byte comparison against the previous commit, so do both when weights are
+  available: the byte check catches everything the test's input space does not reach.
+  First instance: `tests/test_hop_matching.py::TestMixedConditionRegressionGuard` against
+  `_top_k_from_scores`.
+- **Validate every input before opening the single output handle.** A stage that opens one
+  output file and then loops over inputs must complete all validation in a pre-pass. Otherwise a
+  refusal triggered by the *n*-th input leaves a truncated file at the output path — and in this
+  repo that path is exactly what the sweep's skip-if-exists logic reads as finished work, so a
+  loud failure becomes a silent wrong result on the next run. Two observations, unfixed here
+  because they are outside issue #15's scope: `truncate_top20.py` streams input to output line
+  by line (a malformed later line leaves a partial file), and `rerank_similarity_results.py`
+  parses all input up front but writes incrementally (a cross-encoder failure mid-loop leaves a
+  partial file). Neither is a new regression, and both would be a small, separate change.
 
 ## Alternatives considered
 

--- a/docs/adr/0022-hop-matched-retrieval-the-implementers-design.md
+++ b/docs/adr/0022-hop-matched-retrieval-the-implementers-design.md
@@ -1,0 +1,197 @@
+# 0022. Hop-Matched Retrieval: The Implementer's Design
+
+- **Status**: Accepted (design agent-authored, pending Jahid)
+- **Date**: 2026-08-21
+
+## Context
+
+Issue #15 asks for three retrieval conditions on the MuSiQue evaluation set: **mixed** (no
+hop constraint, today's behaviour), **oracle-hop-matched** (few-shot examples of the
+query's *gold* hop depth) and **router-hop-matched** (the same, from a *predicted* hop
+depth). "Hop-aware" retrieval sits in the contribution statement (ADR
+[0006](./0006-drop-the-jury-fix-dataset-roles-and-the-few-shot-method.md)) as an
+assumption, and the point of #15 is to turn it into a measured number.
+
+**That the three conditions exist and get measured is Jahid's decision** (issue #15). How
+the filter is implemented was not decided by anyone; this record states the implementation
+so the November write-up does not mistake an implementer default for a research choice, and
+so changing one is a visible edit rather than archaeology.
+
+**Nothing in this record is a measurement.** No condition has been run on the evaluation
+set; there is no metric here, and none may be claimed until an `experiments/log.md` entry
+exists. What *has* been executed is listed under "What was verified" below.
+
+## Decision (the implementer's, in one line)
+
+Hop matching is an **opt-in candidate filter inside
+`MusiQue/scripts/check_question_similarity.py`, applied before top-k selection**, with the
+query's hop depth coming from a pluggable source (`gold` or a predictions file), and with
+mixed being the literal absence of the filter. Knobs live in `hop_match` in
+`configs/similarity.json`; no hop-matching constant lives in the source.
+
+## Implementation conventions (agent-authored)
+
+1. **The filter binds before top-k, in the bi-encoder stage — not after it.** With matching
+   on, the top-20 for a query is computed over the pool rows in that query's hop bucket
+   only, so `truncate_top20.py`, `rerank_similarity_results.py` and the decomposer's
+   few-shot block inherit the restriction with **no changes at all** (verified end-to-end,
+   below). The rejected alternative — retrieve mixed, then drop out-of-bucket neighbours —
+   is a different method, not a cheaper version of this one: it returns fewer than k
+   examples for some queries, and it makes the matched condition's example count a function
+   of the mixed ranking. Filtering at candidate level keeps k constant across conditions, so
+   mixed and matched differ in *which* examples are retrieved, not *how many*.
+
+2. **Mixed is the absence of the filter, not the filter with everything allowed.**
+   `hop_match.enabled` defaults to **false**; a disabled filter is `None`, and
+   `_top_k_from_scores` then runs its original, untouched branch. This is deliberate: the
+   guarantee wanted from the mixed arm is that it is the same code, not merely the same
+   intent. The pool sweep passes no hop flag, so every existing sweep cell is unaffected.
+
+3. **Nothing falls back to mixed, ever.** Each of these is a hard error with counts: a pool
+   row whose id does not parse (it would be silently unreachable under matching, quietly
+   shrinking the pool for this condition only); a query id that does not parse under
+   `gold`; a query with no entry in the predictions file under `predictions`; a predictions
+   file that is malformed, repeats a query id, or is empty; a `predictions` source with no
+   file named. A per-query fallback would make "hop-matched" a blend of two conditions and
+   the comparison meaningless.
+
+4. **`min_candidates` defaults to `top_k`**: the query's bucket must be able to supply the
+   full top-k, or the run refuses with the bucket sizes printed. The reason is
+   comparability — a bucket that supplies 12 candidates where mixed supplies 20 would make
+   the two conditions differ in candidate-set size *and* in hop composition. The knob
+   accepts an integer instead, which deliberately admits a smaller in-bucket candidate set
+   for someone who wants it; nothing in the repo sets it that way. **The default is a
+   comparability argument, not a measured one** — no evidence says 20 in-bucket candidates
+   beats 12.
+
+5. **The hop source is pluggable, and the router's side of it is an interface, not a
+   router.** `gold` parses the coarse hop depth from the query id (`2hop__…` / `3hop1__…` /
+   `4hop2__…`), the same rule `sample_pool.py` and the decomposer use. `predictions` reads a
+   **JSONL, one object per query**, with the id and hop field names taken from config
+   (`predictions_id_field` / `predictions_hop_field`, defaulting to `query_id` /
+   `predicted_hop`). A prediction *overrides* the gold hop even when it disagrees — that is
+   the whole content of the router condition, and it is the behaviour under test.
+
+   **Today's router output does not conform**, and this is flagged rather than
+   accommodated: `components/router/run_router.py` writes `detailed_results.json` as a JSON
+   *array* of `{question, expected, predicted, correct}`, keyed by question text with **no
+   query id**. Whoever produces the router-hop-matched condition must emit the documented
+   shape (or write a small adapter). Silently keying on question text was rejected: it makes
+   an exact-string match load-bearing on the very field the masking modes rewrite.
+
+6. **The parsing rule is duplicated, and stays duplicated for now.** This repo already had
+   three copies of "hop from id" (`MusiQue/scripts/musique_ids.py`,
+   `MusiQue/scripts/score_similarity_results.py`,
+   `components/decomposer/run_decomposer.py`); `src/hop_matching.py` is the fourth.
+   Consolidating them would mean editing `run_decomposer.py`, which was **frozen** for the
+   queued exp-004/exp-005 launch at the time of writing. The regexes agree today; the
+   duplication is a real (small) drift risk and the obvious cleanup once the freeze lifts.
+
+7. **A matched row carries its own provenance**: when the filter is on, each output row gets
+   `hop_match = {hop_source, query_hop, pool_candidates}`, so a later reader can tell which
+   condition produced a file from the file itself. The field is **absent** when matching is
+   off, which is what keeps the mixed output byte-identical. Downstream stages pass it
+   through untouched.
+
+8. **`--dry-run` is the preflight, and it is the only part a machine without weights can
+   run.** It loads the pool and the queries, resolves and validates the whole hop side, and
+   writes the standard trail (config snapshot + metrics + note, `dry_run: true`) **without
+   loading the encoder** and without writing the output JSONL. It exists because every
+   hop-side failure mode is cheap to hit and expensive to hit late; it is also how
+   `scripts/smoke_test.py` exercises this feature (stage `similarity_hop_match_dryrun`).
+   Caveat, in the shape ADR [0016](./0016-real-run-only-invariants-get-source-level-guards.md)
+   asks to be explicit about: because no model is loaded, a dry run does **not** exercise the
+   parameter-count assertion in `src/model_size.py`.
+
+9. **The hop filters for every query file are built before the output file is opened.** Not
+   a style choice: the output handle is opened once for all query files, so an infeasible
+   bucket discovered in the third file would otherwise leave a truncated JSONL at a path the
+   sweep's skip-if-exists logic treats as finished work. Validating up front also means an
+   infeasible run costs no embedding time.
+
+10. **No new sweep axis.** `scripts/pool_sweep_orchestrator.py` is untouched: it passes no
+    hop flag and its cells stay mixed. Issue #15's eval set is ADR
+    [0007](./0007-musique-evaluation-set-reuses-v1-600-questions-200-per-hop.md)'s pinned
+    600 (200/hop), not the sweep's 750-query dev sample, so the three conditions are
+    produced by driving `check_question_similarity.py` → `truncate_top20.py` /
+    `rerank_similarity_results.py` directly over the pinned set — the same way exp-006 drove
+    the chain. Adding a hop axis to the sweep would multiply every sweep cell for a question
+    the sweep is not asking.
+
+11. **The pool embedding cache is untouched and is shared across the three conditions.** The
+    filter selects among vectors; it does not change them, so the cache key (pool content
+    hash + model + mode) stays correct and the three conditions can reuse one embedding
+    pass.
+
+## What was verified (and what was not)
+
+Ran on 2026-08-21, CPU only, on this branch:
+
+- `tests/test_hop_matching.py` — **33 tests, all passing**: the three hop buckets, both hop
+  sources, a prediction that disagrees with gold, and every failure mode in item 3.
+- Full suite `python -m unittest discover -s tests` and `scripts/smoke_test.py`
+  (**37/37 stages**, including the new `similarity_hop_match_dryrun`).
+- **Mixed-condition regression, byte level.** The same 9 queries × 45-row throwaway pool
+  through the real bi-encoder (`intfloat/e5-small-v2`, CPU, top-k 20, mode `raw`) at
+  `origin/main` and on this branch with the feature off (both by config default and by an
+  explicit `--no-hop-match`): all three output files sha256
+  `1062c5fc8046f364c9d2499b98ab2cdb0e8e23dec854c74060bc2fd66b0a33e6`. In the suite the same
+  property is guarded without weights by re-implementing the pre-change `_top_k_from_scores`
+  verbatim in the test file and comparing on a seeded score matrix that contains ties.
+- **The conditions do what they say.** Same 9 queries, top-k 5: mixed put 14/45 neighbours in
+  the query's gold bucket; oracle-hop-matched 45/45; router-hop-matched, driven by a
+  predictions file where **every** prediction deliberately disagrees with gold, 45/45 in the
+  *predicted* bucket. All three returned exactly k = 5 neighbours per query.
+- **The chain inherits the filter unchanged**: `truncate_top20.py` and
+  `rerank_similarity_results.py` run on the matched artifact with no code change, keeping
+  45/45 neighbours in bucket and preserving the `hop_match` provenance field.
+
+Not verified, and not claimed: **any effect on decomposition quality** (unmeasured — that is
+the run issue #15 still needs), the feasibility of the real pool at the real top-k under the
+`predictions` source (no predictions file exists yet), and GPU determinism of the embedding
+step (this repo sets no torch determinism flags; same caveat as ADR 0021 item 7).
+
+## Consequences
+
+- The oracle-hop-matched condition is runnable now over the ADR 0014 artifact's pool. Its
+  hop mix is 2-hop 3,594 / 3-hop 4,387 / 4-hop 1,175 (recorded in ADR 0014), so every bucket
+  clears the default `min_candidates = top_k = 20` — checkable without a GPU by running the
+  chain's `--dry-run` first, which is the recommended order.
+- **The router-hop-matched condition is blocked on a predictions file** in the shape of item
+  5. Until one exists, issue #15's "done when" can be met for two of its three conditions
+  only. Whether to produce it from the existing router component, from a fine-tuned router
+  (ADR 0010), or from a hop predictor yet to be trained is **not** an implementer decision.
+- **A confound to state in the write-up, not to fix in code.** Hop matching necessarily
+  shrinks the candidate set: the 4-hop bucket is 1,175 rows against the pool's 9,156, so a
+  matched-versus-mixed difference mixes "examples of the same hop depth" with "examples drawn
+  from a smaller, less diverse candidate set". The two cannot be separated by this
+  manipulation — a size-matched control (mixed retrieval from a random 1,175-row subsample)
+  would be needed, and nobody asked for one. Any gain is therefore "consistent with hop
+  matching helping", not "caused by hop depth alone".
+- Because the filter binds in the retrieval stage, each condition is its **own retrieval
+  artifact**. Three conditions × the pinned 600 means three top-20 files and their
+  truncate/rerank descendants; they are cheap (one shared pool embedding pass) but they are
+  distinct files, and a comparison claim must confirm the three were built from the same pool
+  and the same query id list.
+- `configs/similarity.json` now requires a `hop_match` block: a config without it is refused
+  loudly by `require()`, in this repo's no-silent-default style. `configs/similarity_probe.json`
+  does **not** need one — the probes never call this script.
+
+## Alternatives considered
+
+- **Post-filter a mixed top-20.** Rejected; see item 1. It is cheaper (one retrieval run
+  serves all conditions) and that is its only advantage.
+- **A separate `hop_matched_retrieval.py` stage.** Rejected for the reason ADR 0021 rejected
+  a separate clustering stage: it would need its own output conventions and skip logic, and
+  the repo would have two producers of top-k files.
+- **A new axis in the pool sweep.** Rejected; see item 10.
+- **Fine-hop matching (`3hop1` vs `3hop2`) instead of coarse (2/3/4).** Not implemented. The
+  eval set's fine strata are uneven (ADR 0007 records 146/54 for 3-hop and 114/34/52 for
+  4-hop), the pool's fine buckets would be thinner still, and issue #15 says "hop depth",
+  which everything else in this repo reads as the coarse count. A fine-grained variant would
+  be a new `hop_match` mode and a new feasibility check.
+- **Keying the predictions file on question text** (what the current router output would
+  allow). Rejected; see item 5.
+- **Defaulting `min_candidates` to 1** (retrieve whatever the bucket has). Rejected as the
+  default because it silently changes k per query, but it is reachable by config for someone
+  who wants that behaviour deliberately.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,6 +49,7 @@ When **not** to write one:
 | [0019](./0019-musique-answering-backend-conventions.md) | MuSiQue Answering-Backend Conventions: Reader, Context and Scoring | Accepted (Jahid, 2026-08-20, in session; pending supervisor confirmation) |
 | [0020](./0020-prior-work-re-analysis-convention.md) | Prior-Work Re-Analysis Convention | Accepted |
 | [0021](./0021-clustering-pool-construction-strategy.md) | Clustering-Based Pool Construction: The Implementer's Design | Accepted (design agent-authored, pending Jahid) |
+| [0022](./0022-hop-matched-retrieval-the-implementers-design.md) | Hop-Matched Retrieval: The Implementer's Design | Accepted (design agent-authored, pending Jahid) |
 
 ---
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -13,7 +13,10 @@ normal committed config but resolves data paths into the fixture tree. Output go
 What is NOT covered, and why:
 
 - NER masking, bi-encoder similarity, cross-encoder rerank and the two similarity probes
-  need model weights from the network; they are skipped here.
+  need model weights from the network; they are skipped here. The one exception is
+  ``check_question_similarity.py --dry-run``, which validates the inputs and the
+  hop-matched candidate filter (issue #15, ADR 0022) without loading the encoder — so the
+  filter is exercised end-to-end, the embedding and the top-k are not.
 - The router and decomposer runners are exercised with ``--dry-run``: prompts are
   assembled and artifacts written, but no weights are loaded, so the parameter-count
   assertion in ``src/model_size.py`` is *not* exercised by this test.
@@ -99,6 +102,7 @@ def _stages() -> list[Stage]:
     enriched = WORK / "enriched" / "pool_enriched.jsonl"
     pool_dir = WORK / "pool_sample"
     dev_out = WORK / "dev_sample" / "dev_sample.jsonl"
+    hop_match_dry = WORK / "hop_match_dry"
     truncated = WORK / "retrieval" / "top5_biencoder.jsonl"
     scored = WORK / "retrieval" / "top5_scored.jsonl"
     musique_eval_dir = WORK / "musique_eval"
@@ -293,6 +297,35 @@ def _stages() -> list[Stage]:
                 dev_out.parent / "sample_dev_metrics.json",
             ],
             note="per-hop dev draw across the 2/3/4-hop fixture files",
+        ),
+        Stage(
+            name="similarity_hop_match_dryrun",
+            cmd=[
+                sys.executable, MUSIQUE_SCRIPTS / "check_question_similarity.py",
+                "--pool-file", pool_dir / "pool.jsonl",
+                "--query-file", dev_out,
+                "--mode", "raw",
+                # The fixture pool holds one row per hop bucket, so top-k 1 is the largest
+                # value hop matching can satisfy here (min_candidates defaults to top_k).
+                "--top-k", "1",
+                "--n", "10",
+                "--hop-match",
+                "--no-cache",
+                "--run-dir", hop_match_dry,
+                "--dry-run",
+            ],
+            expect_files=[
+                hop_match_dry / "similarity_metrics.json",
+                hop_match_dry / "similarity_config.json",
+                hop_match_dry / "similarity_notes.md",
+            ],
+            expect_metrics=[
+                (hop_match_dry / "similarity_metrics.json", "pool_rows", 3),
+                (hop_match_dry / "similarity_metrics.json", "total_queries", 3),
+                (hop_match_dry / "similarity_metrics.json", "total_written", 0),
+            ],
+            note="hop-matched retrieval preflight over the sampled pool + dev draw "
+            "(--dry-run: the hop filter is built and validated, no bi-encoder is loaded)",
         ),
         Stage(
             name="truncate",

--- a/src/hop_matching.py
+++ b/src/hop_matching.py
@@ -66,6 +66,17 @@ def _sample(items: list[str]) -> str:
     return ", ".join(repr(s) for s in shown) + suffix
 
 
+def is_hop_depth(value: Any) -> bool:
+    """A hop depth is a positive int. ``0`` and negatives are not depths, they are bugs.
+
+    The tighter domain is the pool's own bucket keys, and that is where an out-of-pool
+    depth is caught (:func:`build_hop_filter`, with the bucket sizes printed). This
+    predicate is the cheap first gate, so a predictions file carrying ``0`` or ``-1`` is
+    refused as *not a hop depth* instead of surfacing later as a bucket-size complaint.
+    """
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 1
+
+
 @dataclass(frozen=True)
 class HopMatchSettings:
     """The knobs, resolved from config + CLI. Held frozen so no stage mutates them."""
@@ -78,9 +89,16 @@ class HopMatchSettings:
     min_candidates: int | str
 
     def resolve_min_candidates(self, top_k: int) -> int:
-        if self.min_candidates == MIN_CANDIDATES_TOP_K:
-            return int(top_k)
-        return int(self.min_candidates)
+        """The per-query candidate floor, never below 1.
+
+        ``min_candidates: 0`` is accepted by the config validator (it reads as "no
+        constraint") but it cannot mean "retrieve zero examples for this query" — a query
+        with an empty candidate set is not a hop-matched query, it is a broken one. So the
+        effective floor is 1, and the configured value is still reported verbatim in the
+        run record and in the refusal message.
+        """
+        resolved = int(top_k) if self.min_candidates == MIN_CANDIDATES_TOP_K else int(self.min_candidates)
+        return max(1, resolved)
 
     def as_record(self, top_k: int | None = None) -> dict[str, Any]:
         """The settings as they belong in a metrics JSON / config snapshot."""
@@ -179,8 +197,8 @@ def load_predicted_hops(
             if not isinstance(qid, str) or not qid.strip():
                 bad_rows.append(f"line {lineno}: {id_field!r} missing or not a string")
                 continue
-            if isinstance(hop, bool) or not isinstance(hop, int):
-                bad_rows.append(f"line {lineno}: {hop_field!r}={hop!r} is not an int")
+            if not is_hop_depth(hop):
+                bad_rows.append(f"line {lineno}: {hop_field!r}={hop!r} is not a hop depth")
                 continue
             qid = qid.strip()
             if qid in hops:
@@ -191,7 +209,7 @@ def load_predicted_hops(
         raise SystemExit(
             f"hop predictions file {path} has {len(bad_rows)} unusable row(s): "
             f"{_sample(bad_rows)}. Expected one JSON object per line with "
-            f"{id_field!r} (string) and {hop_field!r} (int)."
+            f"{id_field!r} (string) and {hop_field!r} (a positive int hop depth)."
         )
     if duplicates:
         raise SystemExit(
@@ -275,6 +293,7 @@ def build_hop_filter(
     query_hops: list[int] = []
     unparseable: list[str] = []
     missing_prediction: list[str] = []
+    not_a_depth: list[str] = []
 
     for idx, row in enumerate(query_rows):
         qid = row.get(query_id_field)
@@ -290,6 +309,11 @@ def build_hop_filter(
             hop = (predicted_hops or {}).get(qid.strip())
             if hop is None:
                 missing_prediction.append(qid.strip())
+                continue
+            # load_predicted_hops() already gates a *file*; this gates a dict handed in
+            # programmatically, so no caller can inject a non-depth.
+            if not is_hop_depth(hop):
+                not_a_depth.append(f"{qid.strip()}: {hop!r}")
                 continue
         query_hops.append(hop)
 
@@ -310,28 +334,41 @@ def build_hop_filter(
             f"{settings.predictions_file}: {_sample(missing_prediction)}. The predictions "
             f"file must cover every query; a missing one is not a mixed-condition query."
         )
+    if not_a_depth:
+        raise SystemExit(
+            f"hop-matched retrieval (predictions): {len(not_a_depth)} of {len(query_rows)} "
+            f"queries carry a predicted hop that is not a hop depth (a positive int): "
+            f"{_sample(not_a_depth)}."
+        )
 
     query_hop_counts: dict[int, int] = {}
     for hop in query_hops:
         query_hop_counts[hop] = query_hop_counts.get(hop, 0) + 1
 
+    # ``hop not in pool_buckets`` is folded in rather than left to the size comparison: at
+    # min_candidates=0 a bucket that does not exist would otherwise pass the size test
+    # (0 < 0 is false) and then raise a bare KeyError below. A queried hop the pool cannot
+    # serve at all is the documented hard error, at every min_candidates value.
     infeasible = [
         f"hop {hop}: {len(pool_buckets.get(hop, []))} pool candidates for "
         f"{query_hop_counts[hop]} quer{'y' if query_hop_counts[hop] == 1 else 'ies'}"
+        f"{' (no such bucket in the pool)' if hop not in pool_buckets else ''}"
         for hop in sorted(query_hop_counts)
-        if len(pool_buckets.get(hop, [])) < min_candidates
+        if hop not in pool_buckets or len(pool_buckets[hop]) < min_candidates
     ]
     if infeasible:
         raise SystemExit(
-            f"hop-matched retrieval: a hop bucket cannot supply the required "
-            f"{min_candidates} candidates (top_k={top_k}, "
+            f"hop-matched retrieval: the pool cannot serve a queried hop depth "
+            f"(required candidates per query: {min_candidates}; top_k={top_k}, "
             f"min_candidates={settings.min_candidates!r}):\n  "
             + "\n  ".join(infeasible)
             + "\n  pool buckets: "
             + str({h: len(v) for h, v in sorted(pool_buckets.items())})
             + "\nBuild a pool that covers every queried hop depth, or lower "
             "hop_match.min_candidates deliberately — retrieving fewer than k in-bucket "
-            "examples is a different method, not this one."
+            "examples is a different method, not this one. A hop the pool has no rows for "
+            "at all cannot be fixed by lowering the knob (the floor is 1): the pool has to "
+            "cover it."
         )
 
     allowed = [list(pool_buckets[hop]) for hop in query_hops]
@@ -353,6 +390,7 @@ __all__ = [
     "HopMatchSettings",
     "build_hop_filter",
     "group_pool_by_hop",
+    "is_hop_depth",
     "load_predicted_hops",
     "parse_hop_from_id",
     "settings_from_config",

--- a/src/hop_matching.py
+++ b/src/hop_matching.py
@@ -1,0 +1,359 @@
+"""Hop-matched few-shot retrieval: the candidate filter that binds *before* top-k.
+
+Issue #15 asks whether retrieving few-shot examples of the same hop depth as the query
+helps. Three conditions, all produced by the same retrieval chain:
+
+- **mixed** — no hop constraint. ``enabled = false``, which is the retrieval behaviour
+  this repo had before this module existed.
+- **oracle-hop-matched** — candidates restricted to the pool rows whose hop depth equals
+  the query's *gold* hop depth, parsed from the query id (``2hop__…`` / ``3hop1__…`` /
+  ``4hop2__…``). ``hop_source = "gold"``.
+- **router-hop-matched** — the same restriction, but the hop comes from an external
+  predictions file. ``hop_source = "predictions"``. No router exists in v2 yet; this is
+  the interface it will write into, not the router.
+
+**The filter is a candidate filter, not a post-filter.** With matching on, the bi-encoder
+top-k is computed over the query's hop bucket only, so the whole downstream chain
+(``truncate_top20.py``, ``rerank_similarity_results.py``, the decomposer's few-shot block)
+sees k in-bucket candidates. Filtering a mixed top-20 afterwards would be a different
+method: it would return fewer than k examples for some queries and would make the matched
+condition's example count depend on the mixed ranking.
+
+**Nothing here falls back.** A pool or query id that does not parse, a query with no
+prediction in the predictions file, or a hop bucket that cannot supply the requested k is a
+hard error with counts. A silent fallback to mixed for a subset of queries would make the
+matched condition a blend of two conditions and the comparison meaningless.
+
+Design defaults recorded in ADR 0022.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from run_config import optional, require
+
+#: Where the query's hop depth comes from. Any other value is refused at run time rather
+#: than silently treated as one of these (the shape ADR 0019/0021 use for policy knobs).
+HOP_SOURCES = ("gold", "predictions")
+
+#: ``min_candidates`` sentinel: the query's bucket must hold at least ``top_k`` rows, so a
+#: matched query gets the same number of candidates as a mixed one.
+MIN_CANDIDATES_TOP_K = "top_k"
+
+#: Ids look like ``2hop__482757_12019`` / ``3hop1__…`` / ``4hop2__…``; the leading digits
+#: are the coarse hop depth. Same rule as ``sample_pool.py`` and the decomposer.
+_ID_HOP_RX = re.compile(r"^(?P<h>\d+)hop")
+
+#: How many offending ids an error message lists before it truncates.
+_MAX_REPORTED = 10
+
+
+def parse_hop_from_id(value: Any) -> int | None:
+    """Coarse hop depth from a MuSiQue row id, or None when the id does not parse."""
+    if not isinstance(value, str):
+        return None
+    m = _ID_HOP_RX.match(value.strip())
+    return int(m.group("h")) if m else None
+
+
+def _sample(items: list[str]) -> str:
+    shown = items[:_MAX_REPORTED]
+    suffix = f" (+{len(items) - len(shown)} more)" if len(items) > len(shown) else ""
+    return ", ".join(repr(s) for s in shown) + suffix
+
+
+@dataclass(frozen=True)
+class HopMatchSettings:
+    """The knobs, resolved from config + CLI. Held frozen so no stage mutates them."""
+
+    enabled: bool
+    hop_source: str
+    predictions_file: Path | None
+    predictions_id_field: str
+    predictions_hop_field: str
+    min_candidates: int | str
+
+    def resolve_min_candidates(self, top_k: int) -> int:
+        if self.min_candidates == MIN_CANDIDATES_TOP_K:
+            return int(top_k)
+        return int(self.min_candidates)
+
+    def as_record(self, top_k: int | None = None) -> dict[str, Any]:
+        """The settings as they belong in a metrics JSON / config snapshot."""
+        if not self.enabled:
+            return {"enabled": False}
+        record: dict[str, Any] = {
+            "enabled": True,
+            "hop_source": self.hop_source,
+            "predictions_file": str(self.predictions_file) if self.predictions_file else None,
+            "predictions_id_field": self.predictions_id_field,
+            "predictions_hop_field": self.predictions_hop_field,
+            "min_candidates": self.min_candidates,
+        }
+        if top_k is not None:
+            record["min_candidates_resolved"] = self.resolve_min_candidates(top_k)
+        return record
+
+
+def settings_from_config(
+    cfg: dict[str, Any],
+    *,
+    enabled: bool | None = None,
+    hop_source: str | None = None,
+    predictions_file: str | Path | None = None,
+) -> HopMatchSettings:
+    """Read the ``hop_match`` block; CLI arguments (when not None) win over the config.
+
+    ``enabled = None`` means "whatever the config says" — the mixed condition is the
+    config default, so a stage that passes no flag keeps today's behaviour.
+    """
+    src = cfg.get("_config_path", "<config>")
+    resolved_enabled = bool(require(cfg, "hop_match.enabled")) if enabled is None else bool(enabled)
+    resolved_source = hop_source or require(cfg, "hop_match.hop_source")
+    if resolved_source not in HOP_SOURCES:
+        raise SystemExit(
+            f"hop_match.hop_source={resolved_source!r} is not one of {list(HOP_SOURCES)} "
+            f"(config: {src}). A hop source that is not implemented is refused rather than "
+            f"treated as 'gold'."
+        )
+    file_value = predictions_file if predictions_file is not None else optional(
+        cfg, "hop_match.predictions_file"
+    )
+    resolved_file = Path(str(file_value)) if file_value else None
+    if resolved_enabled and resolved_source == "predictions" and resolved_file is None:
+        raise SystemExit(
+            "hop_match.hop_source='predictions' needs a predictions file: pass "
+            "--hop-predictions or set 'hop_match.predictions_file' in "
+            f"{src}. Without it the router condition would silently become the mixed one."
+        )
+    min_candidates = require(cfg, "hop_match.min_candidates")
+    if min_candidates != MIN_CANDIDATES_TOP_K:
+        if not isinstance(min_candidates, int) or isinstance(min_candidates, bool) or min_candidates < 0:
+            raise SystemExit(
+                f"hop_match.min_candidates={min_candidates!r} must be a non-negative int or "
+                f"the string {MIN_CANDIDATES_TOP_K!r} (config: {src})."
+            )
+    return HopMatchSettings(
+        enabled=resolved_enabled,
+        hop_source=resolved_source,
+        predictions_file=resolved_file,
+        predictions_id_field=require(cfg, "hop_match.predictions_id_field"),
+        predictions_hop_field=require(cfg, "hop_match.predictions_hop_field"),
+        min_candidates=min_candidates,
+    )
+
+
+def load_predicted_hops(
+    path: Path, *, id_field: str, hop_field: str
+) -> dict[str, int]:
+    """Read a predictions JSONL into ``{query_id: predicted_hop}``.
+
+    One row per query id. A duplicate id is refused: two predictions for one query means
+    the file does not say which hop the router chose.
+    """
+    if not path.exists():
+        raise SystemExit(f"hop predictions file not found: {path}")
+    hops: dict[str, int] = {}
+    duplicates: list[str] = []
+    bad_rows: list[str] = []
+    rows = 0
+    with path.open(encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            rows += 1
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"{path}:{lineno} is not valid JSON: {exc}") from exc
+            if not isinstance(row, dict):
+                bad_rows.append(f"line {lineno}: not an object")
+                continue
+            qid = row.get(id_field)
+            hop = row.get(hop_field)
+            if not isinstance(qid, str) or not qid.strip():
+                bad_rows.append(f"line {lineno}: {id_field!r} missing or not a string")
+                continue
+            if isinstance(hop, bool) or not isinstance(hop, int):
+                bad_rows.append(f"line {lineno}: {hop_field!r}={hop!r} is not an int")
+                continue
+            qid = qid.strip()
+            if qid in hops:
+                duplicates.append(qid)
+                continue
+            hops[qid] = hop
+    if bad_rows:
+        raise SystemExit(
+            f"hop predictions file {path} has {len(bad_rows)} unusable row(s): "
+            f"{_sample(bad_rows)}. Expected one JSON object per line with "
+            f"{id_field!r} (string) and {hop_field!r} (int)."
+        )
+    if duplicates:
+        raise SystemExit(
+            f"hop predictions file {path} repeats {len(duplicates)} query id(s): "
+            f"{_sample(sorted(set(duplicates)))}. One prediction per query id."
+        )
+    if not hops:
+        raise SystemExit(f"hop predictions file {path} holds no predictions ({rows} rows read)")
+    return hops
+
+
+def group_pool_by_hop(pool_rows: list[dict[str, Any]], *, id_field: str = "id") -> dict[int, list[int]]:
+    """``{hop: [pool row indices]}``, index order preserved.
+
+    Every pool row must carry a parseable id: a row that cannot be bucketed could never be
+    retrieved under matching, which would quietly shrink the pool for this condition only.
+    """
+    buckets: dict[int, list[int]] = {}
+    unparseable: list[str] = []
+    for idx, row in enumerate(pool_rows):
+        hop = parse_hop_from_id(row.get(id_field))
+        if hop is None:
+            unparseable.append(f"index {idx}: {row.get(id_field)!r}")
+            continue
+        buckets.setdefault(hop, []).append(idx)
+    if unparseable:
+        raise SystemExit(
+            f"hop-matched retrieval: {len(unparseable)} of {len(pool_rows)} pool rows have an "
+            f"id whose hop depth does not parse: {_sample(unparseable)}. Ids must look like "
+            f"'2hop__…' / '3hop1__…'. Fix the pool rather than dropping the rows: under "
+            f"matching an unbucketable row is silently unreachable."
+        )
+    return buckets
+
+
+@dataclass(frozen=True)
+class HopFilter:
+    """Per-query allowed pool indices, plus the counts the run has to record."""
+
+    settings: HopMatchSettings
+    top_k: int
+    min_candidates: int
+    #: allowed[i] = pool row indices the i-th query may retrieve from, ascending.
+    allowed: list[list[int]]
+    #: query_hops[i] = the hop depth the filter used for the i-th query.
+    query_hops: list[int]
+    pool_bucket_counts: dict[int, int]
+    query_hop_counts: dict[int, int]
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            **self.settings.as_record(self.top_k),
+            "queries": len(self.allowed),
+            "pool_bucket_counts": {str(h): n for h, n in sorted(self.pool_bucket_counts.items())},
+            "query_hop_counts": {str(h): n for h, n in sorted(self.query_hop_counts.items())},
+            "candidates_per_query_min": min((len(a) for a in self.allowed), default=0),
+            "candidates_per_query_max": max((len(a) for a in self.allowed), default=0),
+        }
+
+
+def build_hop_filter(
+    *,
+    query_rows: list[dict[str, Any]],
+    pool_buckets: dict[int, list[int]],
+    settings: HopMatchSettings,
+    top_k: int,
+    predicted_hops: dict[str, int] | None = None,
+    query_id_field: str = "id",
+) -> HopFilter | None:
+    """The candidate filter for one query file, or None when matching is off.
+
+    None is the mixed condition: the caller keeps its unfiltered code path, so mixed is
+    not "the filter with everything allowed" but literally the code that ran before.
+    """
+    if not settings.enabled:
+        return None
+    if not query_rows:
+        raise SystemExit("hop-matched retrieval: no query rows to build a filter for")
+
+    min_candidates = settings.resolve_min_candidates(top_k)
+    query_hops: list[int] = []
+    unparseable: list[str] = []
+    missing_prediction: list[str] = []
+
+    for idx, row in enumerate(query_rows):
+        qid = row.get(query_id_field)
+        if settings.hop_source == "gold":
+            hop = parse_hop_from_id(qid)
+            if hop is None:
+                unparseable.append(f"index {idx}: {qid!r}")
+                continue
+        else:
+            if not isinstance(qid, str) or not qid.strip():
+                unparseable.append(f"index {idx}: {qid!r}")
+                continue
+            hop = (predicted_hops or {}).get(qid.strip())
+            if hop is None:
+                missing_prediction.append(qid.strip())
+                continue
+        query_hops.append(hop)
+
+    if unparseable:
+        what = (
+            "gold hop depth does not parse from the query id"
+            if settings.hop_source == "gold"
+            else "query id is missing, so no prediction can be looked up"
+        )
+        raise SystemExit(
+            f"hop-matched retrieval ({settings.hop_source}): {len(unparseable)} of "
+            f"{len(query_rows)} queries — {what}: {_sample(unparseable)}."
+        )
+    if missing_prediction:
+        raise SystemExit(
+            f"hop-matched retrieval (predictions): {len(missing_prediction)} of "
+            f"{len(query_rows)} queries have no prediction in "
+            f"{settings.predictions_file}: {_sample(missing_prediction)}. The predictions "
+            f"file must cover every query; a missing one is not a mixed-condition query."
+        )
+
+    query_hop_counts: dict[int, int] = {}
+    for hop in query_hops:
+        query_hop_counts[hop] = query_hop_counts.get(hop, 0) + 1
+
+    infeasible = [
+        f"hop {hop}: {len(pool_buckets.get(hop, []))} pool candidates for "
+        f"{query_hop_counts[hop]} quer{'y' if query_hop_counts[hop] == 1 else 'ies'}"
+        for hop in sorted(query_hop_counts)
+        if len(pool_buckets.get(hop, [])) < min_candidates
+    ]
+    if infeasible:
+        raise SystemExit(
+            f"hop-matched retrieval: a hop bucket cannot supply the required "
+            f"{min_candidates} candidates (top_k={top_k}, "
+            f"min_candidates={settings.min_candidates!r}):\n  "
+            + "\n  ".join(infeasible)
+            + "\n  pool buckets: "
+            + str({h: len(v) for h, v in sorted(pool_buckets.items())})
+            + "\nBuild a pool that covers every queried hop depth, or lower "
+            "hop_match.min_candidates deliberately — retrieving fewer than k in-bucket "
+            "examples is a different method, not this one."
+        )
+
+    allowed = [list(pool_buckets[hop]) for hop in query_hops]
+    return HopFilter(
+        settings=settings,
+        top_k=int(top_k),
+        min_candidates=min_candidates,
+        allowed=allowed,
+        query_hops=query_hops,
+        pool_bucket_counts={h: len(v) for h, v in pool_buckets.items()},
+        query_hop_counts=query_hop_counts,
+    )
+
+
+__all__ = [
+    "HOP_SOURCES",
+    "MIN_CANDIDATES_TOP_K",
+    "HopFilter",
+    "HopMatchSettings",
+    "build_hop_filter",
+    "group_pool_by_hop",
+    "load_predicted_hops",
+    "parse_hop_from_id",
+    "settings_from_config",
+]

--- a/tests/test_hop_matching.py
+++ b/tests/test_hop_matching.py
@@ -10,9 +10,11 @@ What it covers:
    id, ``predictions`` from an external JSONL), and that a prediction which *disagrees* with
    the gold hop moves the candidate set, which is the whole point of the router condition.
 2. **Every failure mode is a hard error with counts** — an unparseable pool id, an
-   unparseable query id, a query with no prediction, a hop bucket too small for ``top_k``,
-   a malformed / duplicated / empty predictions file, and a ``predictions`` source with no
-   file. None of them may fall back to the mixed condition.
+   unparseable query id, a query with no prediction, a predicted hop that is not a hop
+   depth, a hop bucket too small for ``top_k``, a queried hop the pool has no bucket for at
+   all (including at ``min_candidates: 0``, PR #39 finding 1), a malformed / duplicated /
+   empty predictions file, and a ``predictions`` source with no file. None of them may fall
+   back to the mixed condition, and none may surface as an uncaught exception.
 3. **The regression guard for the mixed condition** — with the feature off,
    ``_top_k_from_scores`` returns exactly what the pre-change implementation returned
    (re-implemented verbatim in this file), on a seeded score matrix that contains ties; the
@@ -312,7 +314,7 @@ class TestFilterGoldSource(unittest.TestCase):
             )
         message = str(ctx.exception)
         self.assertIn("hop 4: 2 pool candidates for 2 queries", message)
-        self.assertIn("5 candidates", message)
+        self.assertIn("required candidates per query: 5", message)
 
     def test_a_queried_hop_absent_from_the_pool_is_refused(self) -> None:
         with self.assertRaises(SystemExit) as ctx:
@@ -323,6 +325,41 @@ class TestFilterGoldSource(unittest.TestCase):
                 top_k=1,
             )
         self.assertIn("hop 4: 0 pool candidates", str(ctx.exception))
+
+    def test_a_missing_bucket_is_refused_even_at_min_candidates_zero(self) -> None:
+        """PR #39 review finding 1: this used to pass the size test and raise KeyError.
+
+        ``0 < 0`` is false, so a hop with no bucket at all slipped through the feasibility
+        guard and hit a bare ``pool_buckets[hop]``. It must be the documented hard error
+        with counts, at every ``min_candidates`` value.
+        """
+        with self.assertRaises(SystemExit) as ctx:
+            HM.build_hop_filter(
+                query_rows=[{"id": "4hop1__a_b_c_d"}],
+                pool_buckets={2: [0, 1, 2]},
+                settings=_settings(min_candidates=0),
+                top_k=5,
+            )
+        message = str(ctx.exception)
+        self.assertIn("hop 4: 0 pool candidates for 1 query", message)
+        self.assertIn("no such bucket in the pool", message)
+        self.assertIn("min_candidates=0", message)
+
+    def test_an_empty_bucket_is_refused_even_at_min_candidates_zero(self) -> None:
+        """Same guard from the other side: a present-but-empty bucket serves nobody."""
+        with self.assertRaises(SystemExit) as ctx:
+            HM.build_hop_filter(
+                query_rows=[{"id": "4hop1__a_b_c_d"}],
+                pool_buckets={2: [0, 1], 4: []},
+                settings=_settings(min_candidates=0),
+                top_k=5,
+            )
+        self.assertIn("hop 4: 0 pool candidates", str(ctx.exception))
+
+    def test_min_candidates_never_resolves_below_one(self) -> None:
+        self.assertEqual(_settings(min_candidates=0).resolve_min_candidates(20), 1)
+        self.assertEqual(_settings(min_candidates=0).resolve_min_candidates(0), 1)
+        self.assertEqual(_settings().resolve_min_candidates(0), 1)
 
     def test_min_candidates_as_an_int_relaxes_the_requirement(self) -> None:
         pool = _pool({2: 6, 4: 2})
@@ -378,6 +415,33 @@ class TestFilterPredictionsSource(unittest.TestCase):
         self.assertIn("2 of 3 queries have no prediction", message)
         self.assertIn(queries[1]["id"], message)
 
+    def test_a_predicted_hop_that_is_not_a_depth_is_refused(self) -> None:
+        """PR #39 review finding 2: 0 and -1 are not hop depths, and must say so.
+
+        Caught here rather than surfacing later as a bucket-size complaint about a hop
+        that could never exist.
+        """
+        pool = _pool({2: 6, 3: 6, 4: 6})
+        queries = _queries([2, 3])
+        for bad in (0, -1):
+            with self.assertRaises(SystemExit, msg=repr(bad)) as ctx:
+                HM.build_hop_filter(
+                    query_rows=queries,
+                    pool_buckets=HM.group_pool_by_hop(pool),
+                    settings=_settings(hop_source="predictions", predictions_file=Path("p.jsonl")),
+                    top_k=3,
+                    predicted_hops={queries[0]["id"]: 2, queries[1]["id"]: bad},
+                )
+            message = str(ctx.exception)
+            self.assertIn("not a hop depth", message)
+            self.assertIn("1 of 2 queries", message)
+
+    def test_is_hop_depth_domain(self) -> None:
+        for good in (1, 2, 3, 4, 17):
+            self.assertTrue(HM.is_hop_depth(good), msg=repr(good))
+        for bad in (0, -1, True, False, 2.0, "2", None):
+            self.assertFalse(HM.is_hop_depth(bad), msg=repr(bad))
+
     def test_predictions_file_round_trip(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = self._predictions_file(
@@ -401,6 +465,9 @@ class TestFilterPredictionsSource(unittest.TestCase):
             tmpdir = Path(tmp)
             cases = {
                 "not an int": [{"query_id": "2hop__a", "predicted_hop": "three"}],
+                "zero hops": [{"query_id": "2hop__a", "predicted_hop": 0}],
+                "negative hops": [{"query_id": "2hop__a", "predicted_hop": -1}],
+                "boolean": [{"query_id": "2hop__a", "predicted_hop": True}],
                 "missing id": [{"predicted_hop": 3}],
                 "duplicate": [
                     {"query_id": "2hop__a", "predicted_hop": 3},

--- a/tests/test_hop_matching.py
+++ b/tests/test_hop_matching.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""Checks for hop-matched few-shot retrieval (issue #15, ADR 0022).
+
+CPU only, no model weights, no network. Everything here runs on hand-made pool/query rows
+and hand-made score matrices; the CLI checks use ``--dry-run``, which loads no model.
+
+What it covers:
+
+1. **The filter itself** — all three hop buckets, both hop sources (``gold`` from the query
+   id, ``predictions`` from an external JSONL), and that a prediction which *disagrees* with
+   the gold hop moves the candidate set, which is the whole point of the router condition.
+2. **Every failure mode is a hard error with counts** — an unparseable pool id, an
+   unparseable query id, a query with no prediction, a hop bucket too small for ``top_k``,
+   a malformed / duplicated / empty predictions file, and a ``predictions`` source with no
+   file. None of them may fall back to the mixed condition.
+3. **The regression guard for the mixed condition** — with the feature off,
+   ``_top_k_from_scores`` returns exactly what the pre-change implementation returned
+   (re-implemented verbatim in this file), on a seeded score matrix that contains ties; the
+   config default is ``enabled: false``; and a disabled filter is ``None`` rather than
+   "everything allowed", so mixed keeps the original code path.
+4. **The filtered top-k is computed inside the bucket** — the neighbours are the bucket's
+   own top-k, in the bucket's own order, and there are still ``top_k`` of them.
+5. **The CLI wiring** — ``--dry-run`` exits 0 and writes the run trail for the gold and the
+   predictions source, and exits non-zero with counts on an infeasible bucket.
+
+Run::
+
+    .venv/bin/python -m unittest tests.test_hop_matching -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIMILARITY_SCRIPT = REPO_ROOT / "MusiQue" / "scripts" / "check_question_similarity.py"
+SIMILARITY_CONFIG = REPO_ROOT / "configs" / "similarity.json"
+
+for _path in (REPO_ROOT / "src", SIMILARITY_SCRIPT.parent):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+import hop_matching as HM  # noqa: E402
+
+
+def _import_similarity_script() -> Any:
+    """Import check_question_similarity.py the way the script itself is run."""
+    name = "check_question_similarity"
+    spec = importlib.util.spec_from_file_location(name, SIMILARITY_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CQS = _import_similarity_script()
+
+
+def _settings(**overrides: Any) -> HM.HopMatchSettings:
+    params: dict[str, Any] = {
+        "enabled": True,
+        "hop_source": "gold",
+        "predictions_file": None,
+        "predictions_id_field": "query_id",
+        "predictions_hop_field": "predicted_hop",
+        "min_candidates": HM.MIN_CANDIDATES_TOP_K,
+    }
+    params.update(overrides)
+    return HM.HopMatchSettings(**params)
+
+
+def _pool(per_hop: dict[int, int]) -> list[dict[str, Any]]:
+    """Pool rows with ids in this dataset's shape, interleaved across buckets.
+
+    Interleaved on purpose: if the filter accidentally sliced a contiguous range it would
+    still pass on a bucket-sorted pool.
+    """
+    rows: list[dict[str, Any]] = []
+    counters = {hop: 0 for hop in per_hop}
+    remaining = dict(per_hop)
+    while any(remaining.values()):
+        for hop in sorted(per_hop):
+            if remaining[hop] <= 0:
+                continue
+            i = counters[hop]
+            fine = "" if hop == 2 else str(1 + (i % 2))
+            rows.append(
+                {
+                    "id": f"{hop}hop{fine}__pool_{hop}_{i}",
+                    "question": f"pool question {hop}/{i}",
+                }
+            )
+            counters[hop] += 1
+            remaining[hop] -= 1
+    return rows
+
+
+def _queries(hops: list[int]) -> list[dict[str, Any]]:
+    return [
+        {"id": f"{hop}hop{'' if hop == 2 else '1'}__q_{i}", "question": f"query {i} ({hop} hop)"}
+        for i, hop in enumerate(hops)
+    ]
+
+
+def _reference_top_k(
+    scores: np.ndarray, pool_rows: list[dict[str, Any]], top_k: int
+) -> list[list[dict[str, Any]]]:
+    """The pre-change ``_top_k_from_scores`` body, verbatim.
+
+    This is the baseline the mixed condition is held to: if the refactor that added the
+    ``allowed_indices`` parameter changed anything about the unfiltered path — ordering,
+    tie handling, rounding, which keys are emitted — this reference disagrees with it.
+    """
+    all_neighbours: list[list[dict[str, Any]]] = []
+    for i in range(scores.shape[0]):
+        row_scores = scores[i]
+        top_idx = np.argsort(row_scores)[::-1][:top_k]
+        neighbours: list[dict[str, Any]] = []
+        for j in top_idx:
+            prow = pool_rows[int(j)]
+            entry: dict[str, Any] = {
+                "pool_id": prow.get("id"),
+                "pool_index": prow.get("index"),
+                "pool_question": prow.get("question"),
+                "pool_question_masked_typed": prow.get("question_masked_typed"),
+                "pool_question_masked_uniform": prow.get("question_masked_uniform"),
+                "pool_few_shot_decomposition_musique": prow.get("few_shot_decomposition_musique"),
+                "score": round(float(row_scores[j]), 4),
+            }
+            neighbours.append({k: v for k, v in entry.items() if v is not None})
+        all_neighbours.append(neighbours)
+    return all_neighbours
+
+
+def _scores(num_queries: int, num_pool: int, *, seed: int = 42) -> np.ndarray:
+    """A seeded score matrix rounded to 2 decimals, so ties actually occur."""
+    rng = np.random.default_rng(seed)
+    return np.round(rng.random((num_queries, num_pool), dtype=np.float32), 2)
+
+
+class TestParseHop(unittest.TestCase):
+    def test_the_three_id_shapes(self) -> None:
+        self.assertEqual(HM.parse_hop_from_id("2hop__482757_12019"), 2)
+        self.assertEqual(HM.parse_hop_from_id("3hop1__a_b"), 3)
+        self.assertEqual(HM.parse_hop_from_id("4hop2__a_b"), 4)
+
+    def test_unparseable_is_none(self) -> None:
+        for value in ("", "hop2__x", "musique_123", None, 3, ["2hop__x"]):
+            self.assertIsNone(HM.parse_hop_from_id(value), msg=repr(value))
+
+
+class TestPoolBuckets(unittest.TestCase):
+    def test_buckets_hold_the_row_indices_in_order(self) -> None:
+        rows = _pool({2: 3, 3: 2, 4: 1})
+        buckets = HM.group_pool_by_hop(rows)
+        self.assertEqual(sorted(buckets), [2, 3, 4])
+        self.assertEqual([len(v) for _, v in sorted(buckets.items())], [3, 2, 1])
+        for hop, idxs in buckets.items():
+            self.assertEqual(idxs, sorted(idxs))
+            for i in idxs:
+                self.assertEqual(HM.parse_hop_from_id(rows[i]["id"]), hop)
+
+    def test_unparseable_pool_id_is_refused_with_counts(self) -> None:
+        rows = _pool({2: 2, 3: 1})
+        rows.append({"id": "no_hop_here", "question": "?"})
+        with self.assertRaises(SystemExit) as ctx:
+            HM.group_pool_by_hop(rows)
+        message = str(ctx.exception)
+        self.assertIn("1 of 4 pool rows", message)
+        self.assertIn("no_hop_here", message)
+
+
+class TestSettings(unittest.TestCase):
+    def _cfg(self, **hop_match: Any) -> dict[str, Any]:
+        block = {
+            "enabled": False,
+            "hop_source": "gold",
+            "predictions_file": None,
+            "predictions_id_field": "query_id",
+            "predictions_hop_field": "predicted_hop",
+            "min_candidates": "top_k",
+        }
+        block.update(hop_match)
+        return {"hop_match": block, "_config_path": "<test>"}
+
+    def test_committed_config_defaults_to_the_mixed_condition(self) -> None:
+        """The shipped default must be mixed: a stage that passes no flag is unchanged."""
+        cfg = json.loads(SIMILARITY_CONFIG.read_text(encoding="utf-8"))
+        self.assertIn("hop_match", cfg)
+        self.assertFalse(cfg["hop_match"]["enabled"])
+        self.assertEqual(cfg["hop_match"]["hop_source"], "gold")
+        self.assertEqual(cfg["hop_match"]["min_candidates"], "top_k")
+        self.assertIsNone(cfg["hop_match"]["predictions_file"])
+
+    def test_cli_overrides_the_config_both_ways(self) -> None:
+        enabled = HM.settings_from_config(self._cfg(), enabled=True)
+        self.assertTrue(enabled.enabled)
+        disabled = HM.settings_from_config(self._cfg(enabled=True), enabled=False)
+        self.assertFalse(disabled.enabled)
+        self.assertFalse(HM.settings_from_config(self._cfg()).enabled)
+
+    def test_unknown_hop_source_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            HM.settings_from_config(self._cfg(), enabled=True, hop_source="vibes")
+        self.assertIn("hop_source", str(ctx.exception))
+
+    def test_predictions_source_without_a_file_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            HM.settings_from_config(self._cfg(), enabled=True, hop_source="predictions")
+        self.assertIn("--hop-predictions", str(ctx.exception))
+
+    def test_predictions_source_takes_the_file_from_config_or_cli(self) -> None:
+        from_cfg = HM.settings_from_config(
+            self._cfg(hop_source="predictions", predictions_file="a/b.jsonl"), enabled=True
+        )
+        self.assertEqual(from_cfg.predictions_file, Path("a/b.jsonl"))
+        from_cli = HM.settings_from_config(
+            self._cfg(hop_source="predictions", predictions_file="a/b.jsonl"),
+            enabled=True,
+            predictions_file="c/d.jsonl",
+        )
+        self.assertEqual(from_cli.predictions_file, Path("c/d.jsonl"))
+
+    def test_min_candidates_resolution_and_validation(self) -> None:
+        self.assertEqual(_settings().resolve_min_candidates(20), 20)
+        self.assertEqual(_settings(min_candidates=3).resolve_min_candidates(20), 3)
+        for bad in (-1, "twenty", 2.5, True):
+            with self.assertRaises(SystemExit, msg=repr(bad)):
+                HM.settings_from_config(self._cfg(min_candidates=bad), enabled=True)
+
+    def test_record_hides_nothing_and_says_disabled(self) -> None:
+        self.assertEqual(_settings(enabled=False).as_record(20), {"enabled": False})
+        record = _settings().as_record(20)
+        self.assertTrue(record["enabled"])
+        self.assertEqual(record["min_candidates_resolved"], 20)
+
+
+class TestFilterGoldSource(unittest.TestCase):
+    def test_disabled_yields_no_filter_at_all(self) -> None:
+        got = HM.build_hop_filter(
+            query_rows=_queries([2]),
+            pool_buckets={2: [0]},
+            settings=_settings(enabled=False),
+            top_k=1,
+        )
+        self.assertIsNone(got)
+
+    def test_every_bucket_restricts_to_its_own_pool_rows(self) -> None:
+        pool = _pool({2: 6, 3: 5, 4: 4})
+        buckets = HM.group_pool_by_hop(pool)
+        queries = _queries([2, 3, 4, 4, 2])
+        hop_filter = HM.build_hop_filter(
+            query_rows=queries, pool_buckets=buckets, settings=_settings(), top_k=4
+        )
+        assert hop_filter is not None
+        self.assertEqual(hop_filter.query_hops, [2, 3, 4, 4, 2])
+        self.assertEqual(hop_filter.query_hop_counts, {2: 2, 3: 1, 4: 2})
+        self.assertEqual(hop_filter.pool_bucket_counts, {2: 6, 3: 5, 4: 4})
+        self.assertEqual(hop_filter.min_candidates, 4)
+        for allowed, hop in zip(hop_filter.allowed, hop_filter.query_hops):
+            self.assertEqual(allowed, buckets[hop])
+            self.assertTrue(all(HM.parse_hop_from_id(pool[i]["id"]) == hop for i in allowed))
+
+    def test_summary_reports_the_counts_a_run_must_record(self) -> None:
+        pool = _pool({2: 6, 3: 5, 4: 4})
+        hop_filter = HM.build_hop_filter(
+            query_rows=_queries([2, 4]),
+            pool_buckets=HM.group_pool_by_hop(pool),
+            settings=_settings(),
+            top_k=4,
+        )
+        assert hop_filter is not None
+        summary = hop_filter.summary()
+        self.assertEqual(summary["queries"], 2)
+        self.assertEqual(summary["pool_bucket_counts"], {"2": 6, "3": 5, "4": 4})
+        self.assertEqual(summary["query_hop_counts"], {"2": 1, "4": 1})
+        self.assertEqual(summary["candidates_per_query_min"], 4)
+        self.assertEqual(summary["candidates_per_query_max"], 6)
+
+    def test_unparseable_query_id_is_refused_with_counts(self) -> None:
+        pool = _pool({2: 6, 3: 6, 4: 6})
+        queries = _queries([2, 3]) + [{"id": "not_an_id", "question": "?"}]
+        with self.assertRaises(SystemExit) as ctx:
+            HM.build_hop_filter(
+                query_rows=queries,
+                pool_buckets=HM.group_pool_by_hop(pool),
+                settings=_settings(),
+                top_k=2,
+            )
+        message = str(ctx.exception)
+        self.assertIn("1 of 3 queries", message)
+        self.assertIn("not_an_id", message)
+
+    def test_a_bucket_too_small_for_top_k_is_refused_with_counts(self) -> None:
+        pool = _pool({2: 6, 3: 6, 4: 2})
+        with self.assertRaises(SystemExit) as ctx:
+            HM.build_hop_filter(
+                query_rows=_queries([2, 4, 4]),
+                pool_buckets=HM.group_pool_by_hop(pool),
+                settings=_settings(),
+                top_k=5,
+            )
+        message = str(ctx.exception)
+        self.assertIn("hop 4: 2 pool candidates for 2 queries", message)
+        self.assertIn("5 candidates", message)
+
+    def test_a_queried_hop_absent_from_the_pool_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            HM.build_hop_filter(
+                query_rows=_queries([4]),
+                pool_buckets=HM.group_pool_by_hop(_pool({2: 6, 3: 6})),
+                settings=_settings(),
+                top_k=1,
+            )
+        self.assertIn("hop 4: 0 pool candidates", str(ctx.exception))
+
+    def test_min_candidates_as_an_int_relaxes_the_requirement(self) -> None:
+        pool = _pool({2: 6, 4: 2})
+        hop_filter = HM.build_hop_filter(
+            query_rows=_queries([4]),
+            pool_buckets=HM.group_pool_by_hop(pool),
+            settings=_settings(min_candidates=2),
+            top_k=5,
+        )
+        assert hop_filter is not None
+        self.assertEqual(hop_filter.min_candidates, 2)
+        self.assertEqual(len(hop_filter.allowed[0]), 2)
+
+
+class TestFilterPredictionsSource(unittest.TestCase):
+    def _predictions_file(self, dirpath: Path, rows: list[dict[str, Any]]) -> Path:
+        path = dirpath / "hop_predictions.jsonl"
+        path.write_text(
+            "".join(json.dumps(r, ensure_ascii=False) + "\n" for r in rows), encoding="utf-8"
+        )
+        return path
+
+    def test_the_prediction_wins_over_the_gold_hop(self) -> None:
+        """A wrong prediction must move the candidate set — that is the router condition."""
+        pool = _pool({2: 6, 3: 6, 4: 6})
+        buckets = HM.group_pool_by_hop(pool)
+        queries = _queries([2, 3, 4])
+        predicted = {queries[0]["id"]: 4, queries[1]["id"]: 3, queries[2]["id"]: 2}
+        hop_filter = HM.build_hop_filter(
+            query_rows=queries,
+            pool_buckets=buckets,
+            settings=_settings(hop_source="predictions", predictions_file=Path("p.jsonl")),
+            top_k=3,
+            predicted_hops=predicted,
+        )
+        assert hop_filter is not None
+        self.assertEqual(hop_filter.query_hops, [4, 3, 2])
+        self.assertEqual(hop_filter.allowed[0], buckets[4])
+        self.assertEqual(hop_filter.allowed[2], buckets[2])
+
+    def test_a_missing_prediction_is_refused_with_counts(self) -> None:
+        pool = _pool({2: 6, 3: 6, 4: 6})
+        queries = _queries([2, 3, 4])
+        with self.assertRaises(SystemExit) as ctx:
+            HM.build_hop_filter(
+                query_rows=queries,
+                pool_buckets=HM.group_pool_by_hop(pool),
+                settings=_settings(hop_source="predictions", predictions_file=Path("p.jsonl")),
+                top_k=3,
+                predicted_hops={queries[0]["id"]: 2},
+            )
+        message = str(ctx.exception)
+        self.assertIn("2 of 3 queries have no prediction", message)
+        self.assertIn(queries[1]["id"], message)
+
+    def test_predictions_file_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._predictions_file(
+                Path(tmp),
+                [
+                    {"query_id": "2hop__a", "predicted_hop": 3},
+                    {"query_id": "3hop1__b", "predicted_hop": 2, "extra": "ignored"},
+                ],
+            )
+            hops = HM.load_predicted_hops(path, id_field="query_id", hop_field="predicted_hop")
+            self.assertEqual(hops, {"2hop__a": 3, "3hop1__b": 2})
+
+    def test_predictions_file_field_names_are_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._predictions_file(Path(tmp), [{"qid": "2hop__a", "hop": 4}])
+            hops = HM.load_predicted_hops(path, id_field="qid", hop_field="hop")
+            self.assertEqual(hops, {"2hop__a": 4})
+
+    def test_bad_predictions_files_are_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            cases = {
+                "not an int": [{"query_id": "2hop__a", "predicted_hop": "three"}],
+                "missing id": [{"predicted_hop": 3}],
+                "duplicate": [
+                    {"query_id": "2hop__a", "predicted_hop": 3},
+                    {"query_id": "2hop__a", "predicted_hop": 2},
+                ],
+                "empty": [],
+            }
+            for label, rows in cases.items():
+                path = self._predictions_file(tmpdir, rows)
+                with self.assertRaises(SystemExit, msg=label):
+                    HM.load_predicted_hops(
+                        path, id_field="query_id", hop_field="predicted_hop"
+                    )
+            missing = tmpdir / "absent.jsonl"
+            with self.assertRaises(SystemExit):
+                HM.load_predicted_hops(
+                    missing, id_field="query_id", hop_field="predicted_hop"
+                )
+
+
+class TestMixedConditionRegressionGuard(unittest.TestCase):
+    """With the feature off, retrieval output must be what it was before the feature."""
+
+    def test_unfiltered_path_matches_the_pre_change_implementation(self) -> None:
+        pool = _pool({2: 9, 3: 8, 4: 6})
+        scores = _scores(7, len(pool))
+        for top_k in (1, 5, 20, len(pool)):
+            expected = _reference_top_k(scores, pool, top_k)
+            got = CQS._top_k_from_scores(scores, pool, top_k)
+            self.assertEqual(got, expected, msg=f"top_k={top_k}")
+            self.assertEqual(
+                CQS._top_k_from_scores(scores, pool, top_k, allowed_indices=None),
+                expected,
+                msg=f"explicit None, top_k={top_k}",
+            )
+
+    def test_allowing_the_whole_pool_reproduces_the_unfiltered_ranking(self) -> None:
+        pool = _pool({2: 5, 3: 5, 4: 5})
+        scores = _scores(4, len(pool), seed=7)
+        allowed = [list(range(len(pool)))] * scores.shape[0]
+        self.assertEqual(
+            CQS._top_k_from_scores(scores, pool, 5, allowed_indices=allowed),
+            _reference_top_k(scores, pool, 5),
+        )
+
+    def test_a_disabled_filter_is_none_not_everything_allowed(self) -> None:
+        self.assertIsNone(
+            HM.build_hop_filter(
+                query_rows=_queries([2, 3, 4]),
+                pool_buckets={},
+                settings=_settings(enabled=False),
+                top_k=20,
+            )
+        )
+
+
+class TestFilteredTopK(unittest.TestCase):
+    def test_the_top_k_is_ranked_inside_the_bucket(self) -> None:
+        pool = _pool({2: 9, 3: 8, 4: 7})
+        buckets = HM.group_pool_by_hop(pool)
+        queries = _queries([2, 3, 4])
+        hop_filter = HM.build_hop_filter(
+            query_rows=queries, pool_buckets=buckets, settings=_settings(), top_k=5
+        )
+        assert hop_filter is not None
+        scores = _scores(len(queries), len(pool), seed=11)
+        got = CQS._top_k_from_scores(scores, pool, 5, allowed_indices=hop_filter.allowed)
+
+        for i, hop in enumerate(hop_filter.query_hops):
+            self.assertEqual(len(got[i]), 5, msg=f"query {i} should still get top_k")
+            in_bucket_ids = {pool[j]["id"] for j in buckets[hop]}
+            self.assertTrue({nb["pool_id"] for nb in got[i]} <= in_bucket_ids)
+            # The same ranking as scoring the bucket on its own.
+            bucket_rows = [pool[j] for j in buckets[hop]]
+            bucket_scores = scores[i : i + 1, buckets[hop]]
+            self.assertEqual(got[i], _reference_top_k(bucket_scores, bucket_rows, 5)[0])
+
+    def test_a_bucket_smaller_than_top_k_returns_the_whole_bucket(self) -> None:
+        """Only reachable with an explicit min_candidates; the default refuses this case."""
+        pool = _pool({2: 6, 4: 2})
+        buckets = HM.group_pool_by_hop(pool)
+        hop_filter = HM.build_hop_filter(
+            query_rows=_queries([4]),
+            pool_buckets=buckets,
+            settings=_settings(min_candidates=1),
+            top_k=5,
+        )
+        assert hop_filter is not None
+        got = CQS._top_k_from_scores(
+            _scores(1, len(pool), seed=3), pool, 5, allowed_indices=hop_filter.allowed
+        )
+        self.assertEqual(len(got[0]), 2)
+
+
+class TestDryRunCLI(unittest.TestCase):
+    """The CLI wiring, through --dry-run: no weights, no network, no output file."""
+
+    def _write_inputs(self, tmpdir: Path, *, pool: dict[int, int], hops: list[int]) -> tuple[Path, Path]:
+        pool_path = tmpdir / "pool.jsonl"
+        pool_path.write_text(
+            "".join(json.dumps(r) + "\n" for r in _pool(pool)), encoding="utf-8"
+        )
+        query_path = tmpdir / "queries.jsonl"
+        query_path.write_text(
+            "".join(json.dumps(r) + "\n" for r in _queries(hops)), encoding="utf-8"
+        )
+        return pool_path, query_path
+
+    def _run(self, tmpdir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        env["QAV2_PATHS_CONFIG"] = str(REPO_ROOT / "configs" / "smoke_paths.json")
+        return subprocess.run(
+            [sys.executable, str(SIMILARITY_SCRIPT), "--dry-run", "--no-cache",
+             "--mode", "raw", "--run-dir", str(tmpdir / "run"), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(REPO_ROOT),
+        )
+
+    def test_gold_source_dry_run_writes_the_trail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            pool_path, query_path = self._write_inputs(
+                tmpdir, pool={2: 4, 3: 4, 4: 4}, hops=[2, 3, 4, 2]
+            )
+            out = tmpdir / "must_not_exist.jsonl"
+            proc = self._run(
+                tmpdir,
+                "--pool-file", str(pool_path),
+                "--query-file", str(query_path),
+                "--top-k", "3",
+                "--n", "10",
+                "--hop-match",
+                "--out", str(out),
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertFalse(out.exists(), "a dry run must not write the output JSONL")
+            metrics = json.loads((tmpdir / "run" / "similarity_metrics.json").read_text())
+            self.assertTrue(metrics["dry_run"])
+            self.assertTrue(metrics["hop_match"]["enabled"])
+            self.assertEqual(metrics["hop_match"]["hop_source"], "gold")
+            self.assertEqual(metrics["hop_match"]["min_candidates_resolved"], 3)
+            self.assertEqual(metrics["total_queries"], 4)
+            per_file = metrics["hop_match_per_query_file"][0]["hop_match"]
+            self.assertEqual(per_file["query_hop_counts"], {"2": 2, "3": 1, "4": 1})
+            self.assertEqual(per_file["pool_bucket_counts"], {"2": 4, "3": 4, "4": 4})
+            for name in ("similarity_config.json", "similarity_notes.md"):
+                self.assertTrue((tmpdir / "run" / name).exists(), msg=name)
+
+    def test_predictions_source_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            pool_path, query_path = self._write_inputs(
+                tmpdir, pool={2: 4, 3: 4, 4: 4}, hops=[2, 3]
+            )
+            queries = _queries([2, 3])
+            preds = tmpdir / "preds.jsonl"
+            preds.write_text(
+                "".join(
+                    json.dumps({"query_id": q["id"], "predicted_hop": 4}) + "\n" for q in queries
+                ),
+                encoding="utf-8",
+            )
+            proc = self._run(
+                tmpdir,
+                "--pool-file", str(pool_path),
+                "--query-file", str(query_path),
+                "--top-k", "3",
+                "--n", "10",
+                "--hop-match",
+                "--hop-source", "predictions",
+                "--hop-predictions", str(preds),
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            metrics = json.loads((tmpdir / "run" / "similarity_metrics.json").read_text())
+            per_file = metrics["hop_match_per_query_file"][0]["hop_match"]
+            self.assertEqual(per_file["query_hop_counts"], {"4": 2})
+            self.assertEqual(metrics["hop_match"]["hop_source"], "predictions")
+
+    def test_dry_run_refuses_an_infeasible_bucket(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            pool_path, query_path = self._write_inputs(
+                tmpdir, pool={2: 4, 3: 4, 4: 1}, hops=[4]
+            )
+            proc = self._run(
+                tmpdir,
+                "--pool-file", str(pool_path),
+                "--query-file", str(query_path),
+                "--top-k", "3",
+                "--n", "10",
+                "--hop-match",
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("hop 4: 1 pool candidates", proc.stdout + proc.stderr)
+
+    def test_mixed_dry_run_needs_no_hop_information(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            pool_path = tmpdir / "pool.jsonl"
+            pool_path.write_text(
+                json.dumps({"id": "no_hop_prefix", "question": "q"}) + "\n", encoding="utf-8"
+            )
+            query_path = tmpdir / "queries.jsonl"
+            query_path.write_text(
+                json.dumps({"id": "also_no_prefix", "question": "q"}) + "\n", encoding="utf-8"
+            )
+            proc = self._run(
+                tmpdir,
+                "--pool-file", str(pool_path),
+                "--query-file", str(query_path),
+                "--top-k", "1",
+                "--n", "10",
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            metrics = json.loads((tmpdir / "run" / "similarity_metrics.json").read_text())
+            self.assertEqual(metrics["hop_match"], {"enabled": False})
+            self.assertEqual(metrics["hop_match_per_query_file"][0]["queries"], 1)
+
+    def test_the_two_hop_flags_are_mutually_exclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            pool_path, query_path = self._write_inputs(tmpdir, pool={2: 2}, hops=[2])
+            proc = self._run(
+                tmpdir,
+                "--pool-file", str(pool_path),
+                "--query-file", str(query_path),
+                "--hop-match",
+                "--no-hop-match",
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("not allowed with argument", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Retrieval-side machinery for #15's three conditions. The filter binds in `check_question_similarity.py`'s bi-encoder stage before top-k selection, so truncation, CE rerank, and the decomposer's few-shot block inherit it unchanged. Hop source is pluggable: `gold` (parsed from query row id) or a predictions JSONL keyed by query_id (the interface for the future router condition). Off by default — mixed retrieval is byte-identical to current behavior, verified at sha256 level with real e5-small weights (config-default and explicit `--no-hop-match` both reproduce the pre-change output hash) plus an in-suite guard against a verbatim copy of the pre-change top-k function.

Fail-fast on every hop-side defect (unparseable ids, missing predictions, bucket smaller than top_k) with counts, and hop filters for all query files validate before the output handle opens so an infeasible bucket can't leave a truncated JSONL that skip-if-exists would treat as done. New `--dry-run` preflight validates the hop side without loading the encoder. Implementer defaults recorded in ADR 0022.

Evidence: 33 new unit tests OK; full suite 305 OK; smoke 37/37 (new `similarity_hop_match_dryrun` stage); live condition checks — mixed 14/45 neighbours in gold bucket, oracle 45/45, predictions-source 45/45 in the deliberately-disagreeing predicted bucket; fail-fast observed non-zero with per-bucket counts printed.

Known limits, stated not hidden: the router-hop-matched condition needs a conforming predictions file (v1's router output carries no query_id — where predictions come from is a #23/#27 question); hop-matching shrinks the candidate set, so condition gains confound depth-match with pool size (a size-matched control would separate them — not built, not asked for). exp-004/005's frozen launch path untouched.

Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)