### PR TITLE
End-to-end backends: MuSiQue step-failure taxonomy + MetaQA compile-execute wrapper (Refs #16)

### DIFF
--- a/components/answerer/run_answerer.py
+++ b/components/answerer/run_answerer.py
@@ -16,7 +16,13 @@ What it does, per item:
 3. ask the reader model each sub-question over the item's **full paragraph list**;
 4. take the **final** step's answer as the predicted answer for the item;
 5. score it with MuSiQue's official answer EM and answer F1 against the item's gold answer
-   plus its alias list (``src/answer_metrics.py``).
+   plus its alias list (``src/answer_metrics.py``);
+6. flag each sub-question with a **step-level failure taxonomy**
+   (``src/step_failures.py``) — broken reference, generation error, empty answer — so a
+   wrong answer can be located rather than only counted. Two categories issue #16 named
+   (empty retrieval, unresolvable entity) do not exist in this design and a third (wrong
+   intermediate answer) needs gold sub-answers ADR 0019 keeps out of this path; all three
+   are emitted in the metrics JSON as unavailable, with the reason, rather than as zero.
 
 The three methodology choices — reader from the decomposer's registry, full-paragraph
 context, official EM/F1 — are Jahid's, made 2026-08-20 in session and pending supervisor
@@ -107,6 +113,13 @@ from run_config import (  # noqa: E402
     runs_path,
 )
 from seeding import set_global_seed  # noqa: E402
+from step_failures import (  # noqa: E402
+    STEP_FAILURE_DEFINITIONS,
+    STEP_FAILURE_TAXONOMY_NOTE,
+    UNAVAILABLE_STEP_FAILURE_CATEGORIES,
+    classify_step,
+    summarize_step_failures,
+)
 from step_lines import (  # noqa: E402
     post_process_generation,
     split_step_lines,
@@ -120,7 +133,10 @@ _WS_RX = re.compile(r"\s+")
 #: The only context policy that may ship (ADR 0019 decision 2).
 CONTEXT_POLICIES = ("all_paragraphs",)
 
-PER_ITEM_SCHEMA = "musique_answer_per_item/1"
+#: Bumped to /2 when each step record gained ``failure_flags`` (the step-level failure
+#: taxonomy, ``src/step_failures.py``). The change is additive — every /1 field is still
+#: there — but the version says which files carry the flags without having to open them.
+PER_ITEM_SCHEMA = "musique_answer_per_item/2"
 
 
 # ------------------------------------------------------------------ pure helpers
@@ -987,6 +1003,10 @@ def main() -> None:
     answers_truncated = 0
     rows_at_max_new_tokens = 0
     paragraph_counts: list[int] = []
+    #: Failure flags per sub-question (``src/step_failures.py``): every step of every item,
+    #: and separately the step whose answer *is* the item's prediction.
+    step_failure_flags: list[list[str]] = []
+    final_step_failure_flags: list[list[str]] = []
 
     for i, row in enumerate(eval_rows):
         if (i + 1) % progress_every == 0:
@@ -1088,6 +1108,15 @@ def main() -> None:
                     generation_records.append(dict(cost))
 
             answers[k] = answer
+            failure_flags = classify_step(
+                answer=answer,
+                unresolved_references=unresolved,
+                error=error,
+                executed=not args.dry_run,
+            )
+            step_failure_flags.append(failure_flags)
+            if k == len(steps):
+                final_step_failure_flags.append(failure_flags)
             step_records.append(
                 {
                     "step": k,
@@ -1098,6 +1127,7 @@ def main() -> None:
                     "resolved_references": resolved,
                     "unresolved_references": unresolved,
                     "error": error,
+                    "failure_flags": failure_flags,
                     **cost,
                 }
             )
@@ -1203,6 +1233,20 @@ def main() -> None:
                 1 for n in paragraph_counts if n < expected_paragraphs
             ),
         },
+        "step_failure_taxonomy": {
+            "note": STEP_FAILURE_TAXONOMY_NOTE,
+            "definitions": STEP_FAILURE_DEFINITIONS,
+            "not_available": UNAVAILABLE_STEP_FAILURE_CATEGORIES,
+            "all_steps": summarize_step_failures(step_failure_flags),
+            # The final step's answer is the item's prediction (see the loop), so a flag here
+            # is decisive for EM/F1 in a way an earlier step's is not - it is reported apart
+            # rather than averaged into the whole.
+            "final_step_only": summarize_step_failures(final_step_failure_flags),
+            "items_with_any_step_flag": sum(
+                1 for it in per_item if any(s["failure_flags"] for s in it["steps"])
+            ),
+            "items_with_no_steps_so_no_flags": items_with_no_steps,
+        },
         "evaluation_set": eval_set_record,
         "cost": cost_summary(generation_records),
         "metric_definitions": ANSWER_METRIC_DEFINITIONS,
@@ -1295,6 +1339,15 @@ def main() -> None:
             f"failed generations: "
             f"{failed_generations}; references resolved/unresolved: "
             f"{resolved_refs}/{unresolved_refs}",
+            "- Step failures: "
+            + json.dumps(metrics["step_failure_taxonomy"]["all_steps"]["by_category"])
+            + f" over {metrics['step_failure_taxonomy']['all_steps']['steps']} step(s) "
+            f"({metrics['step_failure_taxonomy']['all_steps']['steps_clean']} clean); "
+            "final-step flags: "
+            + json.dumps(metrics["step_failure_taxonomy"]["final_step_only"]["by_category"])
+            + "; not available here: "
+            + ", ".join(sorted(UNAVAILABLE_STEP_FAILURE_CATEGORIES))
+            + " (see the metrics JSON for why each is absent rather than zero)",
             (
                 f"- Parameters: {size_record['parameter_count']:,} "
                 f"(ceiling {size_record['parameter_ceiling']:,})"

--- a/configs/answer_musique.json
+++ b/configs/answer_musique.json
@@ -40,6 +40,8 @@
   },
   "_substitution_note": "Each [#k] in a sub-question is replaced by the answer the reader produced for step k (src/step_lines.py::substitute_step_references). accept_bare_references also recognises MuSiQue's bare '#k', which is both the gold convention read by --gold-decompositions and, per ADR 0012 (target_reference_style 'as_is'), the style the fine-tuned arm emits; without it the oracle ceiling could not be executed at all. A reference with no answer yet (a forward reference, an out-of-range k, a failed or empty generation) is left in the text verbatim and counted, never dropped. dry_run_answer_template stands in for a generated answer under --dry-run so the substitution chain is exercised with no model loaded.",
 
+  "_step_failure_taxonomy_note": "The step-level failure taxonomy (issue #16) has no knobs here on purpose: its category names and the rule that decides each one are code (src/step_failures.py), the same way the MetaQA compile-error taxonomy is code in scripts/evaluate_decompositions.py. Every flag is derived from fields this run already writes to <out_prefix>_per_item.json (unresolved_references, error, answer), so the counts in metrics.step_failure_taxonomy are re-derivable by hand from that file. Three categories named in issue #16 are reported as UNAVAILABLE rather than zero - empty_retrieval and unresolvable_entity do not exist in this design (there is no retriever and no knowledge base; ADR 0019 decision 2), and wrong_intermediate_answer would need the gold sub-answers that ADR 0019 keeps out of this path. Adding any of them is Jahid's call with his supervisor, not a config edit.",
+
   "answer_post_process": {
     "take_first_line": true,
     "strip_prefixes": ["Answer:", "answer:", "A:"],

--- a/configs/metaqa_compile_execute.json
+++ b/configs/metaqa_compile_execute.json
@@ -1,0 +1,18 @@
+{
+  "_note": "Config for scripts/run_metaqa_compile_execute.py: the MetaQA end-to-end backend of issue #16, in ONE command. It composes two existing scripts rather than reimplementing either - scripts/evaluate_decompositions.py compiles a predicted decomposition into KG ops and executes them (its step templates, relation rules, compile-error taxonomy and execution-error categories are code and stay code), and scripts/compare_answer_accuracy.py compares the executed answer set against MetaQA's gold answers with Jaccard. Because it composes them, it owns no methodology knob of its own: every knob is read from the two configs named below, so a value has exactly one home and cannot drift between the wrapper and the script it wraps.",
+
+  "_grag_note": "THIS IS NOT GRAG. ADR 0006 gives MetaQA end-to-end evaluation through the supervisor's GRAG system; GRAG is external, and no interface, endpoint, repository or handover for it exists in this repo or in the v1 repo (searched 2026-08-22). This path is direct execution against the MetaQA KG built from kb.txt (scripts/kg.py) and is labelled as such in every artifact it writes (backend_label below, and backend.grag_wired false in the metrics JSON). It is a separate, self-standing path, not a stand-in for GRAG: a GRAG number and a compile-execute number are not the same measurement and must not be compared as if they were. Wiring GRAG stays blocked on Jahid obtaining it from his supervisor.",
+
+  "seed": 42,
+  "_seed_note": "The one seed this run threads through everything. The composed configs also carry a 'seed' key for when their scripts are run standalone; this wrapper calls their functions directly, so those keys are NOT used here - the snapshot records all three so a reader can see which seed governed.",
+
+  "kg_eval_config": "metaqa_kg_eval.json",
+  "answer_accuracy_config": "answer_accuracy.json",
+  "_composed_config_note": "kg_eval_config supplies kb_key and max_items (the compile+execute half). answer_accuracy_config supplies hops, the gold question/answer path templates, answer_separator, exact_match_jaccard and analysis_subdir (the gold-comparison half). One exception is deliberate: metaqa_kg_eval.json's write_error_analysis is NOT read here, because the gold comparison reads the success dump - the wrapper always writes the three per-item dumps, and they land under the gitignored runs root, never in git.",
+
+  "backend_label": "metaqa_compile_execute_direct_kg",
+  "run_subdir": "metaqa_compile_execute",
+  "out_prefix": "metaqa_e2e_",
+
+  "paths_config": "paths.json"
+}

--- a/configs/metaqa_compile_execute.json
+++ b/configs/metaqa_compile_execute.json
@@ -10,6 +10,11 @@
   "answer_accuracy_config": "answer_accuracy.json",
   "_composed_config_note": "kg_eval_config supplies kb_key and max_items (the compile+execute half). answer_accuracy_config supplies hops, the gold question/answer path templates, answer_separator, exact_match_jaccard and analysis_subdir (the gold-comparison half). One exception is deliberate: metaqa_kg_eval.json's write_error_analysis is NOT read here, because the gold comparison reads the success dump - the wrapper always writes the three per-item dumps, and they land under the gitignored runs root, never in git.",
 
+  "eval_set": {
+    "require_gold_for_every_item": true
+  },
+  "_eval_set_note": "A processed question with no MetaQA gold answer for its hop depth cannot be scored, so it disappears from every exact-match and Jaccard denominator - the run would then report accuracy over a silently smaller set than it read, and a comparison against another arm would not be a comparison (CLAUDE.md evidence discipline, ADR 0011). With this true the run is REFUSED in that case; --allow-unpinned-eval-set is the recorded per-run opt-out for fixture and probe runs, which are not experiment arms. This mirrors the MuSiQue answering backend's assertion, weaker by necessity: MetaQA has no ADR-pinned id subset the way ADR 0007 pins MuSiQue's 600, so identity is carried by evaluation_set.question_set_sha256 (a fingerprint over the sorted hop+question lines) rather than by an id list. Two MetaQA runs are the same evaluation set iff that fingerprint matches.",
+
   "backend_label": "metaqa_compile_execute_direct_kg",
   "run_subdir": "metaqa_compile_execute",
   "out_prefix": "metaqa_e2e_",

--- a/docs/adr/0019-musique-answering-backend-conventions.md
+++ b/docs/adr/0019-musique-answering-backend-conventions.md
@@ -3,6 +3,15 @@
 - **Status**: Accepted (Jahid, 2026-08-20, in session; pending supervisor confirmation)
 - **Date**: 2026-08-20
 
+> **2026-08-22 (issue #16, PR #42).** None of the three decisions below changed. The
+> *implementation conventions* that came with completing issue #16 — the step-level failure
+> taxonomy added to this backend, the "a category that cannot be produced is reported as
+> unavailable with a reason, never as zero" rule, and the conventions of the sibling MetaQA
+> compile-execute path — are recorded in ADR
+> [0025](./0025-end-to-end-backend-conventions-the-implementers-design.md). One item there is
+> queued for Jahid *against* this record: implementing `wrong_intermediate_answer` would mean
+> reading the gold sub-answers this ADR deliberately keeps out of the path, which amends it.
+
 ## Context
 
 ADR [0006](./0006-drop-the-jury-fix-dataset-roles-and-the-few-shot-method.md) gives MuSiQue

--- a/docs/adr/0025-end-to-end-backend-conventions-the-implementers-design.md
+++ b/docs/adr/0025-end-to-end-backend-conventions-the-implementers-design.md
@@ -1,0 +1,182 @@
+# 0025. End-to-End Backend Conventions: The Implementer's Design
+
+- **Status**: Accepted (design agent-authored, pending Jahid)
+- **Date**: 2026-08-22
+
+## Context
+
+Issue #16 asked for two end-to-end backends — a MuSiQue answering backend and a MetaQA
+compile-execute wrapper — so that a decomposition is judged by the answer it leads to and
+not only by how it looks. The MuSiQue reader, its context regime and its answer metric are
+Jahid's decisions and are recorded in ADR
+[0019](./0019-musique-answering-backend-conventions.md); the MetaQA dataset role is his
+supervisor's and is recorded in ADR
+[0006](./0006-drop-the-jury-fix-dataset-roles-and-the-few-shot-method.md) §2.
+
+Building the rest of issue #16 (PR #42) forced three conventions that **no ADR settles and
+that an agent must not present as research decisions**. Gate-1 review asked for them to be
+captured before merge, because each one changes how a number in the thesis reads. They are
+recorded here, in the style of ADR
+[0022](./0022-hop-matched-retrieval-the-implementers-design.md): this is the implementer's
+design, it is changeable without touching any of Jahid's decisions, and where a choice is
+genuinely his it says so and stops.
+
+Nothing here is a measured result. No experiment was run for it; the numbers quoted are from
+the fabricated fixtures under `tests/fixtures/` and say only that the code paths run.
+
+## Decision
+
+### 1. MetaQA end-to-end reports two denominators, and picks neither
+
+`scripts/run_metaqa_compile_execute.py` reports exact match and mean Jaccard twice:
+
+- **over executed items with gold** — of the decompositions that compiled *and* executed,
+  how good is the answer set. This is what `scripts/compare_answer_accuracy.py` has always
+  reported. It is a **conditional** number: every compile and execution failure is outside
+  its denominator.
+- **over all items with gold** — every prediction whose question has a gold answer, with a
+  compile or execution failure **counted as the empty answer set it produced**.
+
+The second exists because the first is not comparable with a MuSiQue number. The MuSiQue
+answering backend puts a failed item *inside* its reported EM/F1 (ADR 0019; the metrics JSON
+says so in `failed_generation_note`), so a MetaQA number that excludes failures and a MuSiQue
+number that includes them are not measuring the same thing — and issue #41's cross-dataset
+comparison needs them to be. Coverage is reported alongside both, so the gap between them is
+always visible.
+
+Three rules make the second denominator honest rather than clever:
+
+- **A failure's contribution is computed, not assumed.** It is `jaccard(∅, gold)` through the
+  same scorer, and it is an exact match iff that reaches the same `exact_match_jaccard`
+  threshold the executed items are scored against. For MetaQA's non-empty gold that is 0 on
+  both metrics; the code does not hard-code the 0.
+- **One rule for every item, including the surprising one.** `jaccard(∅, ∅)` is 1.0, so an
+  unexecuted item whose gold answer set is empty *is* an exact match by the definition
+  printed next to the number. An earlier version guarded the mean for that case and left the
+  exact-match count unguarded, which made the reported percentage contradict its own
+  definition text (Gate-1 finding 2). The fix was to apply one rule uniformly and **name**
+  the edge case in `empty_gold_set_note` when it fires, not to null it away. MetaQA gold
+  answers are non-empty, so a non-zero count there points at a malformed gold line.
+- **A measured zero is reported as zero.** A run where every decomposition fails reports
+  0.0% and 0.0. Null is reserved for the one genuinely unmeasured case: no item in the run
+  has a gold answer at all. Reporting null for total failure would hide a measured floor as
+  a missing measurement (Gate-1 finding 1).
+
+**Which of the two is *the* headline MetaQA metric is Jahid's call, not this record's.** The
+script reports both with their definitions attached and refuses to choose.
+
+**Element matching stays strip-only and case-sensitive** — the rule
+`compare_answer_accuracy.py` has always used — and is therefore *not* MuSiQue EM's SQuAD
+`normalize_answer` (ADR 0019 decision 3). The asymmetry is **recorded, not removed**:
+`metric_definitions.answer_normalization` states it and the over-all-items definition repeats
+it, because the two numbers are comparable in denominator but not in string strictness.
+Aligning them would move every MetaQA number ever reported and is a scoring-rule decision for
+Jahid with his supervisor.
+
+### 2. A failure category that cannot be produced is reported as unavailable, with a reason — never as zero
+
+Issue #16 named four step-level failure categories for the MuSiQue backend. Two of them
+(`empty_retrieval`, `unresolvable_entity`) cannot exist in a design that has no retriever and
+no knowledge base — ADR 0019 decision 2 fixes the context to the item's full paragraph list
+and the code refuses any other policy. A third (`wrong_intermediate_answer`) would need the
+gold sub-answers ADR 0019 deliberately keeps out of that path.
+
+The convention: such a category is **emitted in the metrics JSON under `not_available` with
+the reason for each**, and never as a zero count. A missing key reads as "the code forgot
+this"; a zero reads as "this never happened"; and both are false when the truth is "this
+cannot be measured here". This is CLAUDE.md's reproducibility rule — *if it is not measured,
+say it is unmeasured* — applied to a taxonomy rather than to a metric.
+
+The firing categories are counters, **not a partition**: a step can be asked with an
+unresolved reference still in it *and* come back empty, and both facts matter to an error
+analysis. Picking one "cause" per step would need a precedence rule nobody has agreed, so
+`steps_clean` carries the "nothing wrong here" count instead. `src/step_failures.py` is the
+one home for the category names and the classification rule; they are code, the same way the
+MetaQA compile-error taxonomy is code.
+
+**What this does not claim:** a step with no flags is not a step with a *correct* answer. Only
+the final step's correctness is measured, and it is measured by the item's `answer_em` /
+`answer_f1`. Extending `wrong_intermediate_answer` into a real per-step judgement means
+reading MuSiQue's gold sub-answers, which amends ADR 0019 — Jahid's call.
+
+### 3. A path that is not GRAG says so in every artifact it writes
+
+ADR 0006 §2 routes MetaQA end-to-end evaluation through the supervisor's **GRAG** system.
+GRAG is external. Searched on 2026-08-22 in this repo and in the v1 repo
+(`/cta/users/fyilmaz/Thesis---QA`): there is **no interface, endpoint, client, repository or
+handover** for it anywhere — only prose in ADRs 0006/0017/0023 and the 2026-08-12 meeting
+cross-check, which records "no handover date, repo, or access mechanism was discussed".
+
+The convention for this and any future substitute path: it is **neither stubbed as GRAG nor
+presented as GRAG**. The compile-execute path carries a `backend_label`
+(`metaqa_compile_execute_direct_kg`), a hard-coded `backend.grag_wired: false`, and a
+`grag_status` sentence naming what is missing — in the metrics JSON, the config snapshot and
+the run note alike. `grag_wired` is a **constant of the code, not a config knob**, so no flag
+can flip the label without a source change and a review. A test asserts the labelling,
+because the failure mode is silent: a number that looked like a GRAG number would be a claim
+nobody made.
+
+The seven things Jahid must obtain before GRAG can be wired are listed in PR #42 and are not
+duplicated here.
+
+### 4. Evidence conventions carried across from the MuSiQue side
+
+- **Evaluation-set identity is asserted, not trusted.** A processed MetaQA question with no
+  gold answer cannot be scored and would silently shrink every denominator, so the run is
+  refused unless `--allow-unpinned-eval-set` is passed — the same shape as the MuSiQue
+  backend's flag, for the same reason (ADR 0011: a number on a different set is not a
+  comparison). MetaQA has no ADR-pinned id subset the way ADR 0007 pins MuSiQue's 600, so
+  identity is carried by `evaluation_set.question_set_sha256`, a fingerprint over the sorted
+  `hop<TAB>question` lines. **Equal fingerprints mean the same questions were scored**; that
+  is the artifact-level check a comparison claim cites. It is a hash, so no dataset text
+  leaves the run.
+- **A number is traceable to the run that produced its decompositions.** The predictions
+  file is content-addressed, and the decomposer run's sibling `config.json` supplies run id,
+  commit, branch, dirty flag and config paths. Absence is recorded as `found: false` with a
+  reason, never inferred.
+- **A wrapper composes configs rather than copying their values.** `metaqa_compile_execute.json`
+  owns no methodology knob: every knob is read from `metaqa_kg_eval.json` and
+  `answer_accuracy.json`, so a value has exactly one home and cannot drift between the
+  wrapper and the script it wraps. The composed configs' `seed` keys are recorded as unused,
+  because the wrapper calls their functions directly under one seed.
+- **An invariant only a real run could break gets a source-level guard** (ADR
+  [0016](./0016-real-run-only-invariants-get-source-level-guards.md)).
+  `backend.model_loaded: false` is such an invariant: no CPU test can notice a model load
+  being added later, and the ~8B ceiling assertion would then be missing too. An AST guard
+  with negative controls asserts the MetaQA path has no model-loading site.
+
+## Consequences
+
+- A MetaQA end-to-end number can be read against a MuSiQue one **in denominator**, which is
+  what issue #41 needs, while the string-strictness difference stays on the record so the
+  write-up does not overclaim the comparison.
+- Every MetaQA artifact states which evaluation set it scored and which decomposer run it
+  came from, so "same evaluation set" is checkable from files rather than from memory.
+- The GRAG dependency stays visibly open. If Jahid obtains GRAG, it becomes a **second**
+  labelled MetaQA path; its numbers do not retroactively reinterpret the compile-execute
+  ones, because the two measure different systems.
+- Three decisions are queued for Jahid and are *not* taken here: the headline MetaQA
+  denominator, whether MetaQA element matching adopts SQuAD normalization, and whether
+  `wrong_intermediate_answer` is implemented from gold sub-answers.
+- If Jahid or his supervisor prefers different conventions, this record is superseded and the
+  runs made under it are re-run rather than reinterpreted — the same clause ADR 0019 carries.
+
+## Alternatives considered
+
+- **One MetaQA denominator only.** Executed-only is what existed and is the smaller change,
+  but it silently rewards a method that fails to compile (a failure leaves the denominator),
+  and it is not comparable with MuSiQue. All-items-only was the other option; it discards the
+  conditional number that says how good an answer set is *when* a plan runs, which is the
+  useful diagnostic. Reporting both, labelled, was chosen over picking for Jahid.
+- **Guarding the empty-gold case with a null.** Shipped first, caught in review: it made the
+  reported percentage contradict its own printed definition. Rejected in favour of one
+  uniform rule plus a note.
+- **Switching MetaQA to SQuAD `normalize_answer`** so both datasets score strings alike.
+  Defensible and possibly right, but it changes every MetaQA number and is a scoring rule, so
+  it is surfaced rather than taken.
+- **Omitting the unavailable failure categories** instead of emitting them with reasons.
+  Cheaper, and it is exactly how a gap becomes invisible: a later reader cannot distinguish
+  "not applicable" from "forgotten".
+- **Stubbing GRAG** behind an interface so the MetaQA path "works". Rejected outright: a stub
+  that produced numbers under GRAG's name would be a fabricated result, and ADR 0023 already
+  records that the dependency stays flagged, not stubbed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ When **not** to write one:
 | [0022](./0022-hop-matched-retrieval-the-implementers-design.md) | Hop-Matched Retrieval: The Implementer's Design | Accepted (design agent-authored, pending Jahid) |
 | [0023](./0023-jahid-2026-08-22-direction-metric-pipeline-completion-generalisation.md) | Jahid's 2026-08-22 Direction: Composite Replacement, Pipeline Completion Order, Generalisation Framing | Accepted (Jahid, 2026-08-22, in session; marked items pending supervisor confirmation) |
 | [0024](./0024-router-readiness-query-id-keyed-predictions-and-the-router-guided-arm.md) | Router Readiness: Query-Id-Keyed Predictions, a Retrieved-Few-Shot Router, and the Router-Guided Decomposer Arm | Accepted (design agent-authored, pending Jahid) |
+| [0025](./0025-end-to-end-backend-conventions-the-implementers-design.md) | End-to-End Backend Conventions: The Implementer's Design | Accepted (design agent-authored, pending Jahid) |
 
 ---
 

--- a/scripts/compare_answer_accuracy.py
+++ b/scripts/compare_answer_accuracy.py
@@ -157,6 +157,11 @@ def run_analysis(
         "total_exact_match": total_exact,
         "overall_pct_exact": round(100.0 * total_exact / total_with_gold, 2) if total_with_gold else None,
         "overall_mean_jaccard": round(total_jaccard_sum / total_with_gold, 4) if total_with_gold else None,
+        # The UNROUNDED sum, so a caller that needs a different denominator (the MetaQA
+        # end-to-end wrapper counts compile/execute failures too) can recompute exactly
+        # instead of multiplying the 4-dp mean back out (PR #42 review, nit 1). The rounded
+        # mean above is unchanged: it is what this script has always reported.
+        "overall_jaccard_sum": total_jaccard_sum,
         "per_hop": {},
     }
 

--- a/scripts/run_metaqa_compile_execute.py
+++ b/scripts/run_metaqa_compile_execute.py
@@ -44,14 +44,41 @@ questions and the difference is large:
   cross-dataset comparison of issue #41. Which of the two is *the* headline MetaQA metric is
   not this script's call; both are reported with their definitions attached.
 
+A **measured zero is reported as zero**: a run where every decomposition fails reports 0.0%
+and 0.0, not null. Null is reserved for the one genuinely unmeasured case — no item in the
+run has a gold answer at all. Both metrics apply **one rule to every item**, including the
+empty-gold edge case (``jaccard(empty, empty)`` is 1.0 and therefore an exact match), so the
+definition printed next to the numbers is true of all of them; when that edge case fires it
+is named in ``empty_gold_set_note`` rather than nulled away.
+
+Element matching is **strip-only and case-sensitive** (what
+``scripts/compare_answer_accuracy.py`` has always done), which is *not* MuSiQue EM's SQuAD
+normalization. The asymmetry is recorded in ``metric_definitions.answer_normalization`` and in
+the over-all-items definition rather than removed: changing it would move every MetaQA number
+ever reported and is a scoring-rule decision for Jahid.
+
+Which evaluation set was scored is recorded and asserted, mirroring the MuSiQue backend: a
+processed question with no gold answer cannot be scored and would silently shrink every
+denominator, so the run is **refused** unless ``--allow-unpinned-eval-set`` is given (fixture
+and probe runs, which are not experiment arms). MetaQA has no ADR-pinned id subset the way
+ADR 0007 pins MuSiQue's 600, so identity is carried by
+``evaluation_set.question_set_sha256`` — equal fingerprints mean the same questions were
+scored, which is what makes two MetaQA numbers a comparison. The decomposer run that produced
+the predictions is traced through its sibling ``config.json`` (run id, commit, config), or
+recorded as unrecorded.
+
 Usage::
 
     python scripts/run_metaqa_compile_execute.py --predictions <decomposer run>/results.json
     python scripts/run_metaqa_compile_execute.py --predictions <...> --run-dir runs/probe
+
+    # a fixture or probe run, whose questions need not all be in the MetaQA gold files
+    python scripts/run_metaqa_compile_execute.py --predictions <...> --allow-unpinned-eval-set
 """
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -60,6 +87,11 @@ from typing import Any
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+#: ``sha256_file`` is imported from the decomposer runner rather than copied, for the reason
+#: ADR 0019 records about ``assert_pinned_eval_set``: a second copy of "how an input is
+#: content-addressed" would be a second thing to keep in step. That module imports nothing
+#: heavy at module level (measured: ~60ms, no torch), so a CPU-only script can take it.
+sys.path.insert(0, str(_REPO_ROOT / "components" / "decomposer"))
 
 # The two halves, imported rather than reimplemented: one home for the compiler, one home
 # for the Jaccard scorer.
@@ -68,6 +100,7 @@ from evaluate_decompositions import evaluate_decomposition_rate  # noqa: E402
 from kg import build_metaqa_kg  # noqa: E402
 from run_artifacts import now_iso, write_run_artifacts  # noqa: E402
 from run_config import load_config, load_paths, require, resolve_path, runs_path  # noqa: E402
+from run_decomposer import sha256_file  # noqa: E402
 from seeding import set_global_seed  # noqa: E402
 
 #: Recorded in every artifact. GRAG is external and absent (see the module docstring), so
@@ -99,31 +132,199 @@ def gold_for_item(item: dict, gold_by_hop: dict[int, dict[str, set[str]]]) -> se
     return gold_by_hop.get(hop_count, {}).get(question)
 
 
-def over_all_items_with_gold(
+#: The dumps that hold the rows which produced **no** answer set.
+FAILURE_DUMP_FILES = ("compile_fail.json", "exec_fail.json")
+
+
+def processed_rows(analysis_dir: Path) -> list[dict]:
+    """Every row this run processed, read back from its own three dumps.
+
+    ``success.json + compile_fail.json + exec_fail.json`` is exactly the set of rows the
+    compile-execute half read (after the row cap), so taking the evaluation set from them
+    means the cap and the row-selection rule live in one place — the script being wrapped.
+    A missing dump is a refusal for the same reason as in :func:`score_failed_items`.
+    """
+    rows: list[dict] = []
+    for name in DUMP_FILES:
+        path = analysis_dir / name
+        if not path.exists():
+            raise SystemExit(
+                f"expected the dump {path} to exist: it is written unconditionally by the "
+                "compile-execute half, and the evaluation-set record is derived from all "
+                "three dumps. Refusing rather than describing the run's evaluation set from "
+                "an unknown subset of it."
+            )
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        rows.extend(item for item in payload if isinstance(item, dict))
+    return rows
+
+
+def evaluation_set_record(
+    rows: list[dict],
+    *,
+    predictions_path: Path,
+    gold_by_hop: dict[int, dict[str, set[str]]],
+    total_per_hop: dict[int, int],
+    hops: list[int],
+) -> dict[str, Any]:
+    """What evaluation set this run scored, as an identity a later run can be checked against.
+
+    The MuSiQue side asserts the pinned ADR 0007 id set by identity, not only by count
+    (``run_decomposer.assert_pinned_eval_set``), because "an end-to-end number on a different
+    set is not comparable to anything" (ADR 0011). MetaQA has no ADR-pinned subset, so there
+    is no id list to check against — but the same discipline applies, and CLAUDE.md's
+    evidence rule (a comparison claim requires the *same* evaluation set) has to be
+    verifiable from the artifact rather than trusted. So this records:
+
+    - the per-hop row counts and how many of them matched a gold question;
+    - ``question_set_sha256``, a fingerprint over the sorted ``hop<TAB>question`` lines of the
+      rows processed. Two runs with the same fingerprint scored the same questions; two runs
+      with different fingerprints are not a comparison, whatever their row counts say. It is
+      a hash, so no dataset text leaves the run in the metrics JSON.
+    - ``unmatched_questions``: rows with no gold answer. They are silently absent from every
+      accuracy denominator, which is precisely the failure mode worth refusing over.
+
+    ``pinned`` is True when every processed row has a gold answer and there is at least one
+    row: the run scored a well-defined subset of the MetaQA gold set. It is deliberately a
+    weaker claim than the MuSiQue one, and it says so in ``pinned_definition``.
+    """
+    per_hop_rows: dict[str, int] = {}
+    per_hop_matched: dict[str, int] = {}
+    unmatched: list[str] = []
+    fingerprint_lines: list[str] = []
+    rows_without_hop = 0
+
+    for item in rows:
+        question = str(item.get("question") or "").strip()
+        hop = item.get("hop_count")
+        if not isinstance(hop, int):
+            rows_without_hop += 1
+            key = "unknown"
+        else:
+            key = str(hop)
+        per_hop_rows[key] = per_hop_rows.get(key, 0) + 1
+        fingerprint_lines.append(f"{key}\t{question}")
+        gold = gold_for_item(item, gold_by_hop)
+        if gold is None:
+            unmatched.append(f"{key}: {question}" if question else f"{key}: <no question>")
+        else:
+            per_hop_matched[key] = per_hop_matched.get(key, 0) + 1
+
+    digest = hashlib.sha256(
+        "\n".join(sorted(fingerprint_lines)).encode("utf-8")
+    ).hexdigest()
+
+    return {
+        "rows_processed": len(rows),
+        "rows_per_hop": dict(sorted(per_hop_rows.items())),
+        "rows_with_gold_per_hop": dict(sorted(per_hop_matched.items())),
+        "rows_without_a_hop_count": rows_without_hop,
+        "gold_questions_available_per_hop": {str(h): total_per_hop.get(h, 0) for h in hops},
+        "unmatched_question_count": len(unmatched),
+        "unmatched_questions_sample": unmatched[:10],
+        "question_set_sha256": digest,
+        "predictions_path": str(predictions_path),
+        "predictions_sha256": sha256_file(predictions_path),
+        "pinned": bool(rows) and not unmatched,
+        "pinned_definition": (
+            "true when every processed row's question was found in the MetaQA gold files for "
+            "its hop depth, so the run scored a well-defined subset of the gold set. This is "
+            "weaker than the MuSiQue side's assertion (ADR 0007's pinned 600 ids, checked by "
+            "identity): MetaQA has no ADR-pinned subset, so there is no id list to check "
+            "against. question_set_sha256 is what makes two MetaQA runs comparable - equal "
+            "fingerprints mean the same questions were scored."
+        ),
+    }
+
+
+def upstream_decomposer_run(predictions_path: Path) -> dict[str, Any]:
+    """The provenance of the predictions: which run, which commit, which config.
+
+    A decomposer run writes ``config.json`` / ``metrics.json`` next to its ``results.json``
+    (``src/run_artifacts.py``), and ``write_run_artifacts`` stamps git provenance into both.
+    Reading it here is what lets a MetaQA number be traced to the decomposition run and the
+    commit that produced it, instead of to a bare file path (PR #42 review, finding 3).
+
+    Absence is recorded, never inferred: a hand-made or relocated predictions file has no
+    sibling snapshot, and that is reported as ``found: false`` rather than guessed at.
+    """
+    snapshot_path = predictions_path.parent / "config.json"
+    if not snapshot_path.exists():
+        return {
+            "found": False,
+            "note": (
+                f"no decomposer run snapshot at {snapshot_path}: the predictions file has no "
+                "sibling config.json, so the run and commit that produced these "
+                "decompositions are not recorded here. Expected for a hand-made or moved "
+                "predictions file; for a real arm it means the run directory was not kept "
+                "intact, and the provenance has to come from the experiment log entry."
+            ),
+        }
+    try:
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"found": False, "note": f"could not read {snapshot_path}: {exc}"}
+    if not isinstance(snapshot, dict):
+        return {"found": False, "note": f"{snapshot_path} is not a JSON object"}
+
+    git = snapshot.get("git") if isinstance(snapshot.get("git"), dict) else {}
+    return {
+        "found": True,
+        "snapshot_path": str(snapshot_path),
+        "script": snapshot.get("script"),
+        "run_id": snapshot.get("run_id"),
+        "component": snapshot.get("component"),
+        "model": snapshot.get("model"),
+        "model_id": snapshot.get("model_id"),
+        "condition": snapshot.get("condition"),
+        "shared_config": snapshot.get("shared_config"),
+        "model_config": snapshot.get("model_config"),
+        "seed": snapshot.get("seed"),
+        "commit": git.get("commit"),
+        "branch": git.get("branch"),
+        "dirty": git.get("dirty"),
+    }
+
+
+def score_failed_items(
     analysis_dir: Path,
     *,
     gold_by_hop: dict[int, dict[str, set[str]]],
-    executed_exact_matches: int,
+    exact_threshold: float,
 ) -> dict[str, Any]:
-    """Exact match and mean Jaccard with compile/execute failures counted, not excluded.
+    """Score the compile/execute failures as the empty answer set they produced.
 
     A failed item produced no answer set, so its contribution is ``jaccard(set(), gold)``
-    — computed with the imported scorer rather than hard-coded, so an item with an empty gold
-    set (which would score 1.0 by the empty-vs-empty rule) cannot be silently written off as
-    a 0. Such rows are counted separately and, if any exist, the mean is reported as null
-    with a note rather than as a number whose meaning is unclear.
+    and its exact match is ``that jaccard >= exact_threshold`` — **both** computed with the
+    imported scorer and the same threshold the executed items are scored with, so the block's
+    stated definition holds for every item in it. The alternative (special-casing the
+    empty-gold row) was tried and rejected in review: guarding the mean while leaving the
+    exact-match count unguarded made ``exact_match / items_with_gold`` disagree with the
+    definition printed next to it (PR #42 review, finding 2). Applying one rule uniformly is
+    what keeps the definition text true; ``failed_items_with_an_empty_gold_set`` is reported
+    so a reader can see when the empty-vs-empty rule (Jaccard 1.0, therefore an exact match)
+    contributed, and the caller attaches a note whenever it did.
 
-    The failed rows are read from the run's own ``compile_fail.json`` / ``exec_fail.json``
-    dumps, so "which rows this run processed" is taken from the run's output and never
-    re-derived from the predictions file (the row cap would then live in two places).
+    The failed rows are read from the run's own dumps, so "which rows this run processed" is
+    taken from the run's output and never re-derived from the predictions file (the row cap
+    would then live in two places). A missing dump is a **refusal**, not a skip: the dumps
+    are written unconditionally by the compile-execute half, so an absent one means the
+    second denominator would silently omit rows it is supposed to count (PR #42 review,
+    nit 2).
     """
     failed_with_gold = 0
     failed_jaccard_sum = 0.0
     failed_with_empty_gold = 0
-    for name in ("compile_fail.json", "exec_fail.json"):
+    failed_exact_matches = 0
+    for name in FAILURE_DUMP_FILES:
         path = analysis_dir / name
         if not path.exists():
-            continue
+            raise SystemExit(
+                f"expected the failure dump {path} to exist: the compile-execute half writes "
+                f"{', '.join(FAILURE_DUMP_FILES)} unconditionally, so a missing one means "
+                "the over-all-items denominator would omit the rows it is meant to count. "
+                "Refusing rather than reporting a number over an unknown subset."
+            )
         for item in json.loads(path.read_text(encoding="utf-8")):
             gold = gold_for_item(item, gold_by_hop)
             if gold is None:
@@ -131,12 +332,15 @@ def over_all_items_with_gold(
             failed_with_gold += 1
             if not gold:
                 failed_with_empty_gold += 1
-            failed_jaccard_sum += jaccard(set(), gold)
+            score = jaccard(set(), gold)
+            failed_jaccard_sum += score
+            if score >= exact_threshold:
+                failed_exact_matches += 1
     return {
         "failed_items_with_gold": failed_with_gold,
         "failed_items_with_an_empty_gold_set": failed_with_empty_gold,
-        "failed_items_jaccard_sum": round(failed_jaccard_sum, 4),
-        "exact_match_count": executed_exact_matches,
+        "failed_items_jaccard_sum": failed_jaccard_sum,
+        "failed_items_exact_match_count": failed_exact_matches,
     }
 
 
@@ -157,6 +361,14 @@ def _parse_args() -> argparse.Namespace:
         help="Where the artifacts and the per-item dumps go (default: under the runs root).",
     )
     p.add_argument("--seed", type=int, default=None)
+    p.add_argument(
+        "--allow-unpinned-eval-set",
+        action="store_true",
+        help="Permit a run in which some processed questions have no MetaQA gold answer. "
+        "For fixture and probe runs only: such rows are absent from every accuracy "
+        "denominator, the metrics then record evaluation_set.pinned false, and the run is "
+        "not an experiment arm. Mirrors the same flag on the MuSiQue answering backend.",
+    )
     return p.parse_args()
 
 
@@ -237,48 +449,99 @@ def main() -> None:
         seed=seed,
     )
 
-    # ---- the second denominator: failures counted rather than excluded
-    failures = over_all_items_with_gold(
-        analysis_dir,
+    # ---- what evaluation set was actually scored, and where the predictions came from
+    eval_set_record = evaluation_set_record(
+        processed_rows(analysis_dir),
+        predictions_path=args.predictions,
         gold_by_hop=gold_by_hop,
-        executed_exact_matches=int(summary["total_exact_match"]),
+        total_per_hop=total_per_hop,
+        hops=hops,
     )
-    items_with_gold = int(summary["total_with_gold"]) + failures["failed_items_with_gold"]
-    executed_mean_jaccard = summary["overall_mean_jaccard"]
-    if items_with_gold and executed_mean_jaccard is not None:
-        overall_exact_rate = round(100.0 * summary["total_exact_match"] / items_with_gold, 2)
-        jaccard_sum = executed_mean_jaccard * summary["total_with_gold"]
-        overall_mean_jaccard = round(
-            (jaccard_sum + failures["failed_items_jaccard_sum"]) / items_with_gold, 4
+    eval_set_record["allow_unpinned_override"] = args.allow_unpinned_eval_set
+    upstream = upstream_decomposer_run(args.predictions)
+    if (
+        require(cfg, "eval_set.require_gold_for_every_item")
+        and eval_set_record["unmatched_question_count"]
+        and not args.allow_unpinned_eval_set
+    ):
+        raise SystemExit(
+            f"{eval_set_record['unmatched_question_count']} of "
+            f"{eval_set_record['rows_processed']} processed question(s) have no MetaQA gold "
+            f"answer for their hop depth, e.g. {eval_set_record['unmatched_questions_sample']}"
+            "\nThose rows cannot be scored, so they vanish from every exact-match and "
+            "Jaccard denominator and the run would report accuracy over a silently smaller "
+            "set than it read - and a comparison against another arm would not be a "
+            "comparison (CLAUDE.md evidence discipline, ADR 0011).\nEither point "
+            "--predictions at a run over MetaQA questions that are in the gold files "
+            "(datasets.metaqa_questions_template / metaqa_answers_template), or pass "
+            "--allow-unpinned-eval-set for a fixture or probe run that is not an experiment "
+            "arm."
         )
+    print(
+        f"Evaluation set: {eval_set_record['rows_processed']} row(s), pinned="
+        f"{eval_set_record['pinned']}, fingerprint="
+        f"{eval_set_record['question_set_sha256'][:16]}..., upstream decomposer run="
+        + (f"{upstream.get('run_id')} @ {upstream.get('commit')}" if upstream["found"] else "unrecorded")
+    )
+
+    # ---- the second denominator: failures counted rather than excluded
+    failures = score_failed_items(
+        analysis_dir, gold_by_hop=gold_by_hop, exact_threshold=exact_threshold
+    )
+    executed_with_gold = int(summary["total_with_gold"])
+    items_with_gold = executed_with_gold + failures["failed_items_with_gold"]
+    exact_matches = int(summary["total_exact_match"]) + failures["failed_items_exact_match_count"]
+    # The EXACT sum, not the 4-dp mean multiplied back out (PR #42 review, nit 1). It is 0.0
+    # rather than absent when nothing executed, so a run where every item failed reports 0.0
+    # and 0.0% - a measured floor - instead of null, which would read as "unmeasured" and is
+    # exactly what the review probe caught (finding 1).
+    jaccard_sum = float(summary["overall_jaccard_sum"]) + failures["failed_items_jaccard_sum"]
+    if items_with_gold:
+        overall_exact_rate = round(100.0 * exact_matches / items_with_gold, 2)
+        overall_mean_jaccard = round(jaccard_sum / items_with_gold, 4)
     else:
+        # No item in the run has a gold answer: nothing was measured, so nothing is reported.
         overall_exact_rate = None
         overall_mean_jaccard = None
 
     over_all = {
         "definition": (
             "every prediction whose question has a gold answer, with a compile or execution "
-            "failure counted as the empty answer set it produced (jaccard(empty, gold), "
-            "which is 0 for MetaQA's non-empty gold). This is the same convention the "
-            "MuSiQue answering backend uses - a failed item is inside the reported metric, "
-            "not excluded - so it is the denominator that can be read against a MuSiQue "
-            "number (issue #41)."
+            "failure counted as the empty answer set it produced: its Jaccard is "
+            "jaccard(empty, gold) and it is an exact match iff that reaches the same "
+            f"threshold ({exact_threshold}) the executed items are scored against. For "
+            "MetaQA's non-empty gold that contribution is 0 on both metrics. This is the "
+            "same convention the MuSiQue answering backend uses - a failed item is inside "
+            "the reported metric, not excluded - so it is the denominator that can be read "
+            "against a MuSiQue number (issue #41). NOTE the element-level asymmetry with "
+            "MuSiQue: matching here is set membership after whitespace stripping only, "
+            "CASE-SENSITIVE and with no punctuation or article handling, whereas MuSiQue EM "
+            "applies SQuAD's normalize_answer (see answer_normalization in "
+            "metric_definitions). The two numbers are therefore comparable in denominator "
+            "but not in string strictness; aligning them is a scoring-rule decision for "
+            "Jahid, not an implementation detail."
         ),
         "items_with_gold": items_with_gold,
-        "items_with_gold_executed": summary["total_with_gold"],
+        "items_with_gold_executed": executed_with_gold,
         "items_with_gold_not_executed": failures["failed_items_with_gold"],
-        "exact_match_count": failures["exact_match_count"],
+        "exact_match_count": exact_matches,
+        "exact_match_count_executed": int(summary["total_exact_match"]),
+        "exact_match_count_not_executed": failures["failed_items_exact_match_count"],
         "pct_exact": overall_exact_rate,
         "mean_jaccard": overall_mean_jaccard,
+        "jaccard_sum": round(jaccard_sum, 6),
         "items_with_an_empty_gold_set": failures["failed_items_with_an_empty_gold_set"],
     }
     if failures["failed_items_with_an_empty_gold_set"]:
-        over_all["mean_jaccard"] = None
-        over_all["mean_jaccard_note"] = (
+        # Both metrics include them, by the same rule, so the definition above still holds -
+        # but the empty-vs-empty rule is surprising enough to name when it fires.
+        over_all["empty_gold_set_note"] = (
             f"{failures['failed_items_with_an_empty_gold_set']} failed item(s) have an EMPTY "
-            "gold answer set, which the Jaccard rule scores 1.0 against an empty prediction. "
-            "A mean that treats those as successes would misstate the run, so it is reported "
-            "as unmeasured here; the per-hop and executed-only numbers above are unaffected."
+            "gold answer set. The Jaccard rule scores empty-vs-empty as 1.0, so each of them "
+            f"contributed 1.0 to the mean AND counted as an exact match at threshold "
+            f"{exact_threshold} - the same rule applied to every other item in this block, "
+            "not a special case. MetaQA gold answers are non-empty, so a non-zero count here "
+            "points at a malformed gold line rather than at the metric."
         )
 
     print("\n" + "=" * 56)
@@ -335,6 +598,8 @@ def main() -> None:
         "kg_entities": len(kg.id_to_entity),
         "kg_triples": len(kg.triples),
         "data_root": str(data_root),
+        "evaluation_set": eval_set_record,
+        "upstream_decomposer_run": upstream,
         "coverage": coverage,
         "compile_fail_reasons": coverage["compile_fail_reasons"],
         "exec_fail_reasons": coverage["exec_fail_reasons"],
@@ -354,6 +619,21 @@ def main() -> None:
             "exact_match": f"Jaccard >= {exact_threshold} between the executed answer set "
             "and the gold answer set",
             "jaccard": "|intersection| / |union| of the two answer sets; empty vs empty is 1.0",
+            "answer_normalization": (
+                "STRIP-ONLY, and CASE-SENSITIVE. A predicted element is the KG entity string "
+                "exactly as kb.txt spells it with surrounding whitespace removed; a gold "
+                "element is the gold line split on the answer separator with each part "
+                "stripped, and empty parts dropped. There is no lowercasing, no punctuation "
+                "removal and no article handling, so 'The Tin Compass' and 'the tin compass' "
+                "are different elements here. This is what scripts/compare_answer_accuracy.py "
+                "has always done and it is left unchanged - it is NOT the rule MuSiQue EM/F1 "
+                "uses (SQuAD's normalize_answer: lowercase, strip punctuation, drop a/an/the, "
+                "collapse whitespace - src/answer_metrics.py, ADR 0019 decision 3). The "
+                "asymmetry is recorded rather than removed: switching MetaQA to SQuAD "
+                "normalization would change every MetaQA number ever reported and is a "
+                "scoring-rule decision for Jahid with his supervisor (PR #42 review, "
+                "finding 4)."
+            ),
         },
         "composed_from": {
             "compile_execute": "scripts/evaluate_decompositions.py::evaluate_decomposition_rate",
@@ -371,6 +651,11 @@ def main() -> None:
         "backend_label": backend_label,
         "grag_wired": GRAG_WIRED,
         "predictions": str(args.predictions),
+        "predictions_sha256": eval_set_record["predictions_sha256"],
+        "evaluation_set": eval_set_record,
+        "upstream_decomposer_run": upstream,
+        "allow_unpinned_eval_set": args.allow_unpinned_eval_set,
+        "require_gold_for_every_item": require(cfg, "eval_set.require_gold_for_every_item"),
         "kb": str(kb_path),
         "data_root": str(data_root),
         "run_dir": str(run_dir),
@@ -400,7 +685,21 @@ def main() -> None:
         note_title=f"MetaQA end-to-end ({backend_label})",
         note_lines=[
             f"- **Backend: `{backend_label}` — GRAG is NOT wired.** {GRAG_STATUS}",
-            f"- Predictions: `{args.predictions}`",
+            f"- Predictions: `{args.predictions}` (sha256 "
+            f"{eval_set_record['predictions_sha256'][:16]}...)",
+            f"- Evaluation set: {eval_set_record['rows_processed']} row(s) "
+            f"{eval_set_record['rows_per_hop']}, pinned={eval_set_record['pinned']} "
+            f"({eval_set_record['unmatched_question_count']} without gold"
+            + (", --allow-unpinned-eval-set given" if args.allow_unpinned_eval_set else "")
+            + f"), question-set fingerprint `{eval_set_record['question_set_sha256']}`",
+            "- Upstream decomposer run: "
+            + (
+                f"`{upstream['run_id']}` ({upstream.get('model')}, condition "
+                f"{upstream.get('condition')}) at commit `{upstream.get('commit')}`"
+                + (" — **dirty tree**" if upstream.get("dirty") else "")
+                if upstream["found"]
+                else "unrecorded — " + str(upstream["note"])
+            ),
             f"- KB: `{kb_path}` ({len(kg.id_to_entity)} entities, {len(kg.triples)} triples); "
             "no model loaded",
             f"- Coverage: {coverage['total']} item(s), compiled "
@@ -415,8 +714,8 @@ def main() -> None:
             f"answer set): exact {over_all['exact_match_count']} ({over_all['pct_exact']}%), "
             f"mean Jaccard {over_all['mean_jaccard']}"
             + (
-                f" — {over_all['mean_jaccard_note']}"
-                if over_all.get("mean_jaccard_note")
+                f" — {over_all['empty_gold_set_note']}"
+                if over_all.get("empty_gold_set_note")
                 else ""
             ),
         ]

--- a/scripts/run_metaqa_compile_execute.py
+++ b/scripts/run_metaqa_compile_execute.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""MetaQA end-to-end backend: compile a decomposition, execute it, score the answer set.
+
+The MetaQA half of issue #16. ADR 0006 gives MetaQA **end-to-end evaluation only** (it has
+no gold decompositions), so a MetaQA decomposition is judged by the answer set executing it
+produces. Both halves of that already existed as separate scripts run by hand:
+
+1. ``scripts/evaluate_decompositions.py`` compiles each predicted sub-question into a KG op
+   and executes the chain, reporting a compile/execute rate with its error taxonomies;
+2. ``scripts/compare_answer_accuracy.py`` compares the executed answer set against MetaQA's
+   gold answers with Jaccard (exact match = Jaccard 1.0).
+
+This is the **wrapper** that runs them as one command over one predictions file and writes
+one metrics JSON: coverage, exact match, Jaccard, with both error taxonomies preserved
+verbatim. It **imports** the compiler and the scorer — it does not reimplement either. The
+step-template regexes, the relation rules, the compile-error reasons
+(``missing_decomposition``, ``unsupported_template``, ``cannot_infer_relation``,
+``compile_error_other``) and the execution-error categories (``entity_not_in_kb``,
+``bad_reference_or_plan``, ``exec_error_other``) all stay where they are, unchanged;
+``tests/test_metaqa_compile_execute.py`` pins that the wrapper reproduces the standalone
+script's fixture outcomes exactly.
+
+**This is not GRAG.** ADR 0006 routes MetaQA end-to-end evaluation through the supervisor's
+GRAG system. GRAG is external and nothing about its interface exists in this repo or in the
+v1 repo, so it is not wired here and is not stubbed: this path is direct execution against
+the MetaQA KG built from ``kb.txt`` (``scripts/kg.py``), it says so in ``backend_label`` and
+in ``backend.grag_wired: false`` in every metrics JSON it writes, and a number from it is
+not a GRAG number. See ``configs/metaqa_compile_execute.json`` (``_grag_note``).
+
+No model is loaded anywhere in this path — the compiler is regexes and the scorer is set
+arithmetic — so there is no parameter count to assert and, as everywhere in this repo, no
+model scores, rates or judges anything.
+
+Two denominators are reported for exact match and Jaccard, because they answer different
+questions and the difference is large:
+
+- **over executed items with gold** — what ``compare_answer_accuracy.py`` has always
+  reported: of the decompositions that compiled *and* executed, how good is the answer set.
+  It excludes every compile and execution failure, so it is a conditional number.
+- **over all items with gold** — every prediction whose question has a gold answer, with a
+  compile or execution failure counted as the empty answer set it produced. This is the
+  denominator the MuSiQue answering backend uses (a failed item there is inside the reported
+  EM/F1, not excluded), so it is the one that can be read against a MuSiQue number for the
+  cross-dataset comparison of issue #41. Which of the two is *the* headline MetaQA metric is
+  not this script's call; both are reported with their definitions attached.
+
+Usage::
+
+    python scripts/run_metaqa_compile_execute.py --predictions <decomposer run>/results.json
+    python scripts/run_metaqa_compile_execute.py --predictions <...> --run-dir runs/probe
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# The two halves, imported rather than reimplemented: one home for the compiler, one home
+# for the Jaccard scorer.
+from compare_answer_accuracy import jaccard, load_gold_by_hop, run_analysis  # noqa: E402
+from evaluate_decompositions import evaluate_decomposition_rate  # noqa: E402
+from kg import build_metaqa_kg  # noqa: E402
+from run_artifacts import now_iso, write_run_artifacts  # noqa: E402
+from run_config import load_config, load_paths, require, resolve_path, runs_path  # noqa: E402
+from seeding import set_global_seed  # noqa: E402
+
+#: Recorded in every artifact. GRAG is external and absent (see the module docstring), so
+#: this is a constant of the code, not a config knob a flag could flip.
+GRAG_WIRED = False
+GRAG_STATUS = (
+    "not wired: GRAG is the supervisor's system (ADR 0006) and no interface, endpoint, "
+    "client, repository or handover for it exists in this repo or in the v1 repo "
+    "(Thesis---QA) as of 2026-08-22. This run executed decompositions directly against the "
+    "MetaQA KG built from kb.txt instead, which is a different measurement and is labelled "
+    "as one. Obtaining GRAG is an external dependency Jahid chases with his supervisor."
+)
+
+#: The dumps ``evaluate_decomposition_rate`` writes, and what each one holds.
+DUMP_FILES = ("success.json", "compile_fail.json", "exec_fail.json")
+
+
+def gold_for_item(item: dict, gold_by_hop: dict[int, dict[str, set[str]]]) -> set[str] | None:
+    """The gold answer set for one prediction row, or ``None`` when it has no gold.
+
+    Same lookup key as ``compare_answer_accuracy.run_analysis``: the stripped question text
+    within the row's ``hop_count``. Kept to one function so the executed and the failed rows
+    are matched to gold by exactly the same rule.
+    """
+    question = str(item.get("question") or "").strip()
+    hop_count = item.get("hop_count")
+    if not isinstance(hop_count, int):
+        return None
+    return gold_by_hop.get(hop_count, {}).get(question)
+
+
+def over_all_items_with_gold(
+    analysis_dir: Path,
+    *,
+    gold_by_hop: dict[int, dict[str, set[str]]],
+    executed_exact_matches: int,
+) -> dict[str, Any]:
+    """Exact match and mean Jaccard with compile/execute failures counted, not excluded.
+
+    A failed item produced no answer set, so its contribution is ``jaccard(set(), gold)``
+    — computed with the imported scorer rather than hard-coded, so an item with an empty gold
+    set (which would score 1.0 by the empty-vs-empty rule) cannot be silently written off as
+    a 0. Such rows are counted separately and, if any exist, the mean is reported as null
+    with a note rather than as a number whose meaning is unclear.
+
+    The failed rows are read from the run's own ``compile_fail.json`` / ``exec_fail.json``
+    dumps, so "which rows this run processed" is taken from the run's output and never
+    re-derived from the predictions file (the row cap would then live in two places).
+    """
+    failed_with_gold = 0
+    failed_jaccard_sum = 0.0
+    failed_with_empty_gold = 0
+    for name in ("compile_fail.json", "exec_fail.json"):
+        path = analysis_dir / name
+        if not path.exists():
+            continue
+        for item in json.loads(path.read_text(encoding="utf-8")):
+            gold = gold_for_item(item, gold_by_hop)
+            if gold is None:
+                continue
+            failed_with_gold += 1
+            if not gold:
+                failed_with_empty_gold += 1
+            failed_jaccard_sum += jaccard(set(), gold)
+    return {
+        "failed_items_with_gold": failed_with_gold,
+        "failed_items_with_an_empty_gold_set": failed_with_empty_gold,
+        "failed_items_jaccard_sum": round(failed_jaccard_sum, 4),
+        "exact_match_count": executed_exact_matches,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--config", default="metaqa_compile_execute.json")
+    p.add_argument(
+        "--predictions", type=Path, required=True, help="Decomposer run's results.json"
+    )
+    p.add_argument("--kb", type=Path, default=None, help="Override the kb path from config.")
+    p.add_argument("--max-items", type=int, default=None, help="Override the config row cap.")
+    p.add_argument(
+        "--run-dir",
+        type=Path,
+        default=None,
+        help="Where the artifacts and the per-item dumps go (default: under the runs root).",
+    )
+    p.add_argument("--seed", type=int, default=None)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    cfg = load_config(args.config)
+    paths_cfg = load_paths(require(cfg, "paths_config"))
+    data_root = Path(paths_cfg["data_root_resolved"])
+
+    # The two composed configs. Every methodology knob is read from them, so the wrapper
+    # cannot disagree with the script it wraps about what a number means.
+    kg_cfg = load_config(require(cfg, "kg_eval_config"))
+    acc_cfg = load_config(require(cfg, "answer_accuracy_config"))
+
+    seed = args.seed if args.seed is not None else int(require(cfg, "seed"))
+    seeded = set_global_seed(seed)
+
+    max_items = args.max_items if args.max_items is not None else require(kg_cfg, "max_items")
+    hops = [int(h) for h in require(acc_cfg, "hops")]
+    analysis_subdir = require(acc_cfg, "analysis_subdir")
+    exact_threshold = float(require(acc_cfg, "exact_match_jaccard"))
+    out_prefix = require(cfg, "out_prefix")
+    backend_label = require(cfg, "backend_label")
+
+    if not args.predictions.exists():
+        raise SystemExit(f"predictions not found: {args.predictions}")
+    kb_path = args.kb or resolve_path(
+        require(paths_cfg, "datasets." + require(kg_cfg, "kb_key")), data_root
+    )
+
+    run_dir = (
+        args.run_dir
+        if args.run_dir is not None
+        else runs_path(paths_cfg, require(cfg, "run_subdir"))
+    )
+    run_dir = Path(run_dir)
+    analysis_dir = run_dir / analysis_subdir
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Backend: {backend_label} (GRAG wired: {GRAG_WIRED})")
+    print(f"Loading MetaQA KG from {kb_path} ...")
+    kg = build_metaqa_kg(kb_path)
+
+    # ---- half 1: compile + execute (the existing path, called, not reimplemented)
+    print(f"Compiling and executing decompositions in {args.predictions} ...")
+    rate = evaluate_decomposition_rate(
+        kg,
+        args.predictions,
+        max_items=int(max_items) if max_items is not None else None,
+        # Always written: the gold comparison below reads success.json. They hold question
+        # and answer text and land under the gitignored runs root, never in git.
+        output_dir=analysis_dir,
+    )
+    coverage = rate.as_dict()
+
+    # ---- half 2: the executed answer sets against MetaQA gold (the existing scorer)
+    gold_by_hop, total_per_hop = load_gold_by_hop(
+        data_root,
+        require(paths_cfg, "datasets." + require(acc_cfg, "questions_template_key")),
+        require(paths_cfg, "datasets." + require(acc_cfg, "answers_template_key")),
+        hops,
+        require(acc_cfg, "answer_separator"),
+    )
+    if not any(gold_by_hop.values()):
+        raise SystemExit(
+            f"no MetaQA gold question/answer files found under {data_root}; the executed "
+            "answer sets cannot be scored without them (check data_root in the paths config)"
+        )
+
+    summary, per_item = run_analysis(
+        run_dir,
+        gold_by_hop=gold_by_hop,
+        total_per_hop=total_per_hop,
+        hops=hops,
+        analysis_subdir=analysis_subdir,
+        exact_threshold=exact_threshold,
+        seed=seed,
+    )
+
+    # ---- the second denominator: failures counted rather than excluded
+    failures = over_all_items_with_gold(
+        analysis_dir,
+        gold_by_hop=gold_by_hop,
+        executed_exact_matches=int(summary["total_exact_match"]),
+    )
+    items_with_gold = int(summary["total_with_gold"]) + failures["failed_items_with_gold"]
+    executed_mean_jaccard = summary["overall_mean_jaccard"]
+    if items_with_gold and executed_mean_jaccard is not None:
+        overall_exact_rate = round(100.0 * summary["total_exact_match"] / items_with_gold, 2)
+        jaccard_sum = executed_mean_jaccard * summary["total_with_gold"]
+        overall_mean_jaccard = round(
+            (jaccard_sum + failures["failed_items_jaccard_sum"]) / items_with_gold, 4
+        )
+    else:
+        overall_exact_rate = None
+        overall_mean_jaccard = None
+
+    over_all = {
+        "definition": (
+            "every prediction whose question has a gold answer, with a compile or execution "
+            "failure counted as the empty answer set it produced (jaccard(empty, gold), "
+            "which is 0 for MetaQA's non-empty gold). This is the same convention the "
+            "MuSiQue answering backend uses - a failed item is inside the reported metric, "
+            "not excluded - so it is the denominator that can be read against a MuSiQue "
+            "number (issue #41)."
+        ),
+        "items_with_gold": items_with_gold,
+        "items_with_gold_executed": summary["total_with_gold"],
+        "items_with_gold_not_executed": failures["failed_items_with_gold"],
+        "exact_match_count": failures["exact_match_count"],
+        "pct_exact": overall_exact_rate,
+        "mean_jaccard": overall_mean_jaccard,
+        "items_with_an_empty_gold_set": failures["failed_items_with_an_empty_gold_set"],
+    }
+    if failures["failed_items_with_an_empty_gold_set"]:
+        over_all["mean_jaccard"] = None
+        over_all["mean_jaccard_note"] = (
+            f"{failures['failed_items_with_an_empty_gold_set']} failed item(s) have an EMPTY "
+            "gold answer set, which the Jaccard rule scores 1.0 against an empty prediction. "
+            "A mean that treats those as successes would misstate the run, so it is reported "
+            "as unmeasured here; the per-hop and executed-only numbers above are unaffected."
+        )
+
+    print("\n" + "=" * 56)
+    print(f"   METAQA END-TO-END ({backend_label})")
+    print("=" * 56)
+    print(f"Items:            {coverage['total']}")
+    print(f"Compiled OK:      {coverage['compiled_ok']} ({coverage['compiled_ok_rate']:.2%})")
+    print(f"Executed OK:      {coverage['executed_ok']} ({coverage['executed_ok_rate']:.2%})")
+    print(f"Compile fail:     {coverage['compile_fail']} {coverage['compile_fail_reasons']}")
+    print(f"Exec fail:        {coverage['exec_fail']} {coverage['exec_fail_reasons']}")
+    print(
+        f"Over EXECUTED items with gold ({summary['total_with_gold']}): "
+        f"exact {summary['total_exact_match']} ({summary['overall_pct_exact']}%), "
+        f"mean Jaccard {summary['overall_mean_jaccard']}"
+    )
+    print(
+        f"Over ALL items with gold ({items_with_gold}): "
+        f"exact {over_all['exact_match_count']} ({over_all['pct_exact']}%), "
+        f"mean Jaccard {over_all['mean_jaccard']}"
+    )
+    for hop in hops:
+        block = summary["per_hop"][str(hop)]
+        print(
+            f"  {hop}-hop: answered {block['answered_count']} of "
+            f"{block['total_gold_questions']} gold ({block['coverage_pct']}% coverage), "
+            f"with_gold {block['with_gold_count']}, exact {block['exact_match_count']} "
+            f"({block['pct_exact']}%), mean Jaccard {block['mean_jaccard']}"
+        )
+    print("=" * 56)
+
+    details_path = analysis_dir / "answer_details.json"
+    details_path.write_text(
+        json.dumps(per_item, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    metrics: dict[str, Any] = {
+        "script": Path(__file__).name,
+        "created_utc": now_iso(),
+        "seed": seed,
+        "seeded": seeded,
+        "backend": {
+            "label": backend_label,
+            "grag_wired": GRAG_WIRED,
+            "grag_status": GRAG_STATUS,
+            "model_loaded": False,
+            "model_note": (
+                "no model is loaded in this path: the compiler is regexes over the step "
+                "text and the scorer is set arithmetic, so there is no parameter count to "
+                "assert and nothing is scored by a model"
+            ),
+        },
+        "predictions_path": str(args.predictions.resolve()),
+        "kb_path": str(Path(kb_path).resolve()),
+        "kg_entities": len(kg.id_to_entity),
+        "kg_triples": len(kg.triples),
+        "data_root": str(data_root),
+        "coverage": coverage,
+        "compile_fail_reasons": coverage["compile_fail_reasons"],
+        "exec_fail_reasons": coverage["exec_fail_reasons"],
+        "answer_accuracy_over_executed_items": summary,
+        "answer_accuracy_over_all_items_with_gold": over_all,
+        "metric_definitions": {
+            "coverage": (
+                "compiled_ok_rate and executed_ok_rate over the items read from the "
+                "predictions file, from scripts/evaluate_decompositions.py; the "
+                "compile_fail_reasons and exec_fail_reasons breakdowns are that script's "
+                "taxonomies, preserved verbatim"
+            ),
+            "per_hop_coverage_pct": (
+                "answered items / gold questions available for that hop depth, from "
+                "scripts/compare_answer_accuracy.py"
+            ),
+            "exact_match": f"Jaccard >= {exact_threshold} between the executed answer set "
+            "and the gold answer set",
+            "jaccard": "|intersection| / |union| of the two answer sets; empty vs empty is 1.0",
+        },
+        "composed_from": {
+            "compile_execute": "scripts/evaluate_decompositions.py::evaluate_decomposition_rate",
+            "gold_comparison": "scripts/compare_answer_accuracy.py::run_analysis",
+            "kg": "scripts/kg.py::build_metaqa_kg",
+        },
+    }
+
+    snapshot = {
+        "script": Path(__file__).name,
+        "created_utc": now_iso(),
+        "config_path": cfg.get("_config_path"),
+        "kg_eval_config_path": kg_cfg.get("_config_path"),
+        "answer_accuracy_config_path": acc_cfg.get("_config_path"),
+        "backend_label": backend_label,
+        "grag_wired": GRAG_WIRED,
+        "predictions": str(args.predictions),
+        "kb": str(kb_path),
+        "data_root": str(data_root),
+        "run_dir": str(run_dir),
+        "analysis_dir": str(analysis_dir),
+        "max_items": max_items,
+        "hops": hops,
+        "exact_match_jaccard": exact_threshold,
+        "answer_separator": require(acc_cfg, "answer_separator"),
+        "seed": seed,
+        "seeded": seeded,
+        "seed_sources": {
+            "governing": f"{cfg.get('_config_path')} (or --seed)",
+            "unused_component_seeds": {
+                str(kg_cfg.get("_config_path")): kg_cfg.get("seed"),
+                str(acc_cfg.get("_config_path")): acc_cfg.get("seed"),
+            },
+            "note": "the composed scripts' functions are called directly, so their configs' "
+            "seed keys do not apply to this run; they are recorded for provenance only",
+        },
+        "dumps_written": [str(analysis_dir / name) for name in DUMP_FILES],
+    }
+
+    write_run_artifacts(
+        run_dir,
+        config_snapshot=snapshot,
+        metrics=metrics,
+        note_title=f"MetaQA end-to-end ({backend_label})",
+        note_lines=[
+            f"- **Backend: `{backend_label}` — GRAG is NOT wired.** {GRAG_STATUS}",
+            f"- Predictions: `{args.predictions}`",
+            f"- KB: `{kb_path}` ({len(kg.id_to_entity)} entities, {len(kg.triples)} triples); "
+            "no model loaded",
+            f"- Coverage: {coverage['total']} item(s), compiled "
+            f"{coverage['compiled_ok']} ({coverage['compiled_ok_rate']:.2%}), executed "
+            f"{coverage['executed_ok']} ({coverage['executed_ok_rate']:.2%})",
+            f"- Compile fail reasons: {coverage['compile_fail_reasons']}",
+            f"- Exec fail reasons: {coverage['exec_fail_reasons']}",
+            f"- Over EXECUTED items with gold ({summary['total_with_gold']}): exact "
+            f"{summary['total_exact_match']} ({summary['overall_pct_exact']}%), mean Jaccard "
+            f"{summary['overall_mean_jaccard']}",
+            f"- Over ALL items with gold ({items_with_gold}, failures counted as the empty "
+            f"answer set): exact {over_all['exact_match_count']} ({over_all['pct_exact']}%), "
+            f"mean Jaccard {over_all['mean_jaccard']}"
+            + (
+                f" — {over_all['mean_jaccard_note']}"
+                if over_all.get("mean_jaccard_note")
+                else ""
+            ),
+        ]
+        + [
+            f"- **{hop}-hop**: answered {summary['per_hop'][str(hop)]['answered_count']} of "
+            f"{summary['per_hop'][str(hop)]['total_gold_questions']} gold "
+            f"({summary['per_hop'][str(hop)]['coverage_pct']}% coverage), exact "
+            f"{summary['per_hop'][str(hop)]['exact_match_count']} "
+            f"({summary['per_hop'][str(hop)]['pct_exact']}%), mean Jaccard "
+            f"{summary['per_hop'][str(hop)]['mean_jaccard']}"
+            for hop in hops
+        ]
+        + [f"- Per-item: `{details_path}`, dumps: `{analysis_dir}`"],
+        prefix=out_prefix,
+    )
+    print(f"\nResults saved to: {run_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -24,7 +24,7 @@ What is NOT covered, and why:
   for the same reason: the arm selection, the train/eval overlap assertion and the
   prompt/completion formatting run, but no adapter is trained and no cost is measured.
 
-Two stages also carry golden metric values (``expect_metrics``). The fixture never
+Several stages also carry golden metric values (``expect_metrics``). The fixture never
 changes, so those numbers are fixed: if one moves, a metric's normalization or matching
 rule changed, and that must be a deliberate, reviewed edit rather than a silent drift.
 
@@ -112,6 +112,7 @@ def _stages() -> list[Stage]:
     scored = WORK / "retrieval" / "top5_scored.jsonl"
     musique_eval_dir = WORK / "musique_eval"
     kg_eval_dir = WORK / "kg_eval"
+    metaqa_e2e_dir = WORK / "metaqa_compile_execute"
     plots_dir = WORK / "sweep_plots"
     analysis_dir = WORK / "router_analysis"
     router_dry = WORK / "router_dry"
@@ -203,6 +204,56 @@ def _stages() -> list[Stage]:
                 (kg_eval_dir / "kg_eval_metrics.json", "kg_triples", 17),
             ],
             note="compile + execute decompositions against the fabricated MetaQA KG",
+        ),
+        # The same compile-and-execute path plus the gold comparison, in one command
+        # (issue #16). It calls the two scripts above rather than reimplementing them, so its
+        # coverage numbers MUST be the kg_eval numbers; the equivalence itself is pinned
+        # item-for-item by tests/test_metaqa_compile_execute.py. This is NOT GRAG - ADR 0006
+        # routes MetaQA end-to-end through the supervisor's GRAG system, which is external
+        # and not available, and the run's artifacts say so.
+        Stage(
+            name="metaqa_compile_execute",
+            cmd=[
+                sys.executable, SCRIPTS / "run_metaqa_compile_execute.py",
+                "--predictions", FIXTURES / "predictions" / "decomposer_results_metaqa.json",
+                "--run-dir", metaqa_e2e_dir,
+            ],
+            expect_files=[
+                metaqa_e2e_dir / "metaqa_e2e_metrics.json",
+                metaqa_e2e_dir / "metaqa_e2e_config.json",
+                metaqa_e2e_dir / "metaqa_e2e_notes.md",
+                metaqa_e2e_dir / "analysis" / "success.json",
+                metaqa_e2e_dir / "analysis" / "compile_fail.json",
+                metaqa_e2e_dir / "analysis" / "exec_fail.json",
+                metaqa_e2e_dir / "analysis" / "answer_details.json",
+            ],
+            expect_metrics=[
+                # Same 5 fixture rows as kg_eval, so the same 5 / 4 / 3 / 1 / 1.
+                (metaqa_e2e_dir / "metaqa_e2e_metrics.json", "coverage.total", 5),
+                (metaqa_e2e_dir / "metaqa_e2e_metrics.json", "coverage.compiled_ok", 4),
+                (metaqa_e2e_dir / "metaqa_e2e_metrics.json", "coverage.executed_ok", 3),
+                (metaqa_e2e_dir / "metaqa_e2e_metrics.json", "coverage.compile_fail", 1),
+                (metaqa_e2e_dir / "metaqa_e2e_metrics.json", "coverage.exec_fail", 1),
+                # Ada Mireles directed all three fixture movies, so the three executable
+                # rows reproduce the gold answer sets exactly: 3 of 3 exact, Jaccard 1.0.
+                (
+                    metaqa_e2e_dir / "metaqa_e2e_metrics.json",
+                    "answer_accuracy_over_executed_items.total_exact_match",
+                    3,
+                ),
+                (
+                    metaqa_e2e_dir / "metaqa_e2e_metrics.json",
+                    "answer_accuracy_over_executed_items.overall_mean_jaccard",
+                    1.0,
+                ),
+                (
+                    metaqa_e2e_dir / "metaqa_e2e_metrics.json",
+                    "answer_accuracy_over_all_items_with_gold.items_with_gold",
+                    3,
+                ),
+            ],
+            note="MetaQA end-to-end in one command: compile + execute, then exact match and "
+            "Jaccard against the fabricated gold (NOT GRAG - that stays external)",
         ),
         Stage(
             name="kg_summary",

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -217,6 +217,11 @@ def _stages() -> list[Stage]:
                 sys.executable, SCRIPTS / "run_metaqa_compile_execute.py",
                 "--predictions", FIXTURES / "predictions" / "decomposer_results_metaqa.json",
                 "--run-dir", metaqa_e2e_dir,
+                # Two of the five fixture rows carry invented questions that are in no gold
+                # file, which the eval-set assertion refuses for an experiment arm. Same
+                # reason the answerer stages pass their equivalent flag: a fixture run is
+                # not an arm.
+                "--allow-unpinned-eval-set",
             ],
             expect_files=[
                 metaqa_e2e_dir / "metaqa_e2e_metrics.json",

--- a/src/step_failures.py
+++ b/src/step_failures.py
@@ -1,0 +1,149 @@
+"""Step-level failure taxonomy for an executed decomposition (issue #16).
+
+The MuSiQue answering backend (``components/answerer/run_answerer.py``) reports answer EM
+and F1 for an item, which says *whether* a decomposition led to the right answer but not
+*where* it went wrong. This module is the "where": one label set per sub-question, derived
+from what the backend already records (the substitution result, the generation error, the
+cleaned answer), aggregated into counts a run note can carry.
+
+Nothing here loads a model, reads config or touches the filesystem; it is pure
+classification, so the arithmetic is unit-testable without a run.
+
+**Two of the categories issue #16 named cannot be produced by this backend, and are
+declared unavailable rather than approximated** — see
+:data:`UNAVAILABLE_STEP_FAILURE_CATEGORIES`. The rule from CLAUDE.md applies: what is not
+measured is reported as unmeasured, never as zero.
+
+The categories are **not mutually exclusive**: a step can be asked with a broken reference
+*and* come back empty, and both facts matter. So the summary is a set of counters plus
+``steps_clean`` (steps that carry no flag at all), never a partition that would have to
+pick a single "cause" by a precedence rule this repo has not agreed.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+#: What a sub-question can be flagged with, in the order the metrics JSON lists them.
+#: Each one is decided by a field the backend already writes to its per-item file, so a
+#: reader can re-derive every count from ``answer_per_item.json`` by hand.
+STEP_FAILURE_CATEGORIES: tuple[str, ...] = (
+    "broken_reference",
+    "generation_error",
+    "empty_answer",
+    "not_executed",
+)
+
+#: What each flag means, copied into the metrics JSON so a run note is self-describing.
+STEP_FAILURE_DEFINITIONS: dict[str, str] = {
+    "broken_reference": (
+        "the sub-question still carried at least one unresolved step reference when it was "
+        "asked: a forward reference, an out-of-range k, a step whose answer was empty or "
+        "failed, or a malformed '[#k' (src/step_lines.py::substitute_step_references leaves "
+        "these verbatim rather than guessing them, so the reader saw the placeholder)"
+    ),
+    "generation_error": "the generation call for this sub-question raised; the answer is empty",
+    "empty_answer": (
+        "the sub-question was executed without error but the answer was empty after the "
+        "model folder's post-processing and the configured answer cleanup"
+    ),
+    "not_executed": (
+        "no generation was attempted for this sub-question (--dry-run), so its answer is the "
+        "configured dry-run stub and nothing about the reader is being reported"
+    ),
+}
+
+#: The categories issue #16 asked for that this backend **cannot** produce, each with the
+#: reason. They are emitted in the metrics JSON so the gap is on the record instead of being
+#: silently absent — and so nobody later reads a missing key as a zero count.
+#:
+#: Adding any of them is a methodology change, not an implementation detail: the first two
+#: would need a context regime ADR 0019 refuses, the third would need the gold sub-answers
+#: that ADR 0019 keeps out of this path. Jahid's call with his supervisor.
+UNAVAILABLE_STEP_FAILURE_CATEGORIES: dict[str, str] = {
+    "empty_retrieval": (
+        "not applicable: this backend runs no retrieval. ADR 0019 decision 2 fixes the "
+        "context to the MuSiQue item's full paragraph list and the code refuses any other "
+        "policy, so there is no retrieval step that could come back empty. The MetaQA "
+        "compile-execute path has the analogous category (an op returning an empty id set)."
+    ),
+    "unresolvable_entity": (
+        "not applicable: this backend resolves no entities. There is no entity linker and no "
+        "knowledge base in the MuSiQue path - a sub-question is asked over paragraphs as "
+        "text. The MetaQA compile-execute path reports the analogous failure as its "
+        "'entity_not_in_kb' execution-error category."
+    ),
+    "wrong_intermediate_answer": (
+        "unmeasured, not zero: judging an intermediate answer needs a gold answer for that "
+        "sub-question. MuSiQue ships them (question_decomposition[*].answer), but ADR 0019 "
+        "deliberately keeps the gold sub-answers out of this path, and reading them as a "
+        "diagnostic would be a new methodology choice rather than an implementation detail. "
+        "The final step is the exception and is already scored: an item's answer_em / "
+        "answer_f1 IS the correctness of its last step."
+    ),
+}
+
+STEP_FAILURE_TAXONOMY_NOTE = (
+    "Step-level failure flags for the executed sub-questions of this run. The categories are "
+    "NOT mutually exclusive, so the counts in by_category can sum to more than "
+    "steps_with_any_flag; steps_clean counts sub-questions with no flag at all. "
+    "not_available lists the categories issue #16 named that this backend cannot produce, "
+    "with the reason for each - they are absent, not zero."
+)
+
+
+def classify_step(
+    *,
+    answer: str | None,
+    unresolved_references: Sequence[int],
+    error: str | None,
+    executed: bool,
+) -> list[str]:
+    """The failure flags of one sub-question, in :data:`STEP_FAILURE_CATEGORIES` order.
+
+    ``executed`` is False on a dry run, where no generation was attempted: the answer is a
+    stub, so the answer is not judged (no ``empty_answer``) and the step is flagged
+    ``not_executed`` instead. A broken reference is still real on a dry run — the
+    substitution chain runs either way — and is still flagged.
+
+    An empty list means the step carries no observed failure. That is not a claim that its
+    answer is *correct*: see ``wrong_intermediate_answer`` in
+    :data:`UNAVAILABLE_STEP_FAILURE_CATEGORIES`.
+    """
+    flags: set[str] = set()
+    if unresolved_references:
+        flags.add("broken_reference")
+    if error:
+        flags.add("generation_error")
+    elif executed and not str(answer or "").strip():
+        flags.add("empty_answer")
+    if not executed:
+        flags.add("not_executed")
+    return [category for category in STEP_FAILURE_CATEGORIES if category in flags]
+
+
+def summarize_step_failures(flag_lists: Iterable[Sequence[str]]) -> dict[str, Any]:
+    """Aggregate per-step flag lists into the metrics block.
+
+    ``steps`` counts the sub-questions seen, ``steps_clean`` those with no flag,
+    ``steps_with_any_flag`` the rest, and ``by_category`` how often each flag fired. Every
+    declared category is present with an explicit 0 so a category that never fired is
+    distinguishable from one this code does not know about.
+    """
+    by_category = {category: 0 for category in STEP_FAILURE_CATEGORIES}
+    steps = 0
+    with_any = 0
+    for flags in flag_lists:
+        steps += 1
+        if flags:
+            with_any += 1
+        for flag in flags:
+            if flag not in by_category:
+                raise ValueError(f"unknown step failure category: {flag!r}")
+            by_category[flag] += 1
+    return {
+        "steps": steps,
+        "steps_clean": steps - with_any,
+        "steps_with_any_flag": with_any,
+        "by_category": by_category,
+    }

--- a/tests/test_answer_musique.py
+++ b/tests/test_answer_musique.py
@@ -14,6 +14,10 @@ Three things are pinned here, all without a model and without real data:
 3. **Per-hop aggregation** (``components/answerer/run_answerer.py``) — the reporting shape of
    docs/METRICS.md §2, plus the run's step reading agreeing with the decomposition
    evaluator's.
+4. **The step-level failure taxonomy** (``src/step_failures.py``, issue #16) — which flags
+   fire for which step, that the categories are counters rather than a partition, and that
+   the three categories this backend cannot produce are declared unavailable with a reason
+   instead of reported as zero.
 
 Run::
 
@@ -46,6 +50,13 @@ from answer_metrics import (  # noqa: E402
 )
 from model_size import assert_within_ceiling, ceiling_for, load_limits  # noqa: E402
 from run_config import PATHS_CONFIG_ENV, load_config, require  # noqa: E402
+from step_failures import (  # noqa: E402
+    STEP_FAILURE_CATEGORIES,
+    STEP_FAILURE_DEFINITIONS,
+    UNAVAILABLE_STEP_FAILURE_CATEGORIES,
+    classify_step,
+    summarize_step_failures,
+)
 from step_lines import substitute_step_references  # noqa: E402
 
 import run_answerer as ans  # noqa: E402
@@ -735,6 +746,255 @@ class TestDryRunEndToEnd(unittest.TestCase):
         )
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("exactly one of", proc.stdout + proc.stderr)
+
+
+class TestStepFailureTaxonomy(unittest.TestCase):
+    """``src/step_failures.py``: which flags fire, and what is declared unavailable.
+
+    The categories are deliberately not a partition, so these tests check the flag *sets*
+    rather than a single winning label.
+    """
+
+    def test_a_clean_executed_step_has_no_flags(self) -> None:
+        self.assertEqual(
+            classify_step(
+                answer="Amador County", unresolved_references=[], error=None, executed=True
+            ),
+            [],
+        )
+
+    def test_an_unresolved_reference_is_a_broken_reference(self) -> None:
+        self.assertEqual(
+            classify_step(
+                answer="something", unresolved_references=[1], error=None, executed=True
+            ),
+            ["broken_reference"],
+        )
+
+    def test_an_empty_answer_on_an_executed_step(self) -> None:
+        self.assertEqual(
+            classify_step(answer="   ", unresolved_references=[], error=None, executed=True),
+            ["empty_answer"],
+        )
+
+    def test_a_generation_error_is_not_also_reported_as_an_empty_answer(self) -> None:
+        """The error is the cause and the empty answer is its consequence; flagging both
+        would double-count one failure."""
+        self.assertEqual(
+            classify_step(
+                answer="", unresolved_references=[], error="RuntimeError: boom", executed=True
+            ),
+            ["generation_error"],
+        )
+
+    def test_a_broken_reference_and_an_empty_answer_are_both_reported(self) -> None:
+        """Non-exclusive by design: the step was asked with a placeholder in it AND came
+        back with nothing, and an error analysis needs both facts."""
+        self.assertEqual(
+            classify_step(answer="", unresolved_references=[2], error=None, executed=True),
+            ["broken_reference", "empty_answer"],
+        )
+
+    def test_a_dry_run_step_is_not_judged_on_its_answer(self) -> None:
+        """--dry-run substitutes a stub, so 'empty_answer' would say nothing about a reader
+        that was never called; the step is flagged not_executed instead."""
+        self.assertEqual(
+            classify_step(answer="", unresolved_references=[], error=None, executed=False),
+            ["not_executed"],
+        )
+
+    def test_a_broken_reference_is_still_real_on_a_dry_run(self) -> None:
+        """The substitution chain runs either way, so this flag is meaningful with no
+        weights loaded — which is what makes the taxonomy smoke-testable."""
+        self.assertEqual(
+            classify_step(answer="stub", unresolved_references=[1], error=None, executed=False),
+            ["broken_reference", "not_executed"],
+        )
+
+    def test_the_flag_order_is_the_declared_category_order(self) -> None:
+        flags = classify_step(
+            answer="", unresolved_references=[1], error="E: x", executed=False
+        )
+        self.assertEqual(flags, ["broken_reference", "generation_error", "not_executed"])
+        self.assertEqual(
+            flags, [c for c in STEP_FAILURE_CATEGORIES if c in flags], "order must be stable"
+        )
+
+    def test_the_summary_counts_by_category_and_clean_steps(self) -> None:
+        """Four steps: one clean, one broken reference, one empty answer, one with both.
+        by_category sums to 4 while only 3 steps carry any flag — the counters are not a
+        partition, and steps_clean is what says how many were fine."""
+        summary = summarize_step_failures(
+            [[], ["broken_reference"], ["empty_answer"], ["broken_reference", "empty_answer"]]
+        )
+        self.assertEqual(summary["steps"], 4)
+        self.assertEqual(summary["steps_clean"], 1)
+        self.assertEqual(summary["steps_with_any_flag"], 3)
+        self.assertEqual(summary["by_category"]["broken_reference"], 2)
+        self.assertEqual(summary["by_category"]["empty_answer"], 2)
+        self.assertEqual(summary["by_category"]["generation_error"], 0)
+        self.assertEqual(summary["by_category"]["not_executed"], 0)
+
+    def test_every_declared_category_is_present_even_at_zero(self) -> None:
+        """A missing key would be indistinguishable from a category this code forgot."""
+        summary = summarize_step_failures([])
+        self.assertEqual(set(summary["by_category"]), set(STEP_FAILURE_CATEGORIES))
+        self.assertEqual(summary["steps"], 0)
+
+    def test_an_unknown_category_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            summarize_step_failures([["retrieval_was_empty"]])
+
+    def test_the_unavailable_categories_are_named_with_a_reason(self) -> None:
+        """The three categories issue #16 named that this backend cannot produce are on the
+        record with why — absent, never silently zero (CLAUDE.md: unmeasured is unmeasured).
+        Each is also disjoint from the categories that DO fire, so no reader sees a
+        category both counted and declared unavailable."""
+        self.assertEqual(
+            set(UNAVAILABLE_STEP_FAILURE_CATEGORIES),
+            {"empty_retrieval", "unresolvable_entity", "wrong_intermediate_answer"},
+        )
+        self.assertEqual(
+            set(UNAVAILABLE_STEP_FAILURE_CATEGORIES) & set(STEP_FAILURE_CATEGORIES), set()
+        )
+        for category, reason in UNAVAILABLE_STEP_FAILURE_CATEGORIES.items():
+            self.assertTrue(reason.strip(), f"{category} has no reason recorded")
+
+    def test_every_firing_category_is_defined(self) -> None:
+        self.assertEqual(set(STEP_FAILURE_DEFINITIONS), set(STEP_FAILURE_CATEGORIES))
+
+
+class TestStepFailureTaxonomyEndToEnd(unittest.TestCase):
+    """The taxonomy through the real CLI, on a fabricated predictions file.
+
+    The committed MuSiQue predictions fixture happens to have no broken reference (all 6 of
+    its ``[#k]`` resolve), so the broken-reference path needs its own hand-written input.
+    The ids are the fixture tree's, so the rows still join to a MuSiQue item.
+    """
+
+    #: Item 1: step 2's reference is malformed (``[#1`` with no closing bracket), which
+    #: ``substitute_step_references`` leaves verbatim and reports unresolved; step 3 is a
+    #: forward reference to a step that does not exist. Item 2 is clean.
+    ROWS = [
+        {
+            "query_id": "2hop__d001_a",
+            "question": "Which union organised the Marlow Bay strike and who leads it?",
+            "hop_count": 2,
+            "decomposition": (
+                "1. Which union organised the Marlow Bay strike?\n"
+                "2. Who leads [#1?\n"
+                "3. Where does [#9] live?"
+            ),
+        },
+        {
+            "query_id": "3hop1__d002_b",
+            "question": "What is the capital of the country the River Anwen rises in?",
+            "hop_count": 3,
+            "decomposition": (
+                "1. Where does the River Anwen rise?\n2. Which country contains [#1]?"
+            ),
+        },
+    ]
+
+    def test_broken_references_are_counted_and_located(self) -> None:
+        """5 sub-questions in total. Item 1: step 1 clean, step 2 broken (malformed [#1),
+        step 3 broken (no step 9). Item 2: both steps clean. So broken_reference = 2,
+        all 5 steps are not_executed (dry run), steps_clean = 0 because not_executed is
+        itself a flag, and the final-step block sees 2 steps (one per item) of which item
+        1's step 3 is broken."""
+        env = os.environ.copy()
+        env[PATHS_CONFIG_ENV] = str(SMOKE_PATHS_CONFIG)
+        with tempfile.TemporaryDirectory() as tmp:
+            predictions = Path(tmp) / "broken_reference_predictions.json"
+            predictions.write_text(json.dumps(self.ROWS, indent=2), encoding="utf-8")
+            out = Path(tmp) / "out"
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(ANSWERER),
+                    "--predictions",
+                    str(predictions),
+                    "--dry-run",
+                    "--dry-run-limit",
+                    "9",
+                    "--allow-unpinned-eval-set",
+                    "--output-root",
+                    str(out),
+                ],
+                cwd=str(REPO_ROOT),
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            metrics_paths = sorted(out.glob("*/answer_metrics.json"))
+            self.assertEqual(len(metrics_paths), 1)
+            metrics = json.loads(metrics_paths[0].read_text(encoding="utf-8"))
+            per_item = json.loads(
+                (metrics_paths[0].parent / "answer_per_item.json").read_text(encoding="utf-8")
+            )
+
+        taxonomy = metrics["step_failure_taxonomy"]
+        self.assertEqual(taxonomy["all_steps"]["steps"], 5)
+        self.assertEqual(taxonomy["all_steps"]["by_category"]["broken_reference"], 2)
+        self.assertEqual(taxonomy["all_steps"]["by_category"]["not_executed"], 5)
+        self.assertEqual(taxonomy["all_steps"]["by_category"]["empty_answer"], 0)
+        self.assertEqual(taxonomy["all_steps"]["by_category"]["generation_error"], 0)
+        self.assertEqual(taxonomy["all_steps"]["steps_clean"], 0)
+        self.assertEqual(taxonomy["final_step_only"]["steps"], 2)
+        self.assertEqual(taxonomy["final_step_only"]["by_category"]["broken_reference"], 1)
+        self.assertEqual(taxonomy["items_with_any_step_flag"], 2)
+        self.assertEqual(taxonomy["items_with_no_steps_so_no_flags"], 0)
+        self.assertEqual(metrics["counts"]["references_unresolved"], 2)
+
+        # The flags are per step in the per-item file, so an error analysis can point at the
+        # sub-question rather than at a count.
+        first = per_item["items"][0]
+        self.assertEqual([s["failure_flags"] for s in first["steps"]][0], ["not_executed"])
+        self.assertEqual(
+            [s["failure_flags"] for s in first["steps"]][1],
+            ["broken_reference", "not_executed"],
+        )
+        # The malformed reference was never substituted, and never edited away either.
+        self.assertIn("[#1?", first["steps"][1]["sub_question"])
+
+    def test_the_committed_fixture_has_no_broken_reference(self) -> None:
+        """Pins the premise of the class above: if a future fixture edit introduces a broken
+        reference, this test says so instead of the hand-written rows quietly becoming
+        redundant."""
+        env = os.environ.copy()
+        env[PATHS_CONFIG_ENV] = str(SMOKE_PATHS_CONFIG)
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "out"
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(ANSWERER),
+                    "--predictions",
+                    str(PREDICTIONS_FIXTURE),
+                    "--dry-run",
+                    "--dry-run-limit",
+                    "9",
+                    "--allow-unpinned-eval-set",
+                    "--output-root",
+                    str(out),
+                ],
+                cwd=str(REPO_ROOT),
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            metrics = json.loads(
+                sorted(out.glob("*/answer_metrics.json"))[0].read_text(encoding="utf-8")
+            )
+        taxonomy = metrics["step_failure_taxonomy"]
+        self.assertEqual(taxonomy["all_steps"]["steps"], 11)
+        self.assertEqual(taxonomy["all_steps"]["by_category"]["broken_reference"], 0)
+        self.assertEqual(taxonomy["all_steps"]["by_category"]["not_executed"], 11)
+        self.assertEqual(
+            set(taxonomy["not_available"]), set(UNAVAILABLE_STEP_FAILURE_CATEGORIES)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_metaqa_compile_execute.py
+++ b/tests/test_metaqa_compile_execute.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Checks for the MetaQA compile-execute wrapper (``scripts/run_metaqa_compile_execute.py``).
+
+Four things are pinned here, all on the fabricated fixtures under ``tests/fixtures/`` and
+with no model and no network:
+
+1. **Fixture equivalence.** The wrapper reproduces the standalone
+   ``scripts/evaluate_decompositions.py`` outcomes *exactly* — the same counts, the same
+   compile-error taxonomy, the same execution-error categories, entry for entry. The wrapper
+   must not have become a second, drifting compiler; the whole point is that it calls the
+   one that exists. The golden numbers are also the ones
+   ``scripts/smoke_test.py::kg_eval`` has always asserted (5 / 4 / 3 / 1 / 1, KG 15/17), so
+   a change that moves them turns two things red, not one.
+2. **The gold comparison**, hand-computed from the fixture KB and gold files.
+3. **The second denominator** — exact match and Jaccard with compile/execute failures
+   counted rather than excluded. The committed predictions fixture cannot exercise it (its
+   two failing rows have no gold answer), so that case uses hand-written rows whose
+   questions *are* in the fixture gold files.
+4. **The GRAG labelling.** GRAG is not wired, and every artifact has to say so. A test
+   guards it because the failure mode is silent: a run that looked like a GRAG number would
+   be a claim nobody made.
+
+Run::
+
+    .venv/bin/python tests/test_metaqa_compile_execute.py
+    .venv/bin/python -m unittest discover -s tests
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from run_config import PATHS_CONFIG_ENV  # noqa: E402
+
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+PREDICTIONS_FIXTURE = FIXTURES / "predictions" / "decomposer_results_metaqa.json"
+SMOKE_PATHS_CONFIG = REPO_ROOT / "configs" / "smoke_paths.json"
+WRAPPER = REPO_ROOT / "scripts" / "run_metaqa_compile_execute.py"
+STANDALONE = REPO_ROOT / "scripts" / "evaluate_decompositions.py"
+
+#: What the fabricated fixtures produce through the compile-and-execute path. 5 rows: 3
+#: compile and execute, 1 has a step whose relation cannot be inferred, 1 names a movie that
+#: is not in the fixture KB. Identical to the golden values in scripts/smoke_test.py.
+GOLDEN_COVERAGE = {
+    "total": 5,
+    "compiled_ok": 4,
+    "executed_ok": 3,
+    "compile_fail": 1,
+    "exec_fail": 1,
+}
+GOLDEN_COMPILE_FAIL_REASONS = {"cannot_infer_relation": 1}
+GOLDEN_EXEC_FAIL_REASONS = {"entity_not_in_kb": 1}
+GOLDEN_KG = {"kg_entities": 15, "kg_triples": 17}
+
+
+def _run(script: Path, predictions: Path, run_dir: Path, *extra: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env[PATHS_CONFIG_ENV] = str(SMOKE_PATHS_CONFIG)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--predictions",
+            str(predictions),
+            "--run-dir",
+            str(run_dir),
+            *extra,
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestWrapperReproducesTheStandaloneScript(unittest.TestCase):
+    """The wrapper wraps: same compiler, same executor, same taxonomies, same numbers."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory()
+        root = Path(cls._tmp.name)
+
+        wrapper_dir = root / "wrapper"
+        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, wrapper_dir)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        cls.wrapper_metrics: dict[str, Any] = json.loads(
+            (wrapper_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+        )
+        cls.wrapper_dir = wrapper_dir
+
+        standalone_dir = root / "standalone"
+        proc = _run(STANDALONE, PREDICTIONS_FIXTURE, standalone_dir)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        cls.standalone_metrics: dict[str, Any] = json.loads(
+            (standalone_dir / "kg_eval_metrics.json").read_text(encoding="utf-8")
+        )
+        cls.standalone_dir = standalone_dir
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_the_counts_match_the_standalone_script(self) -> None:
+        for key, expected in GOLDEN_COVERAGE.items():
+            self.assertEqual(
+                self.wrapper_metrics["coverage"][key],
+                self.standalone_metrics[key],
+                f"{key}: wrapper and standalone script disagree",
+            )
+            self.assertEqual(self.wrapper_metrics["coverage"][key], expected, key)
+
+    def test_the_rates_match_the_standalone_script(self) -> None:
+        for key in ("compiled_ok_rate", "executed_ok_rate"):
+            self.assertAlmostEqual(
+                self.wrapper_metrics["coverage"][key], self.standalone_metrics[key], places=9
+            )
+        self.assertAlmostEqual(self.wrapper_metrics["coverage"]["compiled_ok_rate"], 0.8)
+        self.assertAlmostEqual(self.wrapper_metrics["coverage"]["executed_ok_rate"], 0.6)
+
+    def test_the_compile_error_taxonomy_is_preserved_entry_for_entry(self) -> None:
+        self.assertEqual(
+            self.wrapper_metrics["compile_fail_reasons"],
+            self.standalone_metrics["compile_fail_reasons"],
+        )
+        self.assertEqual(
+            self.wrapper_metrics["compile_fail_reasons"], GOLDEN_COMPILE_FAIL_REASONS
+        )
+
+    def test_the_execution_error_categories_are_preserved_entry_for_entry(self) -> None:
+        self.assertEqual(
+            self.wrapper_metrics["exec_fail_reasons"],
+            self.standalone_metrics["exec_fail_reasons"],
+        )
+        self.assertEqual(self.wrapper_metrics["exec_fail_reasons"], GOLDEN_EXEC_FAIL_REASONS)
+
+    def test_the_kg_is_the_same_graph(self) -> None:
+        for key, expected in GOLDEN_KG.items():
+            self.assertEqual(self.wrapper_metrics[key], self.standalone_metrics[key], key)
+            self.assertEqual(self.wrapper_metrics[key], expected, key)
+
+    def test_the_per_item_dumps_are_byte_identical(self) -> None:
+        """The dumps are what an error analysis reads, so equivalence has to hold at the item
+        level and not only at the aggregate. The wrapper writes them under the analysis
+        subdirectory (where the gold comparison looks for success.json); the standalone
+        script writes them at the top of its run directory."""
+        for name in ("success.json", "compile_fail.json", "exec_fail.json"):
+            wrapper_payload = json.loads(
+                (self.wrapper_dir / "analysis" / name).read_text(encoding="utf-8")
+            )
+            standalone_payload = json.loads(
+                (self.standalone_dir / name).read_text(encoding="utf-8")
+            )
+            self.assertEqual(wrapper_payload, standalone_payload, name)
+
+
+class TestGoldComparison(unittest.TestCase):
+    """Exact match and Jaccard against the fabricated MetaQA gold, computed by hand.
+
+    From ``tests/fixtures/data_root/metaqa/kb.txt``: Ada Mireles directed Glass Harbor,
+    Winter Marbles and The Tin Compass; their languages are Esperanto, Volapuk and Esperanto.
+    So the three executable fixture rows produce ``{Ada Mireles}``,
+    ``{Glass Harbor, Winter Marbles, The Tin Compass}`` and ``{Esperanto, Volapuk}``, which
+    are exactly the gold answer sets in ``answers_{1,2,3}hop.txt`` — 3 exact matches, mean
+    Jaccard 1.0. Coverage per hop is 1 answered of 3 / 2 / 2 gold questions.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory()
+        run_dir = Path(cls._tmp.name) / "run"
+        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, run_dir)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        cls.metrics: dict[str, Any] = json.loads(
+            (run_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_all_three_executed_rows_are_exact_matches(self) -> None:
+        executed = self.metrics["answer_accuracy_over_executed_items"]
+        self.assertEqual(executed["total_in_success"], 3)
+        self.assertEqual(executed["total_with_gold"], 3)
+        self.assertEqual(executed["total_exact_match"], 3)
+        self.assertEqual(executed["overall_pct_exact"], 100.0)
+        self.assertEqual(executed["overall_mean_jaccard"], 1.0)
+
+    def test_per_hop_coverage_and_accuracy(self) -> None:
+        per_hop = self.metrics["answer_accuracy_over_executed_items"]["per_hop"]
+        self.assertEqual(per_hop["1"]["total_gold_questions"], 3)
+        self.assertEqual(per_hop["1"]["answered_count"], 1)
+        self.assertEqual(per_hop["1"]["coverage_pct"], 33.33)
+        for hop in ("2", "3"):
+            self.assertEqual(per_hop[hop]["total_gold_questions"], 2)
+            self.assertEqual(per_hop[hop]["answered_count"], 1)
+            self.assertEqual(per_hop[hop]["coverage_pct"], 50.0)
+        for hop in ("1", "2", "3"):
+            self.assertEqual(per_hop[hop]["exact_match_count"], 1)
+            self.assertEqual(per_hop[hop]["mean_jaccard"], 1.0)
+
+    def test_the_two_failing_fixture_rows_have_no_gold_so_the_denominators_agree(self) -> None:
+        """The fixture's compile-fail and exec-fail rows carry invented questions that are
+        in no gold file, so nothing is added to the second denominator here. Pinned because
+        it is the premise of the class below."""
+        over_all = self.metrics["answer_accuracy_over_all_items_with_gold"]
+        self.assertEqual(over_all["items_with_gold_not_executed"], 0)
+        self.assertEqual(over_all["items_with_gold"], 3)
+        self.assertEqual(over_all["pct_exact"], 100.0)
+        self.assertEqual(over_all["mean_jaccard"], 1.0)
+
+
+class TestFailuresCountedRatherThanExcluded(unittest.TestCase):
+    """The second denominator, on hand-written rows whose questions ARE in the fixture gold.
+
+    Three fabricated rows, all with a gold answer in the fixture files:
+
+    - ``who directed Glass Harbor`` decomposes and executes to ``{Ada Mireles}`` — an exact
+      match;
+    - ``what is the genre of Winter Marbles`` is given a step whose relation cannot be
+      inferred, so it is a **compile** failure;
+    - ``who wrote Paper Lanterns`` is given a step naming a movie absent from the KB, so it
+      is an **execution** failure.
+
+    Over executed items with gold that is 1 of 1 = 100%. Over all 3 items with gold it is 1
+    of 3 = 33.33%, and mean Jaccard (1.0 + 0 + 0) / 3 = 0.3333. The gap between the two is
+    the point: the first number says nothing about how often a decomposition ran at all.
+    """
+
+    ROWS = [
+        {
+            "question": "who directed Glass Harbor",
+            "hop_count": 1,
+            "decomposition": "1. Who directed Glass Harbor?",
+        },
+        {
+            "question": "what is the genre of Winter Marbles",
+            "hop_count": 1,
+            "decomposition": "1. Please summarise the plot.",
+        },
+        {
+            "question": "who wrote Paper Lanterns",
+            "hop_count": 1,
+            "decomposition": "1. Who wrote Nonexistent Movie?",
+        },
+    ]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory()
+        root = Path(cls._tmp.name)
+        predictions = root / "failing_rows_with_gold.json"
+        predictions.write_text(json.dumps(cls.ROWS, indent=2), encoding="utf-8")
+        proc = _run(WRAPPER, predictions, root / "run")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        cls.metrics: dict[str, Any] = json.loads(
+            (root / "run" / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_coverage_separates_the_compile_and_execution_failures(self) -> None:
+        coverage = self.metrics["coverage"]
+        self.assertEqual(coverage["total"], 3)
+        self.assertEqual(coverage["compiled_ok"], 2)
+        self.assertEqual(coverage["executed_ok"], 1)
+        self.assertEqual(coverage["compile_fail"], 1)
+        self.assertEqual(coverage["exec_fail"], 1)
+        self.assertEqual(self.metrics["compile_fail_reasons"], {"cannot_infer_relation": 1})
+        self.assertEqual(self.metrics["exec_fail_reasons"], {"entity_not_in_kb": 1})
+
+    def test_the_executed_only_denominator_hides_the_failures(self) -> None:
+        executed = self.metrics["answer_accuracy_over_executed_items"]
+        self.assertEqual(executed["total_with_gold"], 1)
+        self.assertEqual(executed["total_exact_match"], 1)
+        self.assertEqual(executed["overall_pct_exact"], 100.0)
+        self.assertEqual(executed["overall_mean_jaccard"], 1.0)
+
+    def test_the_all_items_denominator_counts_them(self) -> None:
+        over_all = self.metrics["answer_accuracy_over_all_items_with_gold"]
+        self.assertEqual(over_all["items_with_gold"], 3)
+        self.assertEqual(over_all["items_with_gold_executed"], 1)
+        self.assertEqual(over_all["items_with_gold_not_executed"], 2)
+        self.assertEqual(over_all["exact_match_count"], 1)
+        self.assertEqual(over_all["pct_exact"], 33.33)
+        self.assertEqual(over_all["mean_jaccard"], 0.3333)
+        self.assertEqual(over_all["items_with_an_empty_gold_set"], 0)
+        self.assertNotIn("mean_jaccard_note", over_all)
+
+
+class TestGragIsNotWiredAndSaysSo(unittest.TestCase):
+    """The labelling guard. ADR 0006 routes MetaQA end-to-end through the supervisor's GRAG;
+    this path does not, and no artifact may leave that ambiguous."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory()
+        run_dir = Path(cls._tmp.name) / "run"
+        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, run_dir)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        cls.metrics: dict[str, Any] = json.loads(
+            (run_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+        )
+        cls.snapshot: dict[str, Any] = json.loads(
+            (run_dir / "metaqa_e2e_config.json").read_text(encoding="utf-8")
+        )
+        cls.note = (run_dir / "metaqa_e2e_notes.md").read_text(encoding="utf-8")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_the_metrics_record_that_grag_is_not_wired(self) -> None:
+        self.assertFalse(self.metrics["backend"]["grag_wired"])
+        self.assertIn("not wired", self.metrics["backend"]["grag_status"])
+        self.assertEqual(
+            self.metrics["backend"]["label"], "metaqa_compile_execute_direct_kg"
+        )
+
+    def test_the_snapshot_and_the_run_note_record_it_too(self) -> None:
+        self.assertFalse(self.snapshot["grag_wired"])
+        self.assertIn("GRAG is NOT wired", self.note)
+
+    def test_no_model_is_loaded_in_this_path(self) -> None:
+        self.assertFalse(self.metrics["backend"]["model_loaded"])
+
+    def test_the_composition_is_recorded(self) -> None:
+        """A reader has to be able to see which existing code produced the numbers."""
+        composed = self.metrics["composed_from"]
+        self.assertIn("evaluate_decompositions.py", composed["compile_execute"])
+        self.assertIn("compare_answer_accuracy.py", composed["gold_comparison"])
+        self.assertIn("kg.py", composed["kg"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_metaqa_compile_execute.py
+++ b/tests/test_metaqa_compile_execute.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Checks for the MetaQA compile-execute wrapper (``scripts/run_metaqa_compile_execute.py``).
 
-Four things are pinned here, all on the fabricated fixtures under ``tests/fixtures/`` and
-with no model and no network:
+Everything here runs on fabricated fixtures (or hand-written rows and a throwaway data root
+built in the test), with no model and no network. Pinned:
 
 1. **Fixture equivalence.** The wrapper reproduces the standalone
    ``scripts/evaluate_decompositions.py`` outcomes *exactly* — the same counts, the same
@@ -19,6 +19,15 @@ with no model and no network:
 4. **The GRAG labelling.** GRAG is not wired, and every artifact has to say so. A test
    guards it because the failure mode is silent: a run that looked like a GRAG number would
    be a claim nobody made.
+5. **A measured zero is not a null** (PR #42 review, finding 1) — a run where every item
+   fails reports 0.0%, and only a run with no gold at all reports null.
+6. **One rule for every item** (finding 2) — an unexecuted item with an empty gold set is
+   scored by the block's stated definition on *both* metrics, with the surprise named rather
+   than nulled.
+7. **Evaluation-set identity and upstream provenance** (finding 3) — the refusal, its
+   recorded opt-out, the question-set fingerprint, and the decomposer run's commit/config.
+8. **No model is loaded here** (nit 3) — an ADR 0016 source-level guard with negative
+   controls, because ``backend.model_loaded: False`` is otherwise an unguarded constant.
 
 Run::
 
@@ -63,6 +72,13 @@ GOLDEN_EXEC_FAIL_REASONS = {"entity_not_in_kb": 1}
 GOLDEN_KG = {"kg_entities": 15, "kg_triples": 17}
 
 
+#: Every fixture and hand-written input here contains at least one question that is in no
+#: gold file, which the eval-set assertion refuses for an experiment arm. A fixture run is
+#: not an arm, so the recorded opt-out is passed — the same convention the answerer's fixture
+#: runs use. ``TestEvaluationSetIdentity`` is where the assertion itself is exercised.
+UNPINNED = "--allow-unpinned-eval-set"
+
+
 def _run(script: Path, predictions: Path, run_dir: Path, *extra: str) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env[PATHS_CONFIG_ENV] = str(SMOKE_PATHS_CONFIG)
@@ -92,7 +108,7 @@ class TestWrapperReproducesTheStandaloneScript(unittest.TestCase):
         root = Path(cls._tmp.name)
 
         wrapper_dir = root / "wrapper"
-        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, wrapper_dir)
+        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, wrapper_dir, UNPINNED)
         assert proc.returncode == 0, proc.stdout + proc.stderr
         cls.wrapper_metrics: dict[str, Any] = json.loads(
             (wrapper_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
@@ -179,7 +195,7 @@ class TestGoldComparison(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls._tmp = tempfile.TemporaryDirectory()
         run_dir = Path(cls._tmp.name) / "run"
-        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, run_dir)
+        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, run_dir, UNPINNED)
         assert proc.returncode == 0, proc.stdout + proc.stderr
         cls.metrics: dict[str, Any] = json.loads(
             (run_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
@@ -262,7 +278,7 @@ class TestFailuresCountedRatherThanExcluded(unittest.TestCase):
         root = Path(cls._tmp.name)
         predictions = root / "failing_rows_with_gold.json"
         predictions.write_text(json.dumps(cls.ROWS, indent=2), encoding="utf-8")
-        proc = _run(WRAPPER, predictions, root / "run")
+        proc = _run(WRAPPER, predictions, root / "run", UNPINNED)
         assert proc.returncode == 0, proc.stdout + proc.stderr
         cls.metrics: dict[str, Any] = json.loads(
             (root / "run" / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
@@ -309,7 +325,7 @@ class TestGragIsNotWiredAndSaysSo(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls._tmp = tempfile.TemporaryDirectory()
         run_dir = Path(cls._tmp.name) / "run"
-        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, run_dir)
+        proc = _run(WRAPPER, PREDICTIONS_FIXTURE, run_dir, UNPINNED)
         assert proc.returncode == 0, proc.stdout + proc.stderr
         cls.metrics: dict[str, Any] = json.loads(
             (run_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
@@ -343,6 +359,526 @@ class TestGragIsNotWiredAndSaysSo(unittest.TestCase):
         self.assertIn("evaluate_decompositions.py", composed["compile_execute"])
         self.assertIn("compare_answer_accuracy.py", composed["gold_comparison"])
         self.assertIn("kg.py", composed["kg"])
+
+
+class TestEveryItemFailing(unittest.TestCase):
+    """PR #42 review, finding 1: a run where nothing executes must report 0.0, not null.
+
+    Two fabricated rows, both with a gold answer in the fixture files, both given a step
+    whose relation cannot be inferred — so both are **compile** failures and nothing reaches
+    the executor. The executed-only block is genuinely unmeasured (0 items, so its mean is
+    null by ``compare_answer_accuracy``'s own rule), but the all-items block has 2 items with
+    gold and measured them both: exact 0 of 2 = **0.0%**, mean Jaccard (0 + 0) / 2 = **0.0**.
+    Reporting null there would say "unmeasured" about a measured floor — the worst kind of
+    wrong number, because it hides a total failure as a missing one.
+    """
+
+    ROWS = [
+        {
+            "question": "what is the genre of Winter Marbles",
+            "hop_count": 1,
+            "decomposition": "1. Please summarise the plot.",
+        },
+        {
+            "question": "who wrote Paper Lanterns",
+            "hop_count": 1,
+            "decomposition": "1. Please summarise the plot.",
+        },
+    ]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory()
+        root = Path(cls._tmp.name)
+        predictions = root / "all_failing.json"
+        predictions.write_text(json.dumps(cls.ROWS, indent=2), encoding="utf-8")
+        proc = _run(WRAPPER, predictions, root / "run")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        cls.metrics: dict[str, Any] = json.loads(
+            (root / "run" / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_nothing_executed(self) -> None:
+        coverage = self.metrics["coverage"]
+        self.assertEqual(coverage["total"], 2)
+        self.assertEqual(coverage["compiled_ok"], 0)
+        self.assertEqual(coverage["executed_ok"], 0)
+        self.assertEqual(coverage["compile_fail"], 2)
+        self.assertEqual(self.metrics["compile_fail_reasons"], {"cannot_infer_relation": 2})
+
+    def test_the_executed_only_block_is_null_because_it_is_genuinely_unmeasured(self) -> None:
+        executed = self.metrics["answer_accuracy_over_executed_items"]
+        self.assertEqual(executed["total_with_gold"], 0)
+        self.assertIsNone(executed["overall_pct_exact"])
+        self.assertIsNone(executed["overall_mean_jaccard"])
+        self.assertEqual(executed["overall_jaccard_sum"], 0.0)
+
+    def test_the_all_items_block_reports_a_measured_zero(self) -> None:
+        over_all = self.metrics["answer_accuracy_over_all_items_with_gold"]
+        self.assertEqual(over_all["items_with_gold"], 2)
+        self.assertEqual(over_all["items_with_gold_executed"], 0)
+        self.assertEqual(over_all["items_with_gold_not_executed"], 2)
+        self.assertEqual(over_all["exact_match_count"], 0)
+        self.assertEqual(over_all["pct_exact"], 0.0)
+        self.assertEqual(over_all["mean_jaccard"], 0.0)
+        self.assertEqual(over_all["jaccard_sum"], 0.0)
+        self.assertIsNotNone(over_all["pct_exact"], "a measured 0 must not be reported as null")
+
+    def test_null_is_still_reported_when_no_item_has_gold_at_all(self) -> None:
+        """The one case that IS unmeasured: nothing to compare against. The fixture's two
+        failing rows carry questions in no gold file, so this run measures nothing and both
+        numbers are null rather than a fabricated 0."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            predictions = root / "no_gold.json"
+            predictions.write_text(
+                json.dumps(
+                    [
+                        {
+                            "question": "a step whose relation cannot be inferred",
+                            "hop_count": 1,
+                            "decomposition": "1. Please summarise the plot.",
+                        }
+                    ],
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            proc = _run(WRAPPER, predictions, root / "run", UNPINNED)
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            metrics = json.loads(
+                (root / "run" / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+            )
+        over_all = metrics["answer_accuracy_over_all_items_with_gold"]
+        self.assertEqual(over_all["items_with_gold"], 0)
+        self.assertIsNone(over_all["pct_exact"])
+        self.assertIsNone(over_all["mean_jaccard"])
+
+
+class TestEmptyGoldSetIsScoredByTheStatedDefinition(unittest.TestCase):
+    """PR #42 review, finding 2: the empty-gold guard must not be asymmetric.
+
+    ``jaccard(empty, empty)`` is 1.0, so by this block's own definition — exact match iff
+    Jaccard reaches the threshold — an unexecuted item with an empty gold set **is** an exact
+    match. The first version guarded only the mean, so a run with 1 executed exact match and
+    1 failed row with empty gold reported 50.0% next to a definition that said 100.0%. The
+    fix applies one rule to every item; the surprise is named in ``empty_gold_set_note``
+    instead of being papered over with a null.
+
+    This needs a gold file with an empty answer set, which the committed fixtures do not
+    have (MetaQA gold answers are never empty), so the test builds a throwaway data root and
+    a throwaway paths config pointing at it. Hand-computed: exact 2 of 2 = 100.0%, mean
+    Jaccard (1.0 + 1.0) / 2 = 1.0.
+    """
+
+    ROWS = [
+        {
+            "question": "who directed Glass Harbor",
+            "hop_count": 1,
+            "decomposition": "1. Who directed Glass Harbor?",
+        },
+        {
+            "question": "a question whose gold answers are blank",
+            "hop_count": 1,
+            "decomposition": "1. Please summarise the plot.",
+        },
+    ]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._data = tempfile.TemporaryDirectory()
+        # The paths-config override must live inside the repo (run_config.load_paths binds it
+        # there deliberately), so it goes in a throwaway directory under configs/.
+        cls._cfg = tempfile.TemporaryDirectory(dir=REPO_ROOT / "configs")
+        data_root = Path(cls._data.name) / "data_root"
+        metaqa = data_root / "metaqa"
+        metaqa.mkdir(parents=True)
+        (metaqa / "kb.txt").write_text(
+            (FIXTURES / "data_root" / "metaqa" / "kb.txt").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        (metaqa / "refined_1hop.txt").write_text(
+            "who directed Glass Harbor\na question whose gold answers are blank\n",
+            encoding="utf-8",
+        )
+        # Line 2 is a separator with nothing around it: every part is empty, so the gold set
+        # for that question is empty while the line-for-line alignment still holds.
+        (metaqa / "answers_1hop.txt").write_text("Ada Mireles\n|\n", encoding="utf-8")
+
+        paths_config = Path(cls._cfg.name) / "paths_probe.json"
+        paths_config.write_text(
+            json.dumps(
+                {
+                    "_note": "throwaway paths config for tests/test_metaqa_compile_execute.py",
+                    "data_root": str(data_root),
+                    "runs_root": str(Path(cls._data.name) / "runs"),
+                    "datasets": {
+                        "metaqa_kb": "metaqa/kb.txt",
+                        "metaqa_questions_template": "metaqa/refined_{hop}hop.txt",
+                        "metaqa_answers_template": "metaqa/answers_{hop}hop.txt",
+                    },
+                    "repo": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        predictions = Path(cls._data.name) / "empty_gold.json"
+        predictions.write_text(json.dumps(cls.ROWS, indent=2), encoding="utf-8")
+        run_dir = Path(cls._data.name) / "run"
+
+        env = os.environ.copy()
+        env[PATHS_CONFIG_ENV] = str(paths_config)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(WRAPPER),
+                "--predictions",
+                str(predictions),
+                "--run-dir",
+                str(run_dir),
+            ],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        cls.metrics: dict[str, Any] = json.loads(
+            (run_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._data.cleanup()
+        cls._cfg.cleanup()
+
+    def test_the_empty_gold_row_is_counted(self) -> None:
+        over_all = self.metrics["answer_accuracy_over_all_items_with_gold"]
+        self.assertEqual(over_all["items_with_gold"], 2)
+        self.assertEqual(over_all["items_with_gold_not_executed"], 1)
+        self.assertEqual(over_all["items_with_an_empty_gold_set"], 1)
+
+    def test_exact_match_and_jaccard_agree_with_the_stated_definition(self) -> None:
+        over_all = self.metrics["answer_accuracy_over_all_items_with_gold"]
+        self.assertEqual(over_all["exact_match_count_executed"], 1)
+        self.assertEqual(over_all["exact_match_count_not_executed"], 1)
+        self.assertEqual(over_all["exact_match_count"], 2)
+        self.assertEqual(over_all["pct_exact"], 100.0)
+        self.assertEqual(over_all["mean_jaccard"], 1.0)
+
+    def test_the_surprise_is_named_rather_than_hidden(self) -> None:
+        over_all = self.metrics["answer_accuracy_over_all_items_with_gold"]
+        self.assertIn("empty_gold_set_note", over_all)
+        self.assertIn("empty-vs-empty", over_all["empty_gold_set_note"])
+        # The old asymmetric behaviour nulled the mean; it must not come back.
+        self.assertIsNotNone(over_all["mean_jaccard"])
+        self.assertNotIn("mean_jaccard_note", over_all)
+
+    def test_the_asymmetry_with_musique_normalization_is_stated(self) -> None:
+        """Finding 4: the element-matching rule here is strip-only and case-sensitive, unlike
+        MuSiQue EM's SQuAD normalization. Recorded, not silently changed."""
+        definitions = self.metrics["metric_definitions"]
+        self.assertIn("answer_normalization", definitions)
+        self.assertIn("CASE-SENSITIVE", definitions["answer_normalization"])
+        self.assertIn("normalize_answer", definitions["answer_normalization"])
+        over_all = self.metrics["answer_accuracy_over_all_items_with_gold"]
+        self.assertIn("asymmetry", over_all["definition"])
+
+
+class TestEvaluationSetIdentity(unittest.TestCase):
+    """PR #42 review, finding 3: which evaluation set was scored has to be in the artifact.
+
+    A row whose question is in no gold file is absent from every accuracy denominator, so
+    the run silently reports over a smaller set than it read. The MuSiQue side refuses that
+    (``run_decomposer.assert_pinned_eval_set``) with a recorded opt-out; this mirrors it.
+    """
+
+    def test_a_run_with_ungolded_questions_is_refused_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = _run(WRAPPER, PREDICTIONS_FIXTURE, Path(tmp) / "run")
+        self.assertNotEqual(proc.returncode, 0)
+        output = proc.stdout + proc.stderr
+        self.assertIn("no MetaQA gold answer", output)
+        self.assertIn("--allow-unpinned-eval-set", output)
+
+    def test_the_opt_out_is_recorded_in_the_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            proc = _run(WRAPPER, PREDICTIONS_FIXTURE, run_dir, UNPINNED)
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            metrics = json.loads(
+                (run_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+            )
+        record = metrics["evaluation_set"]
+        self.assertFalse(record["pinned"])
+        self.assertTrue(record["allow_unpinned_override"])
+        self.assertEqual(record["rows_processed"], 5)
+        self.assertEqual(record["unmatched_question_count"], 2)
+        self.assertEqual(record["rows_per_hop"], {"1": 3, "2": 1, "3": 1})
+        self.assertEqual(record["rows_with_gold_per_hop"], {"1": 1, "2": 1, "3": 1})
+        self.assertEqual(record["gold_questions_available_per_hop"], {"1": 3, "2": 2, "3": 2})
+
+    def test_a_fully_golded_run_is_pinned_with_no_flag(self) -> None:
+        rows = [
+            {
+                "question": "who directed Glass Harbor",
+                "hop_count": 1,
+                "decomposition": "1. Who directed Glass Harbor?",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            predictions = root / "pinned.json"
+            predictions.write_text(json.dumps(rows), encoding="utf-8")
+            proc = _run(WRAPPER, predictions, root / "run")
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            metrics = json.loads(
+                (root / "run" / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+            )
+        record = metrics["evaluation_set"]
+        self.assertTrue(record["pinned"])
+        self.assertEqual(record["unmatched_question_count"], 0)
+        self.assertFalse(record["allow_unpinned_override"])
+
+    def test_the_question_set_fingerprint_identifies_the_set(self) -> None:
+        """Equal fingerprints mean the same questions were scored; that is what makes two
+        MetaQA runs a comparison (CLAUDE.md: same evaluation set, or it is not one)."""
+        one = [
+            {
+                "question": "who directed Glass Harbor",
+                "hop_count": 1,
+                "decomposition": "1. Who directed Glass Harbor?",
+            }
+        ]
+        # Same question, different decomposition: the same evaluation set, so the same
+        # fingerprint. That is the point - the fingerprint identifies the SET, not the arm.
+        two = [{**one[0], "decomposition": "1. Who is the director of Glass Harbor?"}]
+        three = [
+            {
+                "question": "what is the genre of Winter Marbles",
+                "hop_count": 1,
+                "decomposition": "1. What is the genre of Winter Marbles?",
+            }
+        ]
+        digests = []
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for index, rows in enumerate((one, two, three)):
+                predictions = root / f"rows{index}.json"
+                predictions.write_text(json.dumps(rows), encoding="utf-8")
+                proc = _run(WRAPPER, predictions, root / f"run{index}")
+                self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+                metrics = json.loads(
+                    (root / f"run{index}" / "metaqa_e2e_metrics.json").read_text(
+                        encoding="utf-8"
+                    )
+                )
+                digests.append(metrics["evaluation_set"]["question_set_sha256"])
+        self.assertEqual(digests[0], digests[1], "same questions must fingerprint the same")
+        self.assertNotEqual(digests[0], digests[2], "different questions must differ")
+
+    def test_the_predictions_file_is_content_addressed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            _run(WRAPPER, PREDICTIONS_FIXTURE, run_dir, UNPINNED)
+            metrics = json.loads(
+                (run_dir / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+            )
+        digest = metrics["evaluation_set"]["predictions_sha256"]
+        self.assertEqual(len(digest), 64)
+        self.assertEqual(
+            digest,
+            __import__("hashlib")
+            .sha256(PREDICTIONS_FIXTURE.read_bytes())
+            .hexdigest(),
+        )
+
+
+class TestUpstreamProvenance(unittest.TestCase):
+    """Finding 3, second half: a MetaQA number has to be traceable to the run that produced
+    the decompositions, not just to a file path."""
+
+    ROWS = [
+        {
+            "question": "who directed Glass Harbor",
+            "hop_count": 1,
+            "decomposition": "1. Who directed Glass Harbor?",
+        }
+    ]
+
+    def _run_with_sibling(self, sibling: dict[str, Any] | None) -> dict[str, Any]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            decomposer_run = root / "20260822_101500"
+            decomposer_run.mkdir()
+            predictions = decomposer_run / "results.json"
+            predictions.write_text(json.dumps(self.ROWS), encoding="utf-8")
+            if sibling is not None:
+                (decomposer_run / "config.json").write_text(
+                    json.dumps(sibling), encoding="utf-8"
+                )
+            proc = _run(WRAPPER, predictions, root / "run")
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            return json.loads(
+                (root / "run" / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+            )
+
+    def test_a_missing_snapshot_is_recorded_not_inferred(self) -> None:
+        upstream = self._run_with_sibling(None)["upstream_decomposer_run"]
+        self.assertFalse(upstream["found"])
+        self.assertIn("no decomposer run snapshot", upstream["note"])
+
+    def test_the_run_id_commit_and_config_are_carried_through(self) -> None:
+        snapshot = {
+            "script": "run_decomposer.py",
+            "run_id": "20260822_101500",
+            "component": "decomposer",
+            "model": "mistral_7b_instruct",
+            "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+            "condition": "unguided",
+            "shared_config": "configs/decomposer_musique.json",
+            "seed": 42,
+            "git": {"commit": "0123456789abcdef", "branch": "main", "dirty": False},
+        }
+        upstream = self._run_with_sibling(snapshot)["upstream_decomposer_run"]
+        self.assertTrue(upstream["found"])
+        self.assertEqual(upstream["run_id"], "20260822_101500")
+        self.assertEqual(upstream["commit"], "0123456789abcdef")
+        self.assertEqual(upstream["branch"], "main")
+        self.assertFalse(upstream["dirty"])
+        self.assertEqual(upstream["model"], "mistral_7b_instruct")
+        self.assertEqual(upstream["shared_config"], "configs/decomposer_musique.json")
+
+    def test_an_unreadable_snapshot_is_reported_not_crashed_on(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            decomposer_run = root / "run_dir"
+            decomposer_run.mkdir()
+            (decomposer_run / "results.json").write_text(
+                json.dumps(self.ROWS), encoding="utf-8"
+            )
+            (decomposer_run / "config.json").write_text("{not json", encoding="utf-8")
+            proc = _run(WRAPPER, decomposer_run / "results.json", root / "out")
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            metrics = json.loads(
+                (root / "out" / "metaqa_e2e_metrics.json").read_text(encoding="utf-8")
+            )
+        self.assertFalse(metrics["upstream_decomposer_run"]["found"])
+        self.assertIn("could not read", metrics["upstream_decomposer_run"]["note"])
+
+
+class TestMissingDumpIsRefused(unittest.TestCase):
+    """Nit 2: a missing dump must not be skipped silently.
+
+    Both readers of the dumps refuse rather than continue, because a skipped dump would drop
+    rows out of the second denominator with no trace in the output.
+    """
+
+    def test_the_readers_refuse_a_missing_dump(self) -> None:
+        import run_metaqa_compile_execute as wrapper
+
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp)
+            with self.assertRaises(SystemExit) as caught:
+                wrapper.score_failed_items(empty, gold_by_hop={}, exact_threshold=1.0)
+            self.assertIn("compile_fail.json", str(caught.exception))
+            with self.assertRaises(SystemExit) as caught:
+                wrapper.processed_rows(empty)
+            self.assertIn("success.json", str(caught.exception))
+
+
+class TestNoModelIsLoadedGuard(unittest.TestCase):
+    """ADR 0016 source-level guard for ``backend.model_loaded: False`` (nit 3).
+
+    That field is an unguarded constant: nothing in a CPU run can notice if someone later
+    adds a model load to this path, and the value would then be a false claim in every
+    metrics JSON — while the ~8B ceiling assertion (``src/model_size.py``) would also be
+    missing. Only a real run could violate it, so per ADR 0016 the invariant is asserted
+    against the source, with negative controls that re-break it in memory.
+    """
+
+    #: Names whose presence in this script would mean a model is being loaded.
+    LOADER_NAMES = frozenset(
+        {"load_model", "from_pretrained", "AutoModelForCausalLM", "AutoTokenizer", "pipeline"}
+    )
+    #: Top-level modules that only a model-loading path needs.
+    MODEL_MODULES = frozenset({"torch", "transformers", "peft", "accelerate", "bitsandbytes"})
+
+    @staticmethod
+    def model_loading_sites(source: str) -> set[str]:
+        """Every marker in ``source`` that would mean a model is loaded here."""
+        import ast
+
+        found: set[str] = set()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = alias.name.split(".")[0]
+                    if root in TestNoModelIsLoadedGuard.MODEL_MODULES:
+                        found.add(f"import {root}")
+            elif isinstance(node, ast.ImportFrom):
+                root = (node.module or "").split(".")[0]
+                if root in TestNoModelIsLoadedGuard.MODEL_MODULES:
+                    found.add(f"from {root}")
+            elif isinstance(node, ast.Call):
+                func = node.func
+                name = (
+                    func.attr
+                    if isinstance(func, ast.Attribute)
+                    else func.id
+                    if isinstance(func, ast.Name)
+                    else None
+                )
+                if name in TestNoModelIsLoadedGuard.LOADER_NAMES:
+                    found.add(f"call {name}")
+        return found
+
+    def test_the_wrapper_loads_no_model(self) -> None:
+        self.assertEqual(
+            self.model_loading_sites(WRAPPER.read_text(encoding="utf-8")),
+            set(),
+            "this script reports backend.model_loaded false; a model-loading site here "
+            "would make that a false claim and would also need the src/model_size.py "
+            "ceiling assertion",
+        )
+
+    def test_the_metrics_field_and_the_guard_agree(self) -> None:
+        """The guard is only worth having if it protects the field that is actually written."""
+        source = WRAPPER.read_text(encoding="utf-8")
+        self.assertIn('"model_loaded": False', source)
+
+    def test_a_torch_import_is_caught(self) -> None:
+        source = WRAPPER.read_text(encoding="utf-8")
+        self.assertEqual(self.model_loading_sites(source), set(), "base source must be clean")
+        broken = source + "\nimport torch\n"
+        self.assertIn("import torch", broken)
+        self.assertIn("import torch", self.model_loading_sites(broken))
+
+    def test_a_loader_call_is_caught(self) -> None:
+        source = WRAPPER.read_text(encoding="utf-8")
+        anchor = "def main() -> None:"
+        self.assertIn(anchor, source, "the negative control's anchor moved; fix the control")
+        broken = source.replace(
+            anchor, anchor + "\n    tokenizer, model = load_model('x', {}, 'cpu', 'none')", 1
+        )
+        self.assertNotEqual(broken, source, "the negative control did not modify the source")
+        self.assertIn("call load_model", self.model_loading_sites(broken))
+
+    def test_a_from_pretrained_call_is_caught(self) -> None:
+        source = WRAPPER.read_text(encoding="utf-8")
+        anchor = "def main() -> None:"
+        self.assertIn(anchor, source, "the negative control's anchor moved; fix the control")
+        broken = source.replace(
+            anchor, anchor + "\n    m = SomeClass.from_pretrained('x')", 1
+        )
+        self.assertNotEqual(broken, source, "the negative control did not modify the source")
+        self.assertIn("call from_pretrained", self.model_loading_sites(broken))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Completes the code for both halves of issue #16 as far as it can be completed without GRAG. **Refs #16** — evaluation runs on real decompositions are a separate experiment lane, and the GRAG dependency stays blocked and recorded.

## What was already there (important for reviewing the delta)

Most of the MuSiQue half **already exists**: PR #32 (`f83bd04`) shipped `components/answerer/run_answerer.py`, which takes any decomposer run's `results.json`, chains `#k`/`[#k]` references by substituting previous answers, and reports MuSiQue's official answer EM/F1 overall and per gold hop, with the reader loaded through `src/model_size.py` against `answerer_max_params` (8e9). ADR 0019 settles the three methodology choices behind it. Nothing in that design was redesigned here.

Likewise both MetaQA pieces existed as **separate scripts run by hand**: `scripts/evaluate_decompositions.py` (compile + execute against the KG, with its taxonomies) and `scripts/compare_answer_accuracy.py` (Jaccard / exact match against MetaQA gold).

So this PR is two deltas, one per commit.

## Commit 1 — `cec1d51` MuSiQue step-level failure taxonomy

`src/step_failures.py` (new, pure, no I/O) plus wiring in `run_answerer.py`. Each sub-question gets a flag set; `metrics.step_failure_taxonomy` carries an all-steps block and a final-step-only block (the final step's answer *is* the item's prediction, so a flag there is decisive for EM/F1 in a way an earlier one is not), and each step record in the per-item file gains `failure_flags` (schema bumped to `musique_answer_per_item/2`).

Categories that fire: `broken_reference`, `generation_error`, `empty_answer`, `not_executed`. They are **counters, not a partition** — a step can be asked with a placeholder still in it *and* come back empty, and inventing a precedence rule to pick one "cause" is not a call an agent should make.

**Three categories the brief named are declared unavailable with a reason, not reported as zero** — this is the one place the brief and ADR 0019 collide, and per the brief the ADR wins:

| category | why it is absent |
|---|---|
| `empty_retrieval` | **Not applicable.** ADR 0019 decision 2 fixes the context to the item's full paragraph list and `run_answerer.py` refuses any other `context.policy`. There is no retrieval step that could come back empty. (The MetaQA path has the analogous notion.) |
| `unresolvable_entity` | **Not applicable.** No entity linker, no KB in the MuSiQue path — a sub-question is asked over paragraphs as text. The MetaQA path reports the analogue as `entity_not_in_kb`. |
| `wrong_intermediate_answer` | **Unmeasured, not zero.** It needs a gold answer per sub-question. MuSiQue ships them, but ADR 0019 deliberately keeps gold sub-answers out of this path; reading them as a diagnostic would be a new methodology choice. The final step is the exception and is already scored — an item's `answer_em`/`answer_f1` *is* the correctness of its last step. **Decision for Jahid**, not for this PR. |

## Commit 2 — `6737bdd` MetaQA compile-execute wrapper

`scripts/run_metaqa_compile_execute.py` + `configs/metaqa_compile_execute.json`. It **imports** `evaluate_decomposition_rate`, `run_analysis`, `jaccard` and `build_metaqa_kg`; the compiler is untouched (its step-template regexes and relation rules are deliberately code), and both taxonomies pass through verbatim. The config owns **no methodology knob**: every knob is read from `metaqa_kg_eval.json` and `answer_accuracy.json`, so no value gets a second home to drift in. No model is loaded anywhere in this path.

**Two denominators**, both with their definition attached in the metrics JSON:

- **over executed items with gold** — what `compare_answer_accuracy.py` has always reported. It excludes every compile and execution failure, so it is conditional.
- **over all items with gold** — every prediction whose question has a gold answer, with a failure counted as the empty answer set it produced (`jaccard(∅, gold)`, computed with the imported scorer, not hard-coded to 0; an item with an empty gold set would be counted and the mean reported as null rather than silently scored 1.0). This is the MuSiQue backend's own convention — a failed item there is *inside* the reported EM/F1 — so it is the denominator that can be read against a MuSiQue number for the cross-dataset comparison of issue #41. **Which of the two is the headline MetaQA metric is Jahid's call**; the script reports both and picks neither.

## GRAG — the blocker, precisely

**GRAG is not wired and is not stubbed.** ADR 0006 §2 routes MetaQA end-to-end evaluation *through the supervisor's GRAG system*. I searched both repos for any interface artifact on 2026-08-22:

- **This repo (`Thesis---QAv2`)**: word-boundary search for `grag` / `g-rag` / `graph-rag` across `*.py *.md *.json *.txt *.ipynb *.yaml *.sh`. **Four hits, all prose, zero code**: ADR 0006 (§2 + Consequences), ADR 0017 (triage: "the GRAG handover, which Jahid chases with the supervisor himself"), ADR 0023 item 3, and `docs/meetings/2026-08-12-supervisor-meeting-transcript-crosscheck.md`.
- **The v1 repo (`/cta/users/fyilmaz/Thesis---QA`, read-only, nothing copied out)**: the same word-boundary search returns **zero** hits outside dataset text (the only substring matches are the entity "Graglia" inside MuSiQue paragraphs). A broader search for `endpoint` / `api_url` / `base_url` / `localhost:PORT` / `requests.post` / non-reference `http(s)://` returns only a HuggingFace model link and a Jira URL. There is no GRAG client, config, stub, notebook or note in v1 either.

What the record actually says: `docs/meetings/2026-08-12-...md` — "[33:55] *you can connect it to my method, G-Rack*"; "[1:14:13] *We can run MetaQA data on GRAG that you have*" is ambiguous about who has it; and **"no handover date, repo, or access mechanism was discussed."**

### The missing pieces Jahid must obtain from his supervisor

1. **Access** — a repository, container, or a running endpoint, plus credentials if any. Nothing exists locally.
2. **The call interface** — is GRAG a Python library, a CLI, or an HTTP service? What is the function/endpoint signature?
3. **The input contract** — how sub-questions are handed over: one call per sub-question or the whole decomposition at once? Plain text, or a typed/parsed form? Is `[#k]` reference chaining GRAG's job or the caller's (this repo's answerer does it; the MetaQA compiler resolves refs as op inputs — the two are not interchangeable)?
4. **The output contract** — an answer string, a ranked entity list, or a set? MetaQA's gold answers are **sets**, and coverage/exact-match/Jaccard are set metrics, so a single-string return would need a documented conversion rule before any number is comparable.
5. **Which knowledge source GRAG indexes** — MetaQA's `kb.txt`, its own graph, or a text corpus. This decides whether a GRAG number is comparable with the compile-execute number in this PR at all.
6. **Whether GRAG loads a model, and which** — the ~8B ceiling is asserted at every model load in this repo (`src/model_size.py`). If GRAG loads its own reader, the ceiling has to be asserted there too or the arm is outside the standing constraint.
7. **A handover date**, so the calendar (experiments end October 2026) can absorb it.

Until those exist, the MetaQA half of issue #16 is **blocked**, and the compile-execute path in this PR is its own labelled path — `backend_label: metaqa_compile_execute_direct_kg`, `backend.grag_wired: false`, plus a `grag_status` sentence in every metrics JSON, config snapshot and run note, guarded by `TestGragIsNotWiredAndSaysSo`.

## Evidence (ran-X-observed-Y, all CPU, no GPU touched)

```
$ .venv/bin/python -m unittest discover -s tests
Ran 325 tests in 159.832s      # before this PR's second commit
OK
$ .venv/bin/python -m unittest tests.test_answer_musique.TestStepFailureTaxonomy \
      tests.test_answer_musique.TestStepFailureTaxonomyEndToEnd
Ran 15 tests ... OK
$ .venv/bin/python -m unittest tests.test_metaqa_compile_execute
Ran 16 tests in 8.755s ... OK
$ .venv/bin/python scripts/smoke_test.py
[smoke] 38/38 stages passed
```

CPU dry-run of each backend on the synthetic fixtures:

- **MuSiQue** — `run_answerer.py --predictions tests/fixtures/predictions/decomposer_results_musique.json --dry-run`: 4 items joined of 5, 11 sub-questions, `broken_reference: 0`, `not_executed: 11`. On hand-written rows with a malformed `[#1` and a forward `[#9]`: 5 steps, `broken_reference: 2`, `references_unresolved: 2`, final-step block 2 steps of which 1 broken, and the malformed reference left verbatim in the sub-question.
- **MetaQA** — `run_metaqa_compile_execute.py --predictions tests/fixtures/predictions/decomposer_results_metaqa.json`: 5 items, compiled 4 (80.00%), executed 3 (60.00%), `{'cannot_infer_relation': 1}`, `{'entity_not_in_kb': 1}`, 3 of 3 exact / mean Jaccard 1.0, per-hop coverage 33.33% / 50.0% / 50.0%. **Identical to the standalone `evaluate_decompositions.py` on the same input, dumps byte-identical**, and identical to the golden values `scripts/smoke_test.py::kg_eval` has always asserted.

Every number above is from the fabricated fixtures. **They are not an evaluation set and say nothing about the research question** — they say the code paths run and write their artifacts. No experiment-log entry is claimed, because no experiment was run.

## Constraints

- No closed commercial model anywhere; no model scores, rates or judges anything in either path (EM/F1 and Jaccard are string/set metrics).
- Fixed seed threaded from config; the wrapper records which seed governed and that the composed configs' seed keys do not apply to it.
- No data in git — the fabricated rows in the new tests are written to a tempdir, and every per-item dump lands under the gitignored runs root.
- Model-size ceiling: unchanged. The MuSiQue reader still asserts against `answerer_max_params` (8e9) at load; the MetaQA path loads no model and records `model_loaded: false`.

## Decisions for the lead / Jahid

1. **`wrong_intermediate_answer`** — reading MuSiQue's gold sub-answers as a per-step diagnostic would amend ADR 0019. Not done here.
2. **The headline MetaQA denominator** — executed-only or all-items-with-gold. Both are reported; issue #41 comparability argues for the second.
3. **GRAG** — the seven missing pieces above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
