### PR TITLE
Router readiness: query-id-keyed predictions, few-shot-prompted router, router-guided decomposer arm

### DIFF
--- a/components/decomposer/README.md
+++ b/components/decomposer/README.md
@@ -14,7 +14,8 @@ placeholders that refer to earlier answers. Ported from v1, with the four per-mo
   few-shot and post-processing settings.
 - `configs/decomposer.json` — MetaQA: seed, guided flag, embedding-model registry, retrieval defaults.
 - `configs/decomposer_musique.json` — the MuSiQue variant (issue #12): the pinned 600-question
-  evaluation set of ADR 0007, hops 2/3/4, and the three run conditions.
+  evaluation set of ADR 0007, hops 2/3/4, and the run conditions (including `router_guided`,
+  issue #27's with-router arm).
 
 ```bash
 # few-shot examples from a reranked/truncated retrieval file
@@ -34,15 +35,35 @@ python components/decomposer/run_decomposer.py --model mistral_7b_instruct \
 ## Run conditions (`configs/decomposer_musique.json`)
 
 `--condition` selects a named block from the config's `conditions`; the config's
-`condition` key is the default when the flag is omitted. A condition may set only `guided`
-and `stop_after_step_lines` — model, seed and decoding are shared, and the runner rejects a
-condition that tries to move them, so the arms cannot drift apart.
+`condition` key is the default when the flag is omitted. A condition may set only `guided`,
+`hop_source` and `stop_after_step_lines` — model, seed and decoding are shared, and the runner
+rejects a condition that tries to move them, so the arms cannot drift apart.
 
 | condition | prompt | generation |
 |---|---|---|
 | `unguided` | no hop count | `generation_overrides.max_new_tokens` only |
 | `oracle_guided` | the query's gold hop count, and each exemplar's own gold hop count | same |
+| `router_guided` | the **router's predicted** hop count for that query id, exemplars unchanged | same |
 | `unguided_capped` | no hop count | stops after `stop_after_step_lines` step lines (default 8) |
+
+**The with-router arm (`router_guided`, issue #27).** Identical to `oracle_guided` except where
+the query's hop count comes from: a router predictions JSONL (`--hop-predictions`, written by
+`components/router/run_router.py`), joined on the **query id**, whose prediction overrides the
+gold depth even when the two disagree — that disagreement is the behaviour under test. Nothing
+falls back: a query with no prediction in the file is refused, naming the offending ids, because
+filling it in from the gold depth would make the arm a blend of two conditions. The per-hop
+reporting and the pinned-set assertion stay on the **gold** depth, so a prediction cannot move a
+row into another hop's table: `results.json` carries `hop_count` (gold, unchanged meaning),
+`prompt_hop_count` (what the prompt stated) and `hop_count_source`, and `metrics.json`'s
+`hop_source` block carries the predictions path, its sha256 and how often the prediction agreed
+with the gold depth.
+
+```bash
+python components/decomposer/run_decomposer.py --model mistral_7b_instruct \
+    --config decomposer_musique.json --condition router_guided \
+    --hop-predictions runs/router_musique/few_shot/<run_id>/predictions.jsonl \
+    --retrieval-input <the pinned top-5 JSONL over the 600 questions of ADR 0007>
+```
 
 The cap is a `StoppingCriteria` during decoding, plus a trim of the partial line the
 criterion can leave behind once it fires. Step lines are counted **after** `<think>`/tail

--- a/components/decomposer/run_decomposer.py
+++ b/components/decomposer/run_decomposer.py
@@ -250,11 +250,14 @@ def resolve_hop_source(
     where the number came from and in nothing else, which is what makes a with-router versus
     without-router comparison a comparison.
 
-    Four refusals, all of them a run that would otherwise be filed under the wrong label:
+    Five refusals, all of them a run that would otherwise be filed under the wrong label:
 
-    - an unimplemented hop source (not silently treated as ``gold``);
+    - an unimplemented hop source (not silently treated as ``gold``), including a condition
+      that sets ``hop_source`` to null;
     - ``predictions`` in an **unguided** arm - no hop count reaches the prompt at all there,
       so the run would be the unguided arm wearing the router's name;
+    - ``predictions`` with ``few_shot_exemplar_hop_count`` ``"query"``, which would stamp the
+      *prediction* on every exemplar (ADR 0013's defect, with a prediction for a gold depth);
     - ``predictions`` with no file named;
     - ``--hop-predictions`` passed to a ``gold`` arm - the file would be ignored, and the
       run recorded as the oracle while the operator believed it routed.
@@ -262,7 +265,19 @@ def resolve_hop_source(
     Returns the record for the run's config snapshot and metrics.
     """
     src = cfg.get("_config_path", "<config>")
-    source = condition.get("hop_source") or require(cfg, "hop_source")
+    # An explicit null in a condition is refused rather than falling through to the config's
+    # default: "hop_source": null reads as "this arm names no source", and silently running
+    # it as the gold arm would file a routed arm's label on an oracle run (PR #43 review, N4).
+    if "hop_source" in condition:
+        source = condition["hop_source"]
+        if not isinstance(source, str) or not source:
+            raise SystemExit(
+                f"condition {condition_name!r} in {src} sets 'hop_source' to {source!r}. A "
+                f"condition that names a hop source must name one of {list(HOP_SOURCES)}; "
+                f"remove the key to inherit the config's default ({require(cfg, 'hop_source')!r})."
+            )
+    else:
+        source = require(cfg, "hop_source")
     if source not in HOP_SOURCES:
         raise SystemExit(
             f"hop_source={source!r} is not one of {list(HOP_SOURCES)} (config: {src}, "
@@ -297,6 +312,18 @@ def resolve_hop_source(
             f"predictions would never reach the model and the run would be the unguided arm "
             f"under the router's label. Set guided true for this condition, or use "
             f"hop_source 'gold'."
+        )
+    exemplar_hop_mode = require(cfg, "few_shot_exemplar_hop_count")
+    if exemplar_hop_mode == "query":
+        raise SystemExit(
+            f"hop_source 'predictions' (condition {condition_name!r}) with "
+            f"few_shot_exemplar_hop_count 'query' in {src}: that mode stamps the QUERY's hop "
+            f"count on every few-shot exemplar, so the router's prediction would be printed "
+            f"above k exemplars it does not describe - the ADR 0013 defect Jahid's 2026-08-19 "
+            f"decision removed, with a prediction in place of the gold depth. Use "
+            f"'exemplar_gold' (each exemplar states its own gold step count) for a routed "
+            f"arm. Refused for the config combination whether or not few-shot examples are "
+            f"switched on for a given run, so the combination cannot reach a prompt at all."
         )
     file_value = cli_predictions or optional(cfg, "hop_predictions.file")
     if not file_value:

--- a/components/decomposer/run_decomposer.py
+++ b/components/decomposer/run_decomposer.py
@@ -21,9 +21,11 @@ Usage::
 
 ``--config decomposer_musique.json`` runs the pinned MuSiQue evaluation set (ADR 0007) and
 carries a ``conditions`` block: ``unguided``, ``oracle_guided`` (gold hop count in the
-prompt) and ``unguided_capped`` (no hop count, generation stopped at N step lines). All
-three share model, seed, retrieval and decoding; only the prompt's hop information and the
-step-line budget differ. That claim is enforced, not asserted in prose: the unguided prompt
+prompt), ``unguided_capped`` (no hop count, generation stopped at N step lines) and
+``router_guided`` (the hop count comes from a router predictions file, joined by query id -
+issue #27's with-router arm; run it with ``--hop-predictions <router run>/predictions.jsonl``).
+All of them share model, seed, retrieval and decoding; only the prompt's hop information and
+the step-line budget differ. That claim is enforced, not asserted in prose: the unguided prompt
 must be the guided prompt with its hop-bearing lines removed and nothing else changed
 (``unguided_prompt_must_equal_guided_minus_hop_lines``), so the arms cannot differ in a
 second way. The unguided arms therefore need a model folder that ships an
@@ -68,6 +70,7 @@ from typing import Any, Callable
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 
+from hop_matching import HOP_SOURCES, load_predicted_hops  # noqa: E402
 from model_size import assert_within_ceiling, load_limits, unasserted_note  # noqa: E402
 from run_artifacts import now_iso, run_id, write_run_artifacts  # noqa: E402
 from run_config import (  # noqa: E402
@@ -108,7 +111,10 @@ _WORD_RX = re.compile(r"[A-Za-z]{2,}")
 #: Keys a ``conditions.<name>`` block may carry. Deliberately short: the conditions of an
 #: experiment arm differ only in what the prompt says about the hop count and in the
 #: step-line budget. Model, seed and decoding are shared, so no condition can move them.
-_CONDITION_KEYS = frozenset({"guided", "stop_after_step_lines", "_note"})
+#: ``hop_source`` belongs here for the same reason ``guided`` does - it says *which* hop
+#: count the prompt carries (the gold depth, or a router's prediction), which is exactly
+#: what separates the oracle-guided arm from the router-guided one (issue #27).
+_CONDITION_KEYS = frozenset({"guided", "stop_after_step_lines", "hop_source", "_note"})
 
 
 # --------------------------------------------------------------------------- IO
@@ -225,6 +231,152 @@ def resolve_guided(
     if "guided" in condition:
         return bool(condition["guided"])
     return bool(require(cfg, "guided"))
+
+
+def resolve_hop_source(
+    condition_name: str | None,
+    condition: dict,
+    cfg: dict,
+    *,
+    guided: bool,
+    cli_predictions: str | None,
+) -> dict[str, Any]:
+    """Where a guided arm's hop count comes from: the gold depth, or a router's prediction.
+
+    ``gold`` is every arm that existed before issue #27: the query's gold hop depth, parsed
+    from its id on the retrieval path or taken from the per-hop file it was read from.
+    ``predictions`` is the router-guided arm: the hop count comes from a router predictions
+    JSONL, joined by **query id** (:func:`join_predicted_hops`). The two arms then differ in
+    where the number came from and in nothing else, which is what makes a with-router versus
+    without-router comparison a comparison.
+
+    Four refusals, all of them a run that would otherwise be filed under the wrong label:
+
+    - an unimplemented hop source (not silently treated as ``gold``);
+    - ``predictions`` in an **unguided** arm - no hop count reaches the prompt at all there,
+      so the run would be the unguided arm wearing the router's name;
+    - ``predictions`` with no file named;
+    - ``--hop-predictions`` passed to a ``gold`` arm - the file would be ignored, and the
+      run recorded as the oracle while the operator believed it routed.
+
+    Returns the record for the run's config snapshot and metrics.
+    """
+    src = cfg.get("_config_path", "<config>")
+    source = condition.get("hop_source") or require(cfg, "hop_source")
+    if source not in HOP_SOURCES:
+        raise SystemExit(
+            f"hop_source={source!r} is not one of {list(HOP_SOURCES)} (config: {src}, "
+            f"condition: {condition_name!r}). A hop source that is not implemented is "
+            f"refused rather than treated as 'gold'."
+        )
+    record: dict[str, Any] = {
+        "source": source,
+        "condition": condition_name,
+        "predictions_file": None,
+        "predictions_file_sha256": None,
+        "id_field": require(cfg, "hop_predictions.id_field"),
+        "hop_field": require(cfg, "hop_predictions.hop_field"),
+    }
+    if source == "gold":
+        if cli_predictions:
+            raise SystemExit(
+                f"--hop-predictions {cli_predictions!r} was given, but this run's hop source "
+                f"is 'gold' (condition {condition_name!r} in {src}), so the file would be "
+                f"ignored and the run recorded as the oracle arm. Select the condition whose "
+                f"hop_source is 'predictions' (the router-guided arm), or drop the flag."
+            )
+        record["note"] = (
+            "the query's gold hop depth (from its id on the retrieval path, or from the "
+            "per-hop file it was read from) - never a prediction"
+        )
+        return record
+    if not guided:
+        raise SystemExit(
+            f"hop_source 'predictions' in an unguided arm (condition {condition_name!r} in "
+            f"{src}): an unguided prompt carries no hop count at all, so the router's "
+            f"predictions would never reach the model and the run would be the unguided arm "
+            f"under the router's label. Set guided true for this condition, or use "
+            f"hop_source 'gold'."
+        )
+    file_value = cli_predictions or optional(cfg, "hop_predictions.file")
+    if not file_value:
+        raise SystemExit(
+            f"hop_source 'predictions' (condition {condition_name!r}) needs a predictions "
+            f"file: pass --hop-predictions, or set 'hop_predictions.file' in {src}. Without "
+            f"it the router-guided arm would silently become the oracle-guided one.\n"
+            f"The file is a JSONL, one object per query, carrying the fields named by "
+            f"'hop_predictions.id_field' / 'hop_predictions.hop_field' (ADR 0022 item 5); "
+            f"components/router/run_router.py writes exactly that shape."
+        )
+    record["predictions_file"] = str(file_value)
+    record["note"] = (
+        "the hop count in the prompt is the router's prediction for that query id, which "
+        "overrides the gold depth even when the two disagree - that disagreement is the "
+        "behaviour under test"
+    )
+    return record
+
+
+def join_predicted_hops(
+    rows: list[dict],
+    predicted: dict[str, int],
+    *,
+    predictions_path: Path,
+    id_field: str,
+) -> dict[str, Any]:
+    """Set each row's prompt hop count from the router's prediction, joined by query id.
+
+    Mutates ``rows`` in place: ``hop_count`` (the number the prompt states) becomes the
+    prediction, while ``gold_hop_count`` is left alone - the per-hop reporting and the pinned
+    evaluation-set assertion are counted on the gold depth, so a router that predicts 3 for a
+    2-hop question must not move that question into the 3-hop row of the results table.
+
+    Nothing falls back, for ADR 0022 item 3's reason: a query with no prediction is not an
+    oracle-guided query, and a run that mixed the two would be neither arm. A row with no
+    query id cannot be joined at all, and both refusals name the offenders.
+
+    Returns the record for the run's config snapshot and metrics, including how often the
+    prediction agreed with the gold depth (a count, not a claim: the router's own accuracy is
+    measured in its own run).
+    """
+    no_id = [str(i) for i, row in enumerate(rows) if not str(row.get("query_id") or "").strip()]
+    if no_id:
+        raise SystemExit(
+            f"{len(no_id)} of {len(rows)} rows have no query id, so the router's predictions "
+            f"cannot be joined onto them (row indices: {_sample(no_id)}). The router-guided "
+            f"arm needs a question source that carries ids (questions_format 'jsonl', or a "
+            f"retrieval input whose rows carry 'query_id')."
+        )
+    missing = [
+        str(row["query_id"]).strip()
+        for row in rows
+        if str(row["query_id"]).strip() not in predicted
+    ]
+    if missing:
+        raise SystemExit(
+            f"{len(missing)} of {len(rows)} queries have no prediction in {predictions_path} "
+            f"(joined on {id_field!r}): {_sample(missing)}. The predictions file must cover "
+            f"every query in the run; a missing one is not a gold-guided query, and filling "
+            f"it in from the gold depth would make this arm a blend of two conditions."
+        )
+    agreed = 0
+    for row in rows:
+        hop = int(predicted[str(row["query_id"]).strip()])
+        if hop == row["gold_hop_count"]:
+            agreed += 1
+        row["hop_count"] = hop
+    unused = sorted(set(predicted) - {str(r["query_id"]).strip() for r in rows})
+    return {
+        "rows_joined": len(rows),
+        "predictions_in_file": len(predicted),
+        "predictions_unused": len(unused),
+        "rows_agreeing_with_gold_hop": agreed,
+        "rows_disagreeing_with_gold_hop": len(rows) - agreed,
+        "agreement_note": (
+            "a count over the rows of this run, not the router's accuracy: the router's own "
+            "run measures that on its own evaluation set"
+        ),
+    }
 
 
 def resolve_step_line_cap(condition_name: str | None, condition: dict) -> int | None:
@@ -1588,6 +1740,13 @@ def _parse_args() -> argparse.Namespace:
         help="Named condition from the config's 'conditions' block (e.g. unguided, "
         "oracle_guided, unguided_capped). Overrides the config's default 'condition'.",
     )
+    p.add_argument(
+        "--hop-predictions",
+        default=None,
+        help="Router predictions JSONL (one object per query, with the id and hop fields "
+        "named by 'hop_predictions' in the config). Required by a condition whose "
+        "hop_source is 'predictions' - the router-guided arm; refused by a 'gold' one.",
+    )
     p.add_argument("--sample-size", type=int, default=None)
     p.add_argument("--embed-model", default=None, help="Key in decomposer.json embed_models")
     p.add_argument("--retrieval-input", default=None, help="Reranked/truncated top-k JSONL")
@@ -1896,6 +2055,13 @@ def main() -> None:
     seed = args.seed if args.seed is not None else int(require(cfg, "seed"))
     guided = resolve_guided(args.guided, condition_name, condition, cfg)
     stop_after_step_lines = resolve_step_line_cap(condition_name, condition)
+    hop_source_record = resolve_hop_source(
+        condition_name,
+        condition,
+        cfg,
+        guided=guided,
+        cli_predictions=args.hop_predictions,
+    )
     sample_size = args.sample_size if args.sample_size is not None else require(cfg, "sample_size")
     embed_key = args.embed_model or require(cfg, "embed_model")
     embed_model_id = require(cfg, f"embed_models.{embed_key}")
@@ -2046,6 +2212,24 @@ def main() -> None:
             raise SystemExit(f"retrieval input not found: {retrieval_path}")
         retrieval_sha256 = sha256_file(retrieval_path)
 
+    # The router's predictions, content-addressed for the same reason as the retrieval input:
+    # a with-router arm is only comparable to a without-router one if the routing decisions
+    # it actually used can be identified from the run record.
+    hop_predictions_path: Path | None = None
+    if hop_source_record["source"] == "predictions":
+        hop_predictions_path = Path(hop_source_record["predictions_file"])
+        if not hop_predictions_path.is_absolute():
+            hop_predictions_path = _REPO_ROOT / hop_predictions_path
+        if not hop_predictions_path.exists():
+            raise SystemExit(
+                f"hop predictions file not found: {hop_predictions_path}\n"
+                "Point --hop-predictions at a router run's predictions JSONL "
+                "(components/router/run_router.py writes one per run when its question "
+                "source carries ids)."
+            )
+        hop_source_record["predictions_file_resolved"] = str(hop_predictions_path)
+        hop_source_record["predictions_file_sha256"] = sha256_file(hop_predictions_path)
+
     snapshot = {
         "script": Path(__file__).name,
         "created_utc": now_iso(),
@@ -2062,6 +2246,7 @@ def main() -> None:
         "condition": condition_name,
         "condition_settings": condition,
         "guided": guided,
+        "hop_source": hop_source_record,
         "stop_after_step_lines": stop_after_step_lines,
         "seed": seed,
         "seeded": seeded,
@@ -2210,7 +2395,13 @@ def main() -> None:
                 {
                     "query_id": row.get("query_id"),
                     "question": question,
+                    # hop_count is the number the PROMPT will state; gold_hop_count is the
+                    # query's own depth, which is what the per-hop reporting and the pinned
+                    # eval-set assertion are counted on. They are the same number in every
+                    # arm but the router-guided one, where the join below overwrites the
+                    # first and leaves the second alone.
                     "hop_count": hop,
+                    "gold_hop_count": hop,
                     "retrieval_examples": examples,
                 }
             )
@@ -2259,8 +2450,11 @@ def main() -> None:
                         "query_id": item["query_id"],
                         "question": item["question"],
                         # Guided runs inject this hop count: it is the gold depth of the
-                        # file the question was read from, not a model prediction.
+                        # file the question was read from, not a model prediction - unless
+                        # the arm's hop source is a router predictions file, which the join
+                        # below applies to `hop_count` only.
                         "hop_count": hop,
+                        "gold_hop_count": hop,
                         "retrieval_examples": [],
                     }
                 )
@@ -2271,15 +2465,39 @@ def main() -> None:
             )
         print(f"Loaded {len(inference_rows)} total questions.")
 
+    # The router-guided arm (issue #27): the prompt's hop count comes from the router's
+    # predictions, joined by query id. Done here - after the rows exist, before any model is
+    # loaded - so a predictions file that does not cover this run is a refusal that costs no
+    # GPU time.
+    if hop_predictions_path is not None:
+        predicted_hops = load_predicted_hops(
+            hop_predictions_path,
+            id_field=hop_source_record["id_field"],
+            hop_field=hop_source_record["hop_field"],
+        )
+        hop_source_record["join"] = join_predicted_hops(
+            inference_rows,
+            predicted_hops,
+            predictions_path=hop_predictions_path,
+            id_field=hop_source_record["id_field"],
+        )
+        snapshot["hop_source"] = hop_source_record
+        print(f"[decomposer] hop source: {json.dumps(hop_source_record, default=str)}")
+
     # The evaluation set this arm was actually asked to decompose: after any `sample_size`
     # restriction (which a run on the pinned set leaves null), before the `--dry-run` limit,
     # which only shortens the prompt-assembly pass. Three conditions are comparable only if
     # these are the same across them - for the pinned MuSiQue set of ADR 0007, 200 rows per
     # hop for hops 2/3/4, 600 ids in total, and *those* 600 ids.
+    #
+    # Counted on the GOLD depth, never on the prompt's: a router that predicts 3 for a 2-hop
+    # question must not move that question into the 3-hop row of the table, or the pinned-set
+    # assertion would fail on a correctly loaded set and the per-hop numbers would be filed
+    # under a prediction.
     rows_loaded_total = len(inference_rows)
     rows_loaded_per_hop = {
-        str(hop): sum(1 for r in inference_rows if r["hop_count"] == hop)
-        for hop in sorted({r["hop_count"] for r in inference_rows})
+        str(hop): sum(1 for r in inference_rows if r["gold_hop_count"] == hop)
+        for hop in sorted({r["gold_hop_count"] for r in inference_rows})
     }
     loaded_ids = {str(r["query_id"]) for r in inference_rows if r["query_id"] is not None}
     distinct_query_ids = len(loaded_ids)
@@ -2356,7 +2574,10 @@ def main() -> None:
 
     for i, row in enumerate(inference_rows):
         question = row["question"]
+        # The hop count the prompt states (the gold depth, or the router's prediction);
+        # `gold_hop_count` is what the row is filed under.
         hop = row["hop_count"]
+        gold_hop = row["gold_hop_count"]
         if (i + 1) % progress_every == 0:
             print(f"Processed {i + 1}/{len(inference_rows)}...")
 
@@ -2462,12 +2683,17 @@ def main() -> None:
             cost = {k: gen[k] for k in cost}
 
         if args.dry_run or (i + 1) % prompt_log_every == 0:
-            log_path = prompts_dir / f"prompt_idx{i + 1:04d}_hop{hop}.txt"
+            # Filed under the gold depth, so the log file names are the same across arms
+            # (the router's prediction is stated inside the header instead).
+            log_path = prompts_dir / f"prompt_idx{i + 1:04d}_hop{gold_hop}.txt"
             masked_q = mask_fn(question) if mask_fn else "N/A"
             header = [
                 "--- Log Header ---",
                 f"Question (original): {question}",
                 f"Question (masked): {masked_q}",
+                f"Gold hop count: {gold_hop}",
+                f"Hop count in prompt: {hop_input} "
+                f"(source: {hop_source_record['source']})",
                 f"Few-shot source: {source} (k={len(sampled)})",
             ]
             for j, (item, score) in enumerate(sampled_with_scores, start=1):
@@ -2496,7 +2722,12 @@ def main() -> None:
             {
                 "query_id": row.get("query_id"),
                 "question": question,
-                "hop_count": hop,
+                # Unchanged meaning for every consumer: the query's GOLD hop depth. What the
+                # prompt actually stated is `prompt_hop_count` (null in an unguided arm), and
+                # `hop_count_source` says where that number came from.
+                "hop_count": gold_hop,
+                "prompt_hop_count": hop_input,
+                "hop_count_source": hop_source_record["source"],
                 "decomposition": decomposition,
                 "few_shot_source": source,
                 # Same fields in all three arms, whether or not a cap applies. The raw
@@ -2540,6 +2771,10 @@ def main() -> None:
         },
         "condition": condition_name,
         "guided": guided,
+        # Where the prompt's hop count came from, with the join counts when it came from a
+        # router: a metrics file read on its own has to say whether it is the oracle arm or
+        # the routed one, and which predictions file produced it.
+        "hop_source": hop_source_record,
         "stop_after_step_lines": stop_after_step_lines,
         # Two different questions, deliberately reported separately:
         #   rows_at_step_line_cap        - how many decompositions HAVE cap-many steps, by the
@@ -2643,6 +2878,18 @@ def main() -> None:
             f"- Prompt: `{prompt_path}` (style: {prompt_style})",
             f"- Condition: {condition_name or 'none (no conditions block)'}; guided: {guided}; "
             f"step-line cap: {stop_after_step_lines or 'none'}; seed: {seed}",
+            (
+                f"- Hop count in the prompt: {hop_source_record['source']} - "
+                f"`{hop_source_record.get('predictions_file_resolved')}` (sha256 "
+                f"`{hop_source_record['predictions_file_sha256']}`), joined on "
+                f"`{hop_source_record['id_field']}`: "
+                f"{hop_source_record['join']['rows_joined']} row(s), "
+                f"{hop_source_record['join']['rows_agreeing_with_gold_hop']} agreeing with "
+                f"the gold depth"
+                if hop_source_record["source"] == "predictions"
+                else f"- Hop count in the prompt: {hop_source_record['source']} "
+                f"({'injected' if guided else 'not stated - unguided arm'})"
+            ),
             f"- Rows: {len(results)} of {rows_loaded_total} loaded "
             f"(per hop: {rows_loaded_per_hop}; distinct ids: {distinct_query_ids})",
             f"- Evaluation set pinned: {eval_set_record['pinned']} "

--- a/components/router/README.md
+++ b/components/router/README.md
@@ -1,31 +1,71 @@
 # Router Component
 
-Classifies a question into a hop count (1/2/3). Ported from v1, with the ten
-near-identical per-model `router.py` copies consolidated into one runner.
+Predicts a question's hop count. Ported from v1, with the ten near-identical per-model
+`router.py` copies consolidated into one runner. Nothing here is trained — the router is
+prompted.
 
 - `run_router.py` — the runner, for every model.
-- `models/<model_name>/prompt.md` — the hop-count prompt (few-shot), **byte-identical to v1**.
+- `models/<model_name>/prompt.md` — the hop-count prompt (static few-shot), **byte-identical to v1**.
 - `models/<model_name>/config.json` — model id, generation length, loader flags, response parsing.
 - `models/prompt_zero_shot.md` — shared zero-shot prompt (no few-shot examples).
-- `configs/router.json` — everything that is not model-specific (seed, hops, run counts, output roots).
+- `models/prompt_few_shot_musique.md` — shared **retrieved**-few-shot prompt: an instruction, a
+  `{few_shot_examples}` block, the query.
+- `configs/router.json` — the MetaQA path: everything that is not model-specific (seed, hops,
+  run counts, output roots).
+- `configs/router_musique.json` — the few-shot-prompted router of issue #27: the pinned MuSiQue
+  evaluation set (ADR 0007), hops 2/3/4, retrieved exemplars, and a predictions file keyed by
+  query id.
 
 ```bash
 python components/router/run_router.py --model qwen2_5_0_5b
 python components/router/run_router.py --model qwen2_5_0_5b --prompt-file prompt_zero_shot.md
 python components/router/run_router.py --model qwen2_5_0_5b --dry-run   # prompts only, no model
+
+# the few-shot-prompted router over the pinned MuSiQue set (issue #27)
+python components/router/run_router.py --model qwen2_5_0_5b --config router_musique.json
 ```
 
 Output goes under the runs root from `configs/paths.json`: `router/average_zero_shot/<run_id>/`
-for the zero-shot prompt, `router/average_few_shot/<run_id>/` otherwise. Every run writes
-`config.json`, `metrics.json`, `notes.md` and `detailed_results*.json`.
+for the zero-shot prompt, `router/average_few_shot/<run_id>/` otherwise (and
+`router_musique/...` for the MuSiQue config). Every run writes `config.json`, `metrics.json`,
+`notes.md` and `detailed_results*.json`.
 
-`--num-runs N` repeats inference with seeds seed, seed+1, … and reports mean ± std.
+**Predictions keyed by query id.** With a question source that carries ids
+(`questions_format: jsonl`, i.e. the MuSiQue config) a run also writes `predictions.jsonl`:
+one object per query with `query_id` and `predicted_hop` (field names from the config), plus
+the gold depth it is scored against and whether the hop was read out of the response or fell
+back to `parsing.default_hop`. That is the shape ADR 0022 item 5 documents, and it is what the
+two consumers join on:
+
+```bash
+# issue #15's router-hop-matched retrieval condition
+python MusiQue/scripts/check_question_similarity.py --hop-match --hop-source predictions \
+    --hop-predictions runs/router_musique/few_shot/<run_id>/predictions.jsonl
+
+# the decomposer's with-router arm (issue #27)
+python components/decomposer/run_decomposer.py --model mistral_7b_instruct \
+    --config decomposer_musique.json --condition router_guided \
+    --hop-predictions runs/router_musique/few_shot/<run_id>/predictions.jsonl
+```
+
+A missing or repeated query id is refused before a model is loaded; a query the predictions
+file does not cover is refused on the consuming side. Nothing falls back to the gold depth.
+
+**Retrieved few-shot exemplars.** With `few_shot.enabled`, the exemplars for a query are the
+candidates the retrieval artifact already holds for it (the same artifact the decomposer
+reads), each labelled with **its own** gold hop depth parsed from its pool id. A candidate that
+is the query itself is dropped — by id and by normalized question text, using the decomposer's
+own rule — before the top-k is taken, so no query is shown its own answer. A dry run assembles
+all of this and writes the prompt log; it predicts nothing, so it writes no predictions file.
+
+`--num-runs N` repeats inference with seeds seed, seed+1, … and reports mean ± std. The
+predictions file is written from run 0, the same run `detailed_results_run_0.json` records.
 
 **Parameter ceiling.** The runner prints the loaded model's parameter count and asserts it
-against `router_max_params` in `configs/model_limits.json` (~600M, per the standing constraint
-in CLAUDE.md). Model folders above that ceiling are kept here because their prompts are v1
-experimental assets, but the runner will refuse to run them until the ceiling changes — which
-is Jahid's decision with his supervisor, not an agent's.
+against `router_max_params` in `configs/model_limits.json` — 8e9 since ADR 0008 lifted the
+former ~600M router-specific cap to the overall ~8B ceiling (the per-model `notes` fields that
+still mention ~600M predate that ADR). A model above the ceiling is refused at load time;
+raising the number is Jahid's decision with his supervisor, not an agent's.
 
 Plots and an HTML report over completed runs:
 

--- a/components/router/README.md
+++ b/components/router/README.md
@@ -30,12 +30,15 @@ for the zero-shot prompt, `router/average_few_shot/<run_id>/` otherwise (and
 `router_musique/...` for the MuSiQue config). Every run writes `config.json`, `metrics.json`,
 `notes.md` and `detailed_results*.json`.
 
-**Predictions keyed by query id.** With a question source that carries ids
-(`questions_format: jsonl`, i.e. the MuSiQue config) a run also writes `predictions.jsonl`:
-one object per query with `query_id` and `predicted_hop` (field names from the config), plus
-the gold depth it is scored against and whether the hop was read out of the response or fell
-back to `parsing.default_hop`. That is the shape ADR 0022 item 5 documents, and it is what the
-two consumers join on:
+**Predictions keyed by query id.** A **real** run whose config sets `predictions.enabled`
+writes `predictions.jsonl` — one object per query with `query_id` and `predicted_hop` (field
+names from the config), plus the gold depth it is scored against and whether the hop was read
+out of the response or fell back to `parsing.default_hop`. Two gates, both explicit: the knob
+is on only in `configs/router_musique.json` (a `questions_format: lines` source such as
+MetaQA's has no id to key on, so `configs/router.json` sets it false), and a `--dry-run`
+writes **no** predictions file at all — it generates nothing, so there is no prediction to
+record and the metrics say so rather than reporting an empty or invented file. The shape is
+the one ADR 0022 item 5 documents, and it is what the two consumers join on:
 
 ```bash
 # issue #15's router-hop-matched retrieval condition
@@ -57,6 +60,21 @@ reads), each labelled with **its own** gold hop depth parsed from its pool id. A
 is the query itself is dropped — by id and by normalized question text, using the decomposer's
 own rule — before the top-k is taken, so no query is shown its own answer. A dry run assembles
 all of this and writes the prompt log; it predicts nothing, so it writes no predictions file.
+
+**Reading the hop count out of a response.** The retrieved-few-shot prompt ends with the `A:`
+cue, so the model's answer is the *first* thing in its response and anything after the first
+line break is the model writing a fresh question of its own. `response_truncate_at` in the
+config cuts the response there before it is parsed, and that config drops the `A:`-prefix
+regex, so the answer is read as the leading digit; the v1 MetaQA prompts set no markers and
+keep their own regex, so their parsing is unchanged. Every run — dry runs included — asserts
+that the parsing rules can express every depth in `hops` and that `parsing.default_hop` is one
+of them, and records the result as `parsing_coverage`. A response with no readable hop count is
+recorded as `default_hop` with `parse_fallback` true, **counted in the accuracies**, and broken
+out per gold hop as `unparsed_response_rows_per_gold_hop` — a defaulted row is correct for
+whichever class the default belongs to, so that split is what says how much of a per-hop number
+is a prediction. `accuracy_definitions` in `metrics.json` states what each accuracy measures
+(exact-hop against the gold depth; the per-hop rows are within-gold-class recall, not
+precision).
 
 `--num-runs N` repeats inference with seeds seed, seed+1, … and reports mean ± std. The
 predictions file is written from run 0, the same run `detailed_results_run_0.json` records.

--- a/components/router/models/README.md
+++ b/components/router/models/README.md
@@ -9,7 +9,13 @@ One folder per model. Each contains:
   response). The `parsing` and `generation` fields are where v1's per-copy code differences
   now live; the `notes` field in each config records which ones.
 
-Shared in this directory: `prompt_zero_shot.md` — zero-shot prompt, selected with
-`--prompt-file prompt_zero_shot.md`.
+Shared in this directory (not per-model, and not v1 assets):
+
+- `prompt_zero_shot.md` — zero-shot prompt, selected with `--prompt-file prompt_zero_shot.md`.
+- `prompt_few_shot_musique.md` — the retrieved-few-shot prompt of issue #27: an instruction, a
+  `{few_shot_examples}` block the runner fills with the query's retrieved exemplars (each
+  labelled with its own gold hop depth), then the query. Named by
+  `configs/router_musique.json`, so that config cannot be run with a model folder's MetaQA
+  prompt by accident.
 
 Folder naming is lowercase with underscores.

--- a/components/router/models/prompt_few_shot_musique.md
+++ b/components/router/models/prompt_few_shot_musique.md
@@ -1,0 +1,6 @@
+Count the number of reasoning steps (hops) needed to answer the question. Output only the number.
+
+{few_shot_examples}
+
+Q: {question}
+A:

--- a/components/router/run_router.py
+++ b/components/router/run_router.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Router component: classify a question's hop count.
+"""Router component: predict a question's hop count.
 
 One runner for every model. v1 kept ten near-identical copies of ``router.py``
 (one per model folder); they differed only in the model id, the generation length,
@@ -7,15 +7,40 @@ the tokenizer/loader flags and the response-parsing rules. Those differences are
 now fields in ``components/router/models/<model>/config.json`` and the code lives
 here once. Prompts stay per-model and byte-identical to v1.
 
+Three prompting modes, none of which trains anything. Which one runs is decided by the
+prompt file and by the config's ``few_shot`` block:
+
+- **static few-shot** — ``models/<model>/prompt.md``, v1's hand-written MetaQA examples
+  (``configs/router.json``, the default);
+- **zero-shot** — ``models/prompt_zero_shot.md`` (``--prompt-file``);
+- **retrieved few-shot** — ``models/prompt_few_shot_musique.md`` with
+  ``configs/router_musique.json`` (issue #27). The exemplars come from the same retrieval
+  artifact the decomposer reads, each labelled with its **own** gold hop depth, and the
+  query is excluded from its own exemplars by id and by question text (the decomposer's
+  rule, imported rather than re-implemented).
+
 Usage::
 
     python components/router/run_router.py --model qwen2_5_0_5b
     python components/router/run_router.py --model qwen2_5_0_5b --prompt-file prompt_zero_shot.md
     python components/router/run_router.py --model qwen2_5_0_5b --dry-run   # no model load
 
+    # the few-shot-prompted router over a question source that carries ids (issue #27)
+    python components/router/run_router.py --model qwen2_5_0_5b \\
+        --config router_musique.json --prompt-file prompt_few_shot_musique.md \\
+        --retrieval-input <the pinned top-5 JSONL over the 600 questions of ADR 0007>
+
 Every run writes a config snapshot, a metrics JSON and a run note under the
 configured runs root, and asserts the model's parameter count against the router
 ceiling in ``configs/model_limits.json``.
+
+A run whose question source carries ids (``questions_format: jsonl``) also writes a
+**predictions JSONL keyed by query id** — one object per query with the id and the
+predicted hop, the shape ADR 0022 item 5 documents. That is what lets the two consumers
+join on the id instead of on question text: the retrieval chain's ``predictions`` hop
+source (issue #15's router-hop-matched condition) and the decomposer's ``router_guided``
+condition. v1's ``detailed_results.json`` was keyed by question text only, which made an
+exact-string match load-bearing on the very field the masking modes rewrite.
 """
 from __future__ import annotations
 
@@ -28,10 +53,18 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_REPO_ROOT / "src"))
+#: Four rules this component must not own a second copy of: how a question source with ids
+#: is read, what "this exemplar IS the query" means, and what the pinned ADR 0007 evaluation
+#: set is (by id, not only by count). They live in the decomposer's runner and are *imported*
+#: here rather than duplicated, the same way ``components/answerer/run_answerer.py`` imports
+#: the eval-set assertion — a second copy of a leakage rule is a rule that drifts.
+sys.path.insert(0, str(_REPO_ROOT / "components" / "decomposer"))
 
+from hop_matching import parse_hop_from_id  # noqa: E402
 from model_size import assert_within_ceiling, load_limits, unasserted_note  # noqa: E402
 from run_artifacts import now_iso, run_id, write_run_artifacts  # noqa: E402
 from run_config import (  # noqa: E402
+    data_path,
     load_config,
     load_paths,
     optional,
@@ -41,33 +74,226 @@ from run_config import (  # noqa: E402
 )
 from seeding import new_rng, set_global_seed  # noqa: E402
 
+import run_decomposer as rd  # noqa: E402
+
 _THINK_RX = re.compile(r"<think>.*?</think>", re.DOTALL)
 
 _NUMBER_WORDS = {"ONE": 1, "TWO": 2, "THREE": 3}
 
+#: How many offending ids / rows an error message lists before it truncates.
+_MAX_REPORTED = 10
 
-def load_questions(file_path: Path) -> list[str]:
-    """Load questions from a text file (one per line)."""
-    if not file_path.exists():
-        print(f"Warning: {file_path} not found.")
-        return []
-    with file_path.open("r", encoding="utf-8") as f:
-        return [line.strip() for line in f if line.strip()]
+#: Where a retrieved exemplar's hop label comes from. ``pool_id`` parses the coarse hop
+#: depth out of the exemplar's MuSiQue id (``2hop__…``) — the same quantity the router is
+#: scored against, since the gold depth of a query is parsed from *its* id the same way. A
+#: second source (for instance the step count of the exemplar's gold decomposition, which is
+#: what the decomposer's exemplar hop lines state) would teach the prompt a different
+#: quantity than the metric measures, so it is not implemented: an unknown value is refused
+#: here rather than approximated, and adding one is a visible edit.
+EXEMPLAR_HOP_SOURCES = ("pool_id",)
 
 
-def build_prompt(template: str, question: str) -> str:
-    """Fill the question placeholder. Handles both {question} and {{question}}."""
+def build_prompt(template: str, question: str, few_shot_examples: str = "") -> str:
+    """Fill the placeholders the template actually has.
+
+    ``{question}`` / ``{{question}}`` is v1's; ``{few_shot_examples}`` is the retrieved
+    few-shot mode's. Only placeholders present are filled (the decomposer's ``fill_template``
+    rule), so a v1 prompt renders exactly as before.
+    """
     if "{{question}}" in template:
-        return template.replace("{{question}}", question)
-    return template.format(question=question)
+        return template.replace("{{question}}", question).replace(
+            "{{few_shot_examples}}", few_shot_examples
+        )
+    values: dict[str, str] = {}
+    if "{question}" in template:
+        values["question"] = question
+    if "{few_shot_examples}" in template:
+        values["few_shot_examples"] = few_shot_examples
+    if not values:
+        return template
+    return template.format(**values)
 
 
-def parse_hop_response(response: str, question: str, parsing: dict) -> int:
+def _sample(items: list[str]) -> str:
+    shown = items[:_MAX_REPORTED]
+    suffix = f" (+{len(items) - len(shown)} more)" if len(items) > len(shown) else ""
+    return ", ".join(repr(s) for s in shown) + suffix
+
+
+# ------------------------------------------------------------------- few-shot
+
+
+def format_few_shot_examples(examples: list[dict]) -> str:
+    """One ``Q:``/``A:`` block per exemplar, whose answer is that exemplar's own hop count.
+
+    The block shape is the one the prompt asks the model to produce and the one the model
+    folder's ``parsing.answer_regex`` reads back out, so the exemplars demonstrate the output
+    format as well as the task.
+    """
+    return "\n\n".join(f"Q: {ex['question']}\nA: {ex['hop_count']}" for ex in examples)
+
+
+def examples_from_retrieval_row(
+    row: dict, *, mode: str, k: int, exemplar_hop_source: str
+) -> tuple[list[dict], int]:
+    """``k`` (question, hop count) exemplars from one retrieval row's ranked candidates.
+
+    The decomposer's rule, applied to a different payload: candidates that **are** the query
+    are dropped before the top-k is taken (:func:`run_decomposer.is_self_example`, by pool id
+    and by whitespace/case-normalized question text), so the router is never shown the query
+    it is about to predict. Returns ``(examples, self_excluded_count)``.
+
+    Every refusal here is loud, because each one would otherwise put a wrong number in the
+    prompt: fewer than k usable candidates, an exemplar whose hop depth does not parse from
+    its pool id, an exemplar with no question text.
+    """
+    if exemplar_hop_source not in EXEMPLAR_HOP_SOURCES:
+        raise SystemExit(
+            f"unknown few_shot.exemplar_hop_source {exemplar_hop_source!r} (expected one of "
+            f"{list(EXEMPLAR_HOP_SOURCES)})"
+        )
+    key = f"{mode}_top_k"
+    candidates = row.get(key) or []
+    query_id = row.get("query_id") or "<unknown>"
+    kept: list[dict] = []
+    self_excluded = 0
+    for idx, cand in enumerate(candidates):
+        if not isinstance(cand, dict):
+            raise SystemExit(
+                f"[router] query_id={query_id!r} candidate {idx} in {key!r} is not an "
+                f"object: type={type(cand).__name__}"
+            )
+        if rd.is_self_example(
+            cand,
+            exclude_query_id=row.get("query_id"),
+            exclude_question=row.get("query_question"),
+        ):
+            self_excluded += 1
+            continue
+        kept.append(cand)
+    if len(kept) < k:
+        raise SystemExit(
+            f"[router] retrieval row for query_id={query_id!r} has only {len(kept)} usable "
+            f"candidate(s) under {key!r} ({len(candidates)} listed, {self_excluded} dropped "
+            f"as the query itself), need k={k}. Rebuild the retrieval input with the correct "
+            f"k, or lower few_shot k in the config."
+        )
+    examples: list[dict] = []
+    for cand in kept[:k]:
+        hop = parse_hop_from_id(cand.get("pool_id"))
+        if hop is None:
+            raise SystemExit(
+                f"[router] query_id={query_id!r}: exemplar pool_id="
+                f"{cand.get('pool_id')!r} carries no parseable hop depth (expected an id "
+                f"like '2hop__…'), so its 'A:' line cannot state its own hop count. There is "
+                f"deliberately no fallback to the query's hop depth: that would put the "
+                f"answer to the query into its own prompt."
+            )
+        question = cand.get("pool_question")
+        if not isinstance(question, str) or not question.strip():
+            raise SystemExit(
+                f"[router] query_id={query_id!r}: exemplar pool_id="
+                f"{cand.get('pool_id')!r} has no usable 'pool_question'."
+            )
+        examples.append(
+            {"pool_id": cand.get("pool_id"), "question": question.strip(), "hop_count": hop}
+        )
+    return examples, self_excluded
+
+
+# ---------------------------------------------------------------- query ids
+
+
+def assert_query_ids(rows: list[dict], *, source: str, reason: str) -> None:
+    """Refuse rows whose query id is missing or repeated. Both would break the join.
+
+    A row with no id cannot appear in the predictions file at all (the consumer would have
+    no key for it); two rows with the same id would make the file say two different things
+    about one query, which is what ADR 0022 item 3 refuses on the reading side. Caught before
+    a model is loaded, so a multi-hour run cannot end in an unjoinable predictions file.
+    """
+    missing = [
+        f"index {i}"
+        for i, row in enumerate(rows)
+        if not isinstance(row.get("query_id"), str) or not str(row["query_id"]).strip()
+    ]
+    if missing:
+        raise SystemExit(
+            f"[router] {len(missing)} of {len(rows)} rows from {source} have no usable query "
+            f"id: {_sample(missing)}.\n{reason}"
+        )
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for row in rows:
+        qid = str(row["query_id"]).strip()
+        if qid in seen:
+            duplicates.append(qid)
+        seen.add(qid)
+    if duplicates:
+        raise SystemExit(
+            f"[router] {len(duplicates)} query id(s) appear more than once in {source}: "
+            f"{_sample(sorted(set(duplicates)))}. One row per query id.\n{reason}"
+        )
+
+
+def build_prediction_rows(
+    rows: list[dict],
+    predictions: list[int],
+    parsed_flags: list[bool],
+    *,
+    id_field: str,
+    hop_field: str,
+) -> list[dict]:
+    """The predictions JSONL rows: a join key, a predicted hop, and how it was obtained.
+
+    Deliberately narrow. ``expected_hop``/``correct`` are the gold depth this prediction is
+    scored against, and ``parse_fallback`` says the model's response carried no hop count so
+    the model folder's ``parsing.default_hop`` was used — a consumer of a routing decision
+    should be able to see that it was a default rather than a prediction.
+
+    No question text: ADR 0022 item 5 rejected keying this join on question text, so the
+    text is not carried here to be keyed on by accident. The run's ``detailed_results.json``
+    keeps it for debugging.
+    """
+    if not (len(rows) == len(predictions) == len(parsed_flags)):
+        raise AssertionError(
+            f"[router] prediction rows misaligned: {len(rows)} queries, "
+            f"{len(predictions)} predictions, {len(parsed_flags)} parse flags"
+        )
+    out: list[dict] = []
+    for row, hop, parsed in zip(rows, predictions, parsed_flags):
+        out.append(
+            {
+                id_field: str(row["query_id"]).strip(),
+                hop_field: int(hop),
+                "expected_hop": row["expected_hop"],
+                "correct": int(hop) == row["expected_hop"],
+                "parse_fallback": not parsed,
+            }
+        )
+    return out
+
+
+def write_predictions_jsonl(path: Path, rows: list[dict]) -> None:
+    """One JSON object per line, in query order (the shape ADR 0022 item 5 documents)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def parse_hop_response(response: str, question: str, parsing: dict) -> tuple[int, bool]:
     """Extract a hop count from the model response, per the model's parsing config.
 
     Mirrors the three parsing variants that existed across v1's router copies:
     an answer-prefix regex (``A:`` or ``Output|A:``), a first-digit fallback, then
     either hop-word labels ("2-hop", "two hop") or number-word labels (ONE/TWO/THREE).
+
+    Returns ``(hop, parsed)``. ``parsed`` is False when nothing in the response could be
+    read and ``parsing.default_hop`` was used instead: v1 logged that case to stdout and
+    then returned the default as if it were a prediction, so a run's accuracy silently
+    mixed predictions with defaults. The flag is what lets the metrics count them, and it
+    travels into the predictions file as ``parse_fallback``.
     """
     hops: list[int] = parsing["hops"]
     digit_class = "[" + "".join(str(h) for h in hops) + "]"
@@ -79,10 +305,10 @@ def parse_hop_response(response: str, question: str, parsing: dict) -> int:
     if answer_regex:
         flags = re.IGNORECASE if parsing.get("answer_regex_ignorecase") else 0
         if match := re.search(answer_regex, clean, flags):
-            return int(match.group(1))
+            return int(match.group(1)), True
 
     if match := re.search(digit_class, clean):
-        return int(match.group())
+        return int(match.group()), True
 
     fallback = require(parsing, "fallback_labels")
     if fallback == "hop_words":
@@ -93,17 +319,17 @@ def parse_hop_response(response: str, question: str, parsing: dict) -> int:
             (3, ("3-hop", "three hop")),
         ):
             if hop in hops and any(w in lower for w in words):
-                return hop
+                return hop, True
     elif fallback == "number_words":
         upper = clean.upper()
         for label, value in _NUMBER_WORDS.items():
             if value in hops and label in upper:
-                return value
+                return value, True
     else:
         raise SystemExit(f"unknown parsing.fallback_labels: {fallback!r}")
 
     if numbers := re.findall(digit_class, clean):
-        return int(numbers[0])
+        return int(numbers[0]), True
 
     print(
         f"Warning: no valid hop count in response for: '{question[:50]}...'. "
@@ -111,21 +337,25 @@ def parse_hop_response(response: str, question: str, parsing: dict) -> int:
     )
     if parsing.get("debug_print_response"):
         print(f"DEBUG: Full model response was: '{response}'")
-    return default_hop
+    return default_hop, False
 
 
 def classify_hop_count(
+    prompt: str,
     question: str,
     model,
     tokenizer,
     device: str,
-    prompt_template: str,
     generation: dict,
     parsing: dict,
-) -> int:
-    import torch
+) -> tuple[int, bool]:
+    """Generate on one already-assembled prompt and read the hop count out of the response.
 
-    prompt = build_prompt(prompt_template, question)
+    The prompt is assembled by the caller (once per query, before anything is loaded) so
+    that the retrieved-few-shot mode, the dry run and the real run all render the *same*
+    text, and so a ``--dry-run`` exercises prompt assembly for real.
+    """
+    import torch
 
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
@@ -153,7 +383,171 @@ def classify_hop_count(
     except Exception as exc:  # pragma: no cover - defensive, matches v1 behaviour
         default_hop = int(require(parsing, "default_hop"))
         print(f"Error parsing response for '{question[:50]}...': {exc}. Defaulting to {default_hop}.")
-        return default_hop
+        return default_hop, False
+
+
+# -------------------------------------------------------------- question sources
+
+
+def apply_overrides(base: dict, overrides: dict | None, *, block: str, src: str) -> dict:
+    """Overlay config-level overrides on a per-model block, refusing unknown keys.
+
+    Same shape and reasoning as the decomposer's ``apply_generation_overrides``: the model
+    folders are v1 assets (``prompt.md`` byte-identical, ``parsing`` mirroring v1's code), so
+    a config that needs a different value overrides it here instead of editing the asset. A
+    key the model's block does not define is refused rather than added, because a typo would
+    otherwise be a setting that silently does nothing.
+    """
+    merged = dict(base)
+    if not overrides:
+        return merged
+    unknown = sorted(set(overrides) - set(base))
+    if unknown:
+        raise SystemExit(
+            f"{block}_overrides in {src} sets {unknown}, which the model's {block!r} block "
+            f"does not define (has: {sorted(base)})"
+        )
+    merged.update(overrides)
+    return merged
+
+
+def resolve_retrieval_input(cli_value: str | None, cfg: dict, paths_cfg: dict) -> str | None:
+    """The retrieved-few-shot exemplar source: ``--retrieval-input``, then ``input_key``.
+
+    ``retrieval.input_key`` names a ``datasets.<key>`` in the paths config, which is this
+    repo's convention for a path to data outside the tree (no absolute path in a config).
+    ``--retrieval-input`` wins, which is how the fixture and smoke runs point at
+    ``tests/fixtures/retrieval/``. A few-shot run with no exemplar source is refused rather
+    than silently reduced to a zero-shot run under a few-shot label.
+    """
+    src = cfg.get("_config_path", "<config>")
+    explicit = optional(cfg, "retrieval.input")
+    input_key = optional(cfg, "retrieval.input_key")
+    if explicit and input_key:
+        raise SystemExit(
+            f"{src} sets both 'retrieval.input' ({explicit!r}) and 'retrieval.input_key' "
+            f"({input_key!r}); set exactly one, so the config names one retrieval file."
+        )
+    value = cli_value or explicit
+    if not value and input_key:
+        value = str(data_path(paths_cfg, input_key))
+    return value or None
+
+
+def rows_from_questions(
+    *,
+    paths_cfg: dict,
+    cfg: dict,
+    hops: list[int],
+    data_root: Path,
+    seed: int,
+    sample_size,
+) -> list[dict]:
+    """``{query_id, question, expected_hop}`` per query, from the per-hop question files.
+
+    The gold hop depth is the depth of the file the question was read from. ``lines`` files
+    (MetaQA) carry no id, so ``query_id`` is None for them and this run writes no predictions
+    file; ``jsonl`` files (MuSiQue) carry one.
+
+    Sampling stays exactly v1's, seeded before it draws (ADR 0005): one RNG seeded with the
+    run seed, hops drawn in config order, ``min(len(pool), sample_size)`` from each.
+    """
+    template = require(paths_cfg, "datasets." + require(cfg, "questions_template_key"))
+    questions_format = require(cfg, "questions_format")
+    question_field = id_field = ""
+    if questions_format == "jsonl":
+        question_field = require(cfg, "questions_jsonl.question_field")
+        id_field = require(cfg, "questions_jsonl.id_field")
+
+    items_by_hop: dict[int, list[dict]] = {}
+    for hop in hops:
+        path = resolve_path(template.format(hop=hop), data_root)
+        if questions_format == "lines" and not path.exists():
+            # v1 warned and carried on with an empty hop; the "no questions at all" refusal
+            # below is what catches a wholly mis-resolved data root.
+            print(f"Warning: {path} not found.")
+            items_by_hop[hop] = []
+            continue
+        items_by_hop[hop] = rd.load_question_items(
+            path,
+            questions_format=questions_format,
+            question_field=question_field,
+            id_field=id_field,
+        )
+    if sample_size:
+        rng = new_rng(seed)
+        for hop in hops:
+            pool = items_by_hop[hop]
+            items_by_hop[hop] = rng.sample(pool, min(len(pool), int(sample_size)))
+
+    rows: list[dict] = []
+    for hop in hops:
+        for item in items_by_hop[hop]:
+            rows.append(
+                {
+                    "query_id": item["query_id"],
+                    "question": item["question"],
+                    "expected_hop": hop,
+                }
+            )
+    return rows
+
+
+def rows_from_retrieval(path: Path, *, sample_size) -> list[dict]:
+    """``{query_id, question, expected_hop, retrieval_row}`` per query, from a retrieval JSONL.
+
+    The retrieval artifact is the question source *and* the exemplar source, exactly as it is
+    for the decomposer: one row per query, carrying the query id, the query question and the
+    ranked candidate lists. The gold hop depth is parsed from the query id and an id it
+    cannot parse is a refusal, never a guess — the router's accuracy is measured against it.
+
+    ``sample_size_per_hop`` is refused on this path: the artifact is built over a pinned query
+    set (ADR 0007/0014), and a sampled subset would produce a predictions file that does not
+    cover the queries its consumers ask about.
+    """
+    if sample_size:
+        raise SystemExit(
+            f"sample_size_per_hop={sample_size!r} cannot be combined with a retrieval input: "
+            f"{path} is built over a pinned query set, and a sampled run would write a "
+            f"predictions file that does not cover every query its consumers join on. Set "
+            f"sample_size_per_hop to null (or drop --retrieval-input)."
+        )
+    raw = rd.load_jsonl(path)
+    if not raw:
+        raise SystemExit(f"no rows in retrieval input: {path}")
+    rows: list[dict] = []
+    unparseable: list[str] = []
+    no_question: list[str] = []
+    for idx, row in enumerate(raw):
+        question = row.get("query_question")
+        if not isinstance(question, str) or not question.strip():
+            no_question.append(f"index {idx}: query_id={row.get('query_id')!r}")
+            continue
+        hop = parse_hop_from_id(row.get("query_id"))
+        if hop is None:
+            unparseable.append(f"index {idx}: {row.get('query_id')!r}")
+            continue
+        rows.append(
+            {
+                "query_id": row.get("query_id"),
+                "question": question.strip(),
+                "expected_hop": hop,
+                "retrieval_row": row,
+            }
+        )
+    if no_question:
+        raise SystemExit(
+            f"{len(no_question)} of {len(raw)} rows in {path} have no usable "
+            f"'query_question': {_sample(no_question)}"
+        )
+    if unparseable:
+        raise SystemExit(
+            f"{len(unparseable)} of {len(raw)} rows in {path} have a query_id whose hop depth "
+            f"cannot be parsed (expected an id like '2hop__…'): {_sample(unparseable)}. That "
+            f"depth is the gold label the router's accuracy is measured against, so it is a "
+            f"refusal rather than a guess."
+        )
+    return rows
 
 
 def compute_metrics(
@@ -230,6 +624,20 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--sample-size-per-hop", type=int, default=None, help="Override config sample_size_per_hop")
     p.add_argument("--output-root", default=None, help="Override the run output root")
     p.add_argument(
+        "--retrieval-input",
+        default=None,
+        help="Reranked/truncated top-k JSONL: the question source AND the few-shot exemplar "
+        "source for the retrieved-few-shot mode. Overrides retrieval.input / "
+        "retrieval.input_key in the config.",
+    )
+    p.add_argument(
+        "--allow-unpinned-eval-set",
+        action="store_true",
+        help="Permit a run whose loaded row counts/ids are not the config's pinned "
+        "'eval_rows_per_hop' set (ADR 0007). For fixture and smoke runs only: the metrics "
+        "then record evaluation_set.pinned=false, and such a run is not an experiment arm.",
+    )
+    p.add_argument(
         "--dry-run",
         action="store_true",
         help="Assemble prompts and write artifacts without loading a model or generating.",
@@ -265,7 +673,32 @@ def main() -> None:
     )
     hops = [int(h) for h in require(cfg, "hops")]
 
-    prompt_file = args.prompt_file or require(model_cfg, "prompt_file")
+    # Retrieved few-shot (issue #27) and the query-id-keyed predictions file: both off in
+    # configs/router.json, so the MetaQA path is byte-for-byte the run it was before.
+    few_shot_enabled = bool(require(cfg, "few_shot.enabled"))
+    predictions_enabled = bool(require(cfg, "predictions.enabled"))
+    retrieval_input = resolve_retrieval_input(args.retrieval_input, cfg, paths_cfg)
+    if retrieval_input and not few_shot_enabled:
+        raise SystemExit(
+            f"a retrieval input was given ({retrieval_input}) but 'few_shot.enabled' is false "
+            f"in {cfg.get('_config_path', '<config>')}, so no exemplars would be assembled "
+            f"from it. Use a config whose few_shot block is enabled, or drop the input."
+        )
+    if few_shot_enabled and not retrieval_input:
+        raise SystemExit(
+            f"'few_shot.enabled' is true in {cfg.get('_config_path', '<config>')} but no "
+            f"retrieval input was resolved: pass --retrieval-input, or set 'retrieval.input' "
+            f"/ 'retrieval.input_key'. The exemplars are an upstream artifact this runner "
+            f"cannot rebuild, and a few-shot run with no exemplars is a zero-shot run under a "
+            f"few-shot label."
+        )
+
+    # Prompt selection: --prompt-file, then the config's own prompt_file (a config whose
+    # prompting mode needs a specific prompt names it, so the mode cannot be run with the
+    # wrong prompt by forgetting a flag), then the model folder's v1 default.
+    prompt_file = (
+        args.prompt_file or optional(cfg, "prompt_file") or require(model_cfg, "prompt_file")
+    )
     zero_shot = require(cfg, "zero_shot_prompt_marker") in prompt_file
     if args.output_root is not None:
         output_root = Path(args.output_root)
@@ -284,8 +717,50 @@ def main() -> None:
 
     generation = dict(require(model_cfg, "generation"))
     loader = dict(require(model_cfg, "loader"))
-    parsing = dict(require(model_cfg, "parsing"))
+    config_src = cfg.get("_config_path", "<config>")
+    # The model folders are v1 assets (prompts byte-identical, `parsing` mirroring v1's
+    # per-copy code), so a config whose hop depths are not v1's 1/2/3 overrides the response
+    # parsing here instead of editing the asset.
+    parsing = apply_overrides(
+        dict(require(model_cfg, "parsing")),
+        optional(cfg, "parsing_overrides"),
+        block="parsing",
+        src=config_src,
+    )
     parsing["hops"] = hops
+
+    retrieval_mode: str | None = None
+    retrieval_k: int | None = None
+    exemplar_hop_source: str | None = None
+    if few_shot_enabled:
+        retrieval_mode = require(cfg, "retrieval.mode")
+        retrieval_modes = require(cfg, "retrieval.modes")
+        if retrieval_mode not in retrieval_modes:
+            raise SystemExit(f"retrieval mode {retrieval_mode!r} not in {retrieval_modes}")
+        retrieval_k = int(require(cfg, "retrieval.k"))
+        exemplar_hop_source = require(cfg, "few_shot.exemplar_hop_source")
+        if exemplar_hop_source not in EXEMPLAR_HOP_SOURCES:
+            raise SystemExit(
+                f"few_shot.exemplar_hop_source in {config_src} is {exemplar_hop_source!r}; "
+                f"expected one of {list(EXEMPLAR_HOP_SOURCES)}"
+            )
+
+    # Content-address the exemplar source: two router conditions are comparable only if they
+    # read the same exemplars, and "same path" does not prove "same bytes" for a file that
+    # lives outside git (the decomposer records the same pair for the same reason).
+    retrieval_path: Path | None = None
+    retrieval_sha256: str | None = None
+    if retrieval_input:
+        retrieval_path = Path(retrieval_input)
+        if not retrieval_path.is_absolute():
+            retrieval_path = _REPO_ROOT / retrieval_path
+        if not retrieval_path.exists():
+            raise SystemExit(f"retrieval input not found: {retrieval_path}")
+        retrieval_sha256 = rd.sha256_file(retrieval_path)
+
+    predictions_file = require(cfg, "predictions.filename")
+    predictions_id_field = require(cfg, "predictions.id_field")
+    predictions_hop_field = require(cfg, "predictions.hop_field")
 
     current_run_id = run_id()
     seeded = set_global_seed(seed)
@@ -305,10 +780,38 @@ def main() -> None:
         "num_runs": num_runs,
         "sample_size_per_hop": sample_size,
         "hops": hops,
+        "questions_template_key": require(cfg, "questions_template_key"),
+        "questions_format": require(cfg, "questions_format"),
         "device": device,
         "generation": generation,
         "loader": loader,
         "parsing": {k: v for k, v in parsing.items() if k != "hops"},
+        "parsing_overrides": optional(cfg, "parsing_overrides"),
+        "few_shot": {
+            "enabled": few_shot_enabled,
+            "k": retrieval_k,
+            "exemplar_hop_source": exemplar_hop_source,
+            "self_exclusion_by": (
+                ["pool_id == query_id", "normalized pool_question == normalized query"]
+                if few_shot_enabled
+                else None
+            ),
+        },
+        "retrieval": {
+            # The config's own literal values; the path this run read is 'input_resolved'.
+            "input": optional(cfg, "retrieval.input"),
+            "input_key": optional(cfg, "retrieval.input_key"),
+            "input_resolved": str(retrieval_path) if retrieval_path else None,
+            "input_sha256": retrieval_sha256,
+            "mode": retrieval_mode,
+            "k": retrieval_k,
+        },
+        "predictions": {
+            "enabled": predictions_enabled,
+            "filename": predictions_file,
+            "id_field": predictions_id_field,
+            "hop_field": predictions_hop_field,
+        },
         "shared_config": cfg.get("_config_path"),
         "model_config": model_cfg.get("_config_path"),
         "output_root": str(output_root),
@@ -328,59 +831,190 @@ def main() -> None:
     prompt_template = prompt_path.read_text(encoding="utf-8")
     snapshot["prompt_path"] = str(prompt_path)
 
-    # Questions per hop, from the configured data root.
+    # ---- queries: the retrieval artifact when there is one, else the question files ----
     data_root = Path(paths_cfg["data_root_resolved"])
-    template = require(paths_cfg, "datasets." + require(cfg, "questions_template_key"))
-    questions_by_hop: dict[int, list[str]] = {}
-    for hop in hops:
-        path = resolve_path(template.format(hop=hop), data_root)
-        questions_by_hop[hop] = load_questions(path)
+    if retrieval_path is not None:
+        rows = rows_from_retrieval(retrieval_path, sample_size=sample_size)
+        rows_source = str(retrieval_path)
+    else:
+        rows = rows_from_questions(
+            paths_cfg=paths_cfg,
+            cfg=cfg,
+            hops=hops,
+            data_root=data_root,
+            seed=seed,
+            sample_size=sample_size,
+        )
+        rows_source = "questions_template_key"
 
-    if sample_size:
-        # Seeded before sampling: v1 sampled before calling set_seed, so its
-        # --sample_size draws were not reproducible.
-        rng = new_rng(seed)
-        for hop in hops:
-            pool = questions_by_hop[hop]
-            questions_by_hop[hop] = rng.sample(pool, min(len(pool), int(sample_size)))
-
-    all_questions: list[str] = []
-    all_expected: list[int] = []
-    for hop in hops:
-        all_questions.extend(questions_by_hop[hop])
-        all_expected.extend([hop] * len(questions_by_hop[hop]))
-
-    if not all_questions:
+    if not rows:
         raise SystemExit(
-            f"no questions loaded from {data_root} "
-            f"(expected {template} for hops {hops}); set data_root in configs/paths.json"
+            f"no questions loaded from {rows_source} for hops {hops}; "
+            f"set data_root in configs/paths.json"
         )
 
-    counts = {f"{hop}hop": len(questions_by_hop[hop]) for hop in hops}
-    print(f"Loaded {len(all_questions)} questions {counts}")
+    # Query ids, before anything is loaded: a predictions file is a join key plus a number,
+    # so a run that cannot produce one has to say so now rather than after the GPU time.
+    if predictions_enabled:
+        assert_query_ids(
+            rows,
+            source=rows_source,
+            reason=(
+                f"{config_src} sets 'predictions.enabled', so every row needs a unique query "
+                f"id to key the predictions file on: that file is what the retrieval chain's "
+                f"'predictions' hop source and the decomposer's router-guided condition join "
+                f"on (ADR 0022 item 5). A question source with no ids "
+                f"(questions_format 'lines') cannot produce one."
+            ),
+        )
+
+    all_questions = [r["question"] for r in rows]
+    all_expected = [r["expected_hop"] for r in rows]
+    # Counted over the config's hops *and* whatever depths the rows actually carry: the
+    # config's hops keep their key even at zero (v1's shape, and a missing question file is
+    # visible as 0 rather than as an absent key), and a row at a depth the config does not
+    # list is counted rather than dropped - that is what lets the pinned-set assertion below
+    # report it instead of silently ignoring it.
+    counted_hops = sorted({r["expected_hop"] for r in rows} | set(hops))
+    counts = {
+        f"{hop}hop": sum(1 for r in rows if r["expected_hop"] == hop) for hop in counted_hops
+    }
+    rows_per_hop = {str(hop): counts[f"{hop}hop"] for hop in counted_hops}
+    print(f"Loaded {len(rows)} questions {counts}")
+
+    # The pinned evaluation set, by id and not only by count (the decomposer's shared
+    # assertion): a router prediction file over a different 600 questions cannot be joined
+    # against the arms it is supposed to route (ADR 0007, ADR 0011).
+    pinned_ids: set[str] = set()
+    pinned_files: list[str] = []
+    pinned_id_problems: list[str] = []
+    if optional(cfg, "eval_rows_per_hop") is not None:
+        pinned_ids, pinned_files, pinned_id_problems = rd.load_pinned_eval_ids(
+            paths_cfg, cfg, hops, data_root
+        )
+    loaded_ids = {str(r["query_id"]) for r in rows if r["query_id"] is not None}
+    eval_set_record = rd.assert_pinned_eval_set(
+        rows_per_hop,
+        len(rows),
+        cfg=cfg,
+        hops=hops,
+        allow_unpinned=args.allow_unpinned_eval_set,
+        source=rows_source,
+        loaded_ids=loaded_ids,
+        pinned_ids=pinned_ids,
+        pinned_files=pinned_files,
+        pinned_id_problems=pinned_id_problems,
+        remedy=(
+            "Point --retrieval-input at a file built over exactly those questions (or use the "
+            "config's questions_template_key), or pass --allow-unpinned-eval-set for a "
+            "fixture run that is not an experiment arm."
+        ),
+        component="router",
+    )
+    eval_set_record["rows_loaded_total"] = len(rows)
+    eval_set_record["rows_loaded_per_hop"] = rows_per_hop
+    eval_set_record["distinct_query_ids"] = len(loaded_ids)
+    snapshot["evaluation_set"] = eval_set_record
+    print(f"Evaluation set: {json.dumps(eval_set_record, default=str)}")
+
+    # ---- prompts, one per query, before any model is loaded ----
+    if few_shot_enabled and "{few_shot_examples}" not in prompt_template:
+        raise SystemExit(
+            f"'few_shot.enabled' is true in {config_src} but the prompt {prompt_path} has no "
+            f"'{{few_shot_examples}}' placeholder, so the retrieved exemplars would never "
+            f"reach the model and the run would be zero-shot under a few-shot label. Select a "
+            f"prompt that takes exemplars (--prompt-file prompt_few_shot_musique.md)."
+        )
+    if not few_shot_enabled and "{few_shot_examples}" in prompt_template:
+        raise SystemExit(
+            f"the prompt {prompt_path} takes '{{few_shot_examples}}' but 'few_shot.enabled' is "
+            f"false in {config_src}, so the prompt would be rendered with an empty exemplar "
+            f"block. Enable the few-shot block, or select a prompt that carries its own "
+            f"examples."
+        )
+
+    self_excluded_rows = 0
+    self_excluded_examples = 0
+    for row in rows:
+        examples: list[dict] = []
+        if few_shot_enabled:
+            # Both resolved above, next to few_shot_enabled; asserted for the type checker.
+            assert retrieval_mode is not None and retrieval_k is not None
+            examples, dropped = examples_from_retrieval_row(
+                row["retrieval_row"],
+                mode=retrieval_mode,
+                k=retrieval_k,
+                exemplar_hop_source=exemplar_hop_source,
+            )
+            if dropped:
+                self_excluded_rows += 1
+                self_excluded_examples += dropped
+        row["few_shot_examples"] = examples
+        row["prompt"] = build_prompt(
+            prompt_template, row["question"], format_few_shot_examples(examples)
+        )
+
+    few_shot_record = {
+        "enabled": few_shot_enabled,
+        "k": retrieval_k,
+        "exemplar_hop_source": exemplar_hop_source,
+        "retrieval_input": str(retrieval_path) if retrieval_path else None,
+        "retrieval_input_sha256": retrieval_sha256,
+        "retrieval_mode": retrieval_mode,
+        "rows_with_a_self_example_dropped": self_excluded_rows,
+        "self_examples_dropped": self_excluded_examples,
+        "note": (
+            "an exemplar that is the query itself is dropped from the ranked list before the "
+            "top-k is taken (by pool id and by normalized question text)"
+            if few_shot_enabled
+            else "no exemplars were retrieved in this run, so there was nothing to exclude"
+        ),
+    }
+    snapshot["few_shot"] = {**snapshot["few_shot"], **few_shot_record}
 
     output_dir = output_root / current_run_id
 
-    if args.dry_run:
-        sample = all_questions[: max(0, args.dry_run_limit)]
-        prompts = [build_prompt(prompt_template, q) for q in sample]
+    def write_prompt_logs(logged: list[dict]) -> Path:
         prompts_dir = output_dir / "prompts_log"
         prompts_dir.mkdir(parents=True, exist_ok=True)
-        for i, (q, prompt) in enumerate(zip(sample, prompts), start=1):
+        for i, row in enumerate(logged, start=1):
+            exemplars = "\n".join(
+                f"  {j}. hop={ex['hop_count']} pool_id={ex['pool_id']} | {ex['question']}"
+                for j, ex in enumerate(row["few_shot_examples"], start=1)
+            ) or "  (none)"
             (prompts_dir / f"prompt_idx{i:04d}.txt").write_text(
-                f"--- Question ---\n{q}\n\n--- Prompt ---\n{prompt}\n", encoding="utf-8"
+                f"--- Question ---\n{row['question']}\n"
+                f"--- Query id ---\n{row['query_id']}\n"
+                f"--- Gold hop ---\n{row['expected_hop']}\n"
+                f"--- Few-shot exemplars ({len(row['few_shot_examples'])}) ---\n{exemplars}\n"
+                f"\n--- Prompt ---\n{row['prompt']}\n",
+                encoding="utf-8",
             )
+        return prompts_dir
+
+    if args.dry_run:
+        logged = rows[: max(0, args.dry_run_limit)]
+        prompts_dir = write_prompt_logs(logged)
         metrics = {
             "dry_run": True,
-            "total_questions_loaded": len(all_questions),
+            "total_questions_loaded": len(rows),
             "questions_per_hop": counts,
-            "prompts_assembled": len(prompts),
+            "evaluation_set": eval_set_record,
+            "prompts_assembled": len(logged),
             "prompt_chars_mean": (
-                sum(len(p) for p in prompts) / len(prompts) if prompts else 0
+                sum(len(r["prompt"]) for r in logged) / len(logged) if logged else 0
             ),
+            "few_shot": few_shot_record,
             "model_size": unasserted_note("router", require(model_cfg, "model_id")),
             "accuracy_metrics": None,
             "accuracy_metrics_note": "unmeasured: --dry-run does not load a model or generate",
+            # Stated rather than left absent: a dry run predicts nothing, so writing a
+            # predictions file would mean fabricating routing decisions.
+            "predictions_file": None,
+            "predictions_note": (
+                "not written: --dry-run generates nothing, so there is no prediction to key "
+                "by query id"
+            ),
         }
         write_run_artifacts(
             output_dir,
@@ -390,9 +1024,14 @@ def main() -> None:
             note_lines=[
                 f"- Model folder: `{args.model}` (model not loaded)",
                 f"- Prompt: `{prompt_path}`",
-                f"- Questions loaded: {len(all_questions)} {counts}",
-                f"- Prompts assembled: {len(prompts)} (logged under `{prompts_dir}`)",
+                f"- Questions loaded: {len(rows)} {counts} (source: {rows_source})",
+                f"- Evaluation set pinned: {eval_set_record['pinned']} "
+                f"(ids checked: {eval_set_record['id_identity_checked']})",
+                f"- Few-shot: enabled={few_shot_enabled} k={retrieval_k}; "
+                f"self-examples dropped: {self_excluded_examples}",
+                f"- Prompts assembled: {len(logged)} (logged under `{prompts_dir}`)",
                 "- Accuracy: unmeasured (dry run).",
+                "- Predictions file: not written (dry run predicts nothing).",
                 "- Parameter ceiling: not asserted (no model was loaded).",
             ],
         )
@@ -408,6 +1047,7 @@ def main() -> None:
 
     all_runs_metrics: list[dict] = []
     all_runs_predictions: list[list[int]] = []
+    all_runs_parsed: list[list[bool]] = []
     progress_every = int(require(cfg, "progress_every"))
 
     for run_idx in range(num_runs):
@@ -415,15 +1055,17 @@ def main() -> None:
         set_global_seed(run_seed)
         print(f"\n--- Run {run_idx + 1}/{num_runs} (seed={run_seed}) ---")
         predictions: list[int] = []
-        for i, question in enumerate(all_questions):
+        parsed_flags: list[bool] = []
+        for i, row in enumerate(rows):
             if (i + 1) % progress_every == 0:
-                print(f"Processed {i + 1}/{len(all_questions)}...")
-            predictions.append(
-                classify_hop_count(
-                    question, model, tokenizer, device, prompt_template, generation, parsing
-                )
+                print(f"Processed {i + 1}/{len(rows)}...")
+            hop, parsed = classify_hop_count(
+                row["prompt"], row["question"], model, tokenizer, device, generation, parsing
             )
+            predictions.append(hop)
+            parsed_flags.append(parsed)
         all_runs_predictions.append(predictions)
+        all_runs_parsed.append(parsed_flags)
         run_metrics = compute_metrics(
             predictions, all_expected, run_seed, model_id, current_run_id, hops, run_idx=run_idx
         )
@@ -448,7 +1090,13 @@ def main() -> None:
 
     metrics["model_size"] = size_record
     metrics["questions_per_hop"] = counts
+    metrics["evaluation_set"] = eval_set_record
+    metrics["few_shot"] = few_shot_record
     metrics["dry_run"] = False
+    # A prediction that fell back to parsing.default_hop is a default, not a routing
+    # decision; counted so a reader of the metrics can see how much of the accuracy is
+    # actually predicted. Reported for run 0, which is the run the outputs come from.
+    metrics["unparsed_response_rows"] = sum(1 for ok in all_runs_parsed[0] if not ok)
 
     print("\n" + "=" * 30)
     if num_runs == 1:
@@ -468,14 +1116,57 @@ def main() -> None:
     print("=" * 30)
 
     detailed = [
-        {"question": q, "expected": e, "predicted": p, "correct": p == e}
-        for q, e, p in zip(all_questions, all_expected, all_runs_predictions[0])
+        {
+            # query_id first: v1's detailed_results.json was keyed by question text only,
+            # which is the field the masking modes rewrite (ADR 0022 item 5).
+            "query_id": row["query_id"],
+            "question": row["question"],
+            "expected": e,
+            "predicted": p,
+            "correct": p == e,
+            "parse_fallback": not parsed,
+        }
+        for row, e, p, parsed in zip(
+            rows, all_expected, all_runs_predictions[0], all_runs_parsed[0]
+        )
     ]
     output_dir.mkdir(parents=True, exist_ok=True)
     detailed_name = "detailed_results.json" if num_runs == 1 else "detailed_results_run_0.json"
     (output_dir / detailed_name).write_text(
         json.dumps(detailed, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
+
+    # The query-id-keyed predictions file: run 0's predictions, one object per query. This is
+    # the artifact issue #15's router-hop-matched condition and the decomposer's
+    # router_guided condition consume; both join on the id.
+    predictions_path: Path | None = None
+    if predictions_enabled:
+        predictions_path = output_dir / predictions_file
+        write_predictions_jsonl(
+            predictions_path,
+            build_prediction_rows(
+                rows,
+                all_runs_predictions[0],
+                all_runs_parsed[0],
+                id_field=predictions_id_field,
+                hop_field=predictions_hop_field,
+            ),
+        )
+        print(f"Predictions ({len(rows)} rows, keyed by {predictions_id_field}): {predictions_path}")
+    metrics["predictions_file"] = str(predictions_path) if predictions_path else None
+    metrics["predictions_rows"] = len(rows) if predictions_path else 0
+    metrics["predictions_id_field"] = predictions_id_field if predictions_path else None
+    metrics["predictions_hop_field"] = predictions_hop_field if predictions_path else None
+    if predictions_path is None:
+        metrics["predictions_note"] = (
+            f"not written: {config_src} sets predictions.enabled false (a question source "
+            f"with no ids cannot be keyed by query id)"
+        )
+    elif num_runs > 1:
+        metrics["predictions_note"] = (
+            f"predictions are run 0 of {num_runs}, the same run detailed_results_run_0.json "
+            f"records; the other runs' predictions are not written"
+        )
 
     headline = (
         f"- Overall accuracy: {metrics['overall_accuracy']:.4f}"
@@ -495,9 +1186,27 @@ def main() -> None:
             f"ceiling {size_record['parameter_ceiling']:,})",
             f"- Prompt: `{prompt_path}`",
             f"- Seed: {seed} (runs use seed, seed+1, ...)",
-            f"- Questions: {len(all_questions)} {counts}",
+            f"- Questions: {len(all_questions)} {counts} (source: {rows_source})",
+            f"- Evaluation set pinned: {eval_set_record['pinned']} "
+            f"(ids checked against the pinned files: "
+            f"{eval_set_record['id_identity_checked']})",
+            f"- Few-shot: enabled={few_shot_enabled} k={retrieval_k}"
+            + (
+                f" from `{retrieval_path}` (sha256 `{retrieval_sha256}`), mode "
+                f"{retrieval_mode}; self-examples dropped: {self_excluded_examples}"
+                if few_shot_enabled
+                else " (prompt carries its own examples, or none)"
+            ),
             headline,
+            f"- Responses with no readable hop count (defaulted): "
+            f"{metrics['unparsed_response_rows']} of {len(rows)}",
             f"- Detailed predictions: `{output_dir / detailed_name}`",
+            (
+                f"- Predictions keyed by `{predictions_id_field}`: `{predictions_path}` "
+                f"({len(rows)} rows)"
+                if predictions_path
+                else "- Predictions file: not written (this question source carries no ids)."
+            ),
         ],
     )
     print(f"\nResults saved to: {output_dir}")

--- a/components/router/run_router.py
+++ b/components/router/run_router.py
@@ -50,15 +50,19 @@ import re
 import statistics
 import sys
 from pathlib import Path
+from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-#: Four rules this component must not own a second copy of: how a question source with ids
+#: Three rules this component must not own a second copy of: how a question source with ids
 #: is read, what "this exemplar IS the query" means, and what the pinned ADR 0007 evaluation
 #: set is (by id, not only by count). They live in the decomposer's runner and are *imported*
 #: here rather than duplicated, the same way ``components/answerer/run_answerer.py`` imports
 #: the eval-set assertion — a second copy of a leakage rule is a rule that drifts.
+#:
+#: Inserted BEFORE ``src`` so that ``src`` ends up first on the path: the shared modules must
+#: not be shadowed by a same-named file in a component directory (PR #43 review, N3).
 sys.path.insert(0, str(_REPO_ROOT / "components" / "decomposer"))
+sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 from hop_matching import parse_hop_from_id  # noqa: E402
 from model_size import assert_within_ceiling, load_limits, unasserted_note  # noqa: E402
@@ -73,12 +77,23 @@ from run_config import (  # noqa: E402
     runs_path,
 )
 from seeding import new_rng, set_global_seed  # noqa: E402
+from step_lines import post_process_generation  # noqa: E402
 
 import run_decomposer as rd  # noqa: E402
 
-_THINK_RX = re.compile(r"<think>.*?</think>", re.DOTALL)
+#: Number words, for the response-parsing fallbacks. Covers 1-9 rather than v1's 1-3 so the
+#: fallback follows the config's ``hops`` instead of MetaQA's: with 1/2/3 only, a MuSiQue
+#: router's "four hops" fell through to ``parsing.default_hop`` and was scored as a
+#: prediction (PR #43 review, I1). The upper bound is 9 because the digit-class rule builds a
+#: single-character regex class; :func:`assert_parsing_covers_hops` refuses a two-digit hop
+#: depth rather than mis-parsing it.
+_NUMBER_WORDS = {
+    "ONE": 1, "TWO": 2, "THREE": 3, "FOUR": 4, "FIVE": 5,
+    "SIX": 6, "SEVEN": 7, "EIGHT": 8, "NINE": 9,
+}
 
-_NUMBER_WORDS = {"ONE": 1, "TWO": 2, "THREE": 3}
+#: The largest hop depth the digit-class parsing rule can read (single character class).
+MAX_PARSEABLE_HOP = 9
 
 #: How many offending ids / rows an error message lists before it truncates.
 _MAX_REPORTED = 10
@@ -179,6 +194,7 @@ def examples_from_retrieval_row(
             f"k, or lower few_shot k in the config."
         )
     examples: list[dict] = []
+    query_question = row.get("query_question")
     for cand in kept[:k]:
         hop = parse_hop_from_id(cand.get("pool_id"))
         if hop is None:
@@ -198,6 +214,17 @@ def examples_from_retrieval_row(
         examples.append(
             {"pool_id": cand.get("pool_id"), "question": question.strip(), "hop_count": hop}
         )
+    # The point of the exclusion is that no exemplar is the query; assert it on the kept set
+    # rather than trusting the filter above (the decomposer asserts the same thing after its
+    # own filter - PR #43 review, N1).
+    wanted = rd.normalize_for_self_exclusion(query_question)
+    for ex in examples:
+        if wanted and rd.normalize_for_self_exclusion(ex["question"]) == wanted:
+            raise AssertionError(
+                f"[router] query_id={query_id!r} kept an exemplar identical to the query "
+                f"after self-exclusion (pool_id={ex['pool_id']!r}); this is a bug in "
+                f"examples_from_retrieval_row."
+            )
     return examples, self_excluded
 
 
@@ -282,6 +309,112 @@ def write_predictions_jsonl(path: Path, rows: list[dict]) -> None:
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
 
+def clean_response(response: str, truncate_at: list[str] | tuple[str, ...] | None) -> str:
+    """The part of a response that is the model's answer, before any hop count is read.
+
+    Two steps, in this order:
+
+    1. ``<think>`` blocks and outer whitespace go, with the shared helper the decomposer
+       uses (``src/step_lines.py``), so there is one definition of "generation artifact";
+    2. the text is cut at the first of the configured tail markers.
+
+    The order matters and is the reason this is not a single call to
+    ``post_process_generation``: that helper truncates *before* stripping outer whitespace,
+    so a response beginning with a newline would be cut down to the empty string by a
+    ``"\\n"`` marker.
+
+    Why truncation exists at all (PR #43 review, C1). The retrieved-few-shot prompt ends with
+    the ``A:`` cue, so the model's own answer is the *first* thing in the response - and a
+    model with tokens left over then happily writes a fresh ``Q: … A: …`` pair of its own.
+    Read against the untruncated response, an ``A:\\s*(\\d)`` rule matches that regurgitated
+    pair instead of the answer, and returns another question's hop count as this query's
+    prediction with ``parse_fallback`` false. Cutting the response at its first line ends the
+    read at the answer. Markers come from the config, because what counts as the tail depends
+    on the prompt: the v1 MetaQA prompts elicit a multi-line ``Trace:``/``A:`` response and
+    set no markers at all, so their parsing is unchanged.
+    """
+    cleaned = post_process_generation(response, strip_think=True, truncate_at=None)
+    for marker in truncate_at or []:
+        cleaned = cleaned.split(marker)[0]
+    return cleaned.strip()
+
+
+def hop_word_labels(hop: int) -> tuple[str, ...]:
+    """The written forms of "<hop> hops" the ``hop_words`` fallback recognises.
+
+    Derived from the hop depth rather than listed per depth, so the fallback follows the
+    config's ``hops`` and cannot silently cover 1/2/3 only (PR #43 review, I1).
+    """
+    word = next((w for w, v in _NUMBER_WORDS.items() if v == hop), None)
+    labels = [f"{hop}-hop", f"{hop} hop"]
+    if word:
+        labels += [f"{word.lower()}-hop", f"{word.lower()} hop"]
+    return tuple(labels)
+
+
+def assert_parsing_covers_hops(parsing: dict, hops: list[int], *, src: str) -> dict[str, Any]:
+    """Refuse a config whose parsing rules cannot express every hop depth it may predict.
+
+    A source-level guard for what the configs used to say in prose only (ADR 0016: an
+    invariant that matters is asserted, not documented). Three refusals:
+
+    - a hop depth above :data:`MAX_PARSEABLE_HOP`, because the digit-class rule is a
+      single-character regex class and a two-digit depth would read as its first digit;
+    - a hop depth the configured ``fallback_labels`` table has no word for, which would send
+      an otherwise readable response ("four hops") to ``default_hop``;
+    - a ``default_hop`` outside ``hops``, which would score every defaulted row against a
+      class the run does not evaluate.
+
+    The reason this is a refusal and not a warning (PR #43 review, I1): the default is
+    returned *as if it were a prediction*, so an uncovered depth does not look like a
+    failure - it looks like a router that always answers ``default_hop``, and on a set with
+    200 questions per hop that is a plausible-looking accuracy number.
+    """
+    if not hops:
+        raise SystemExit(f"{src} declares no 'hops', so there is nothing to predict")
+    too_deep = [h for h in hops if h < 1 or h > MAX_PARSEABLE_HOP]
+    if too_deep:
+        raise SystemExit(
+            f"{src} declares hop depth(s) {too_deep} outside 1..{MAX_PARSEABLE_HOP}. The "
+            f"response-parsing rules read a single digit (a regex character class), so a "
+            f"two-digit depth would be read as its first digit. Widening the range means "
+            f"changing the parsing rules, not the config."
+        )
+    fallback = require(parsing, "fallback_labels")
+    if fallback == "hop_words":
+        uncovered = [h for h in hops if not hop_word_labels(h)]
+        covered = {h: list(hop_word_labels(h)) for h in hops}
+    elif fallback == "number_words":
+        words = {v: w for w, v in _NUMBER_WORDS.items()}
+        uncovered = [h for h in hops if h not in words]
+        covered = {h: [words[h]] for h in hops if h in words}
+    else:
+        raise SystemExit(f"{src}: unknown parsing.fallback_labels {fallback!r}")
+    if uncovered:
+        raise SystemExit(
+            f"{src}: the {fallback!r} response-parsing fallback has no label for hop "
+            f"depth(s) {uncovered}, so a response naming one in words would fall through to "
+            f"parsing.default_hop and be recorded as a prediction. Extend _NUMBER_WORDS in "
+            f"{Path(__file__).name} (and its test) rather than accepting the gap."
+        )
+    default_hop = int(require(parsing, "default_hop"))
+    if default_hop not in hops:
+        raise SystemExit(
+            f"{src}: parsing.default_hop={default_hop} is not one of hops {hops}. Every "
+            f"unreadable response is recorded as that depth, so a default outside the "
+            f"evaluated classes would be counted as wrong for every query by construction. "
+            f"Set it with parsing_overrides if the model folder's value does not fit."
+        )
+    return {
+        "hops": list(hops),
+        "fallback_labels": fallback,
+        "labels_per_hop": covered,
+        "default_hop": default_hop,
+        "digit_class": "[" + "".join(str(h) for h in hops) + "]",
+        "asserted": True,
+    }
+
+
 def parse_hop_response(response: str, question: str, parsing: dict) -> tuple[int, bool]:
     """Extract a hop count from the model response, per the model's parsing config.
 
@@ -299,7 +432,7 @@ def parse_hop_response(response: str, question: str, parsing: dict) -> tuple[int
     digit_class = "[" + "".join(str(h) for h in hops) + "]"
     default_hop = int(require(parsing, "default_hop"))
 
-    clean = _THINK_RX.sub("", response, count=0).strip()
+    clean = clean_response(response, require(parsing, "truncate_at"))
 
     answer_regex = optional(parsing, "answer_regex")
     if answer_regex:
@@ -313,12 +446,8 @@ def parse_hop_response(response: str, question: str, parsing: dict) -> tuple[int
     fallback = require(parsing, "fallback_labels")
     if fallback == "hop_words":
         lower = clean.lower()
-        for hop, words in (
-            (1, ("1-hop", "one hop")),
-            (2, ("2-hop", "two hop")),
-            (3, ("3-hop", "three hop")),
-        ):
-            if hop in hops and any(w in lower for w in words):
+        for hop in hops:
+            if any(w in lower for w in hop_word_labels(hop)):
                 return hop, True
     elif fallback == "number_words":
         upper = clean.upper()
@@ -354,6 +483,13 @@ def classify_hop_count(
     The prompt is assembled by the caller (once per query, before anything is loaded) so
     that the retrieved-few-shot mode, the dry run and the real run all render the *same*
     text, and so a ``--dry-run`` exercises prompt assembly for real.
+
+    ``eos_token_id`` is passed explicitly (as the decomposer does) so a model that has
+    finished its answer can stop instead of spending the rest of the token budget writing
+    further question/answer pairs of its own. It is the same value ``generate`` would take
+    from the model's generation config, so this changes no v1 decoding; it is the stopping
+    behaviour that is *stated* rather than assumed. It is not what makes the parsing safe -
+    :func:`clean_response` is, because a model can always keep going (PR #43 review, C1).
     """
     import torch
 
@@ -370,6 +506,7 @@ def classify_hop_count(
             top_p=float(require(generation, "top_p")),
             do_sample=bool(require(generation, "do_sample")),
             pad_token_id=tokenizer.pad_token_id,
+            eos_token_id=tokenizer.eos_token_id,
         )
 
     response = tokenizer.decode(
@@ -550,6 +687,52 @@ def rows_from_retrieval(path: Path, *, sample_size) -> list[dict]:
     return rows
 
 
+#: What the accuracy numbers mean, recorded next to them. A metrics file read on its own has
+#: to say what "accuracy" was computed against, and a per-hop row of a routing table is easy
+#: to read as precision when it is recall (PR #43 review, I2).
+ACCURACY_DEFINITIONS = {
+    "gold_hop_count": (
+        "the query's GOLD hop depth: parsed from its MuSiQue id ('2hop__…' -> 2) on the "
+        "retrieval path, or the depth of the per-hop question file it was read from. Never a "
+        "prediction."
+    ),
+    "overall_accuracy": (
+        "exact-hop accuracy: predicted hop == gold hop, over every query in the run. Rows "
+        "whose response carried no readable hop count are INCLUDED, scored at "
+        "parsing.default_hop (see unparsed_response_rows)."
+    ),
+    "hop_<h>_accuracy": (
+        "within-gold-class recall: of the queries whose GOLD depth is h, the fraction "
+        "predicted h. It is not precision - it says nothing about how many other queries "
+        "were also predicted h, so the rows do not decompose a confusion matrix."
+    ),
+    "hop_<h>_total": "how many queries have gold depth h (the denominator above)",
+    "unparsed_response_rows": (
+        "rows whose response carried no readable hop count, so parsing.default_hop was "
+        "recorded as the prediction. They are counted in the accuracies above, which means a "
+        "high count inflates the accuracy of whichever class default_hop belongs to; "
+        "unparsed_response_rows_per_gold_hop breaks them out."
+    ),
+}
+
+
+def unparsed_rows_per_hop(
+    all_expected: list[int], parsed_flags: list[bool], hops: list[int]
+) -> dict[str, int]:
+    """How many defaulted rows sit in each gold hop class.
+
+    Reported because a defaulted row is scored as a prediction: with default_hop = 2, every
+    unreadable response is correct for a 2-hop query and wrong for a 3- or 4-hop one, so
+    where the defaults fell decides how much of a per-hop number is real (PR #43 review, I1).
+    """
+    return {
+        str(hop): sum(
+            1 for expected, ok in zip(all_expected, parsed_flags) if expected == hop and not ok
+        )
+        for hop in hops
+    }
+
+
 def compute_metrics(
     predictions: list[int],
     all_expected: list[int],
@@ -559,7 +742,7 @@ def compute_metrics(
     hops: list[int],
     run_idx: int | None = None,
 ) -> dict:
-    """Metrics for one run."""
+    """Metrics for one run. See :data:`ACCURACY_DEFINITIONS` for what they measure."""
     correct = sum(1 for p, e in zip(predictions, all_expected) if p == e)
     accuracy = correct / len(predictions) if predictions else 0.0
     per_hop: dict[str, float | int] = {}
@@ -703,10 +886,17 @@ def main() -> None:
     if args.output_root is not None:
         output_root = Path(args.output_root)
     else:
-        subdir = (
-            require(cfg, "output_subdir_zero_shot") if zero_shot
-            else require(cfg, "output_subdir_few_shot")
-        )
+        # A config declares an output root only for the prompting modes it supports, so a
+        # config with no zero-shot arm does not carry a dead zero-shot subdir (PR #43 review,
+        # N2). Selecting a prompt that mode does not cover is a refusal naming the key.
+        subdir_key = "output_subdir_zero_shot" if zero_shot else "output_subdir_few_shot"
+        subdir = optional(cfg, subdir_key)
+        if not subdir:
+            raise SystemExit(
+                f"{cfg.get('_config_path', '<config>')} declares no {subdir_key!r}, so it has "
+                f"no output root for the prompt this run selected ({prompt_file!r}). Pass "
+                f"--output-root, or use a config that supports this prompting mode."
+            )
         output_root = runs_path(paths_cfg, subdir)
 
     device = "cpu"
@@ -728,6 +918,14 @@ def main() -> None:
         src=config_src,
     )
     parsing["hops"] = hops
+    # Which tail markers end the answer in this prompt's responses. Declared per config
+    # because it is a property of the prompt shape, not of the model: the v1 MetaQA prompts
+    # set none (their responses are multi-line), the retrieved-few-shot prompt cuts at the
+    # first line break (see clean_response).
+    parsing["truncate_at"] = list(require(cfg, "response_truncate_at"))
+    # Before anything is loaded, and reachable by --dry-run: the parsing rules must be able to
+    # express every hop depth this config may predict, and default_hop must be one of them.
+    parsing_coverage = assert_parsing_covers_hops(parsing, hops, src=config_src)
 
     retrieval_mode: str | None = None
     retrieval_k: int | None = None
@@ -785,8 +983,10 @@ def main() -> None:
         "device": device,
         "generation": generation,
         "loader": loader,
-        "parsing": {k: v for k, v in parsing.items() if k != "hops"},
+        "parsing": {k: v for k, v in parsing.items() if k not in ("hops", "truncate_at")},
         "parsing_overrides": optional(cfg, "parsing_overrides"),
+        "response_truncate_at": parsing["truncate_at"],
+        "parsing_coverage": parsing_coverage,
         "few_shot": {
             "enabled": few_shot_enabled,
             "k": retrieval_k,
@@ -1005,6 +1205,7 @@ def main() -> None:
                 sum(len(r["prompt"]) for r in logged) / len(logged) if logged else 0
             ),
             "few_shot": few_shot_record,
+            "parsing_coverage": parsing_coverage,
             "model_size": unasserted_note("router", require(model_cfg, "model_id")),
             "accuracy_metrics": None,
             "accuracy_metrics_note": "unmeasured: --dry-run does not load a model or generate",
@@ -1092,11 +1293,18 @@ def main() -> None:
     metrics["questions_per_hop"] = counts
     metrics["evaluation_set"] = eval_set_record
     metrics["few_shot"] = few_shot_record
+    metrics["parsing_coverage"] = parsing_coverage
+    metrics["accuracy_definitions"] = ACCURACY_DEFINITIONS
     metrics["dry_run"] = False
     # A prediction that fell back to parsing.default_hop is a default, not a routing
     # decision; counted so a reader of the metrics can see how much of the accuracy is
-    # actually predicted. Reported for run 0, which is the run the outputs come from.
+    # actually predicted, and broken out per gold hop because a default is scored as a
+    # prediction (default_hop is correct for its own class and wrong for every other).
+    # Reported for run 0, which is the run the outputs come from.
     metrics["unparsed_response_rows"] = sum(1 for ok in all_runs_parsed[0] if not ok)
+    metrics["unparsed_response_rows_per_gold_hop"] = unparsed_rows_per_hop(
+        all_expected, all_runs_parsed[0], hops
+    )
 
     print("\n" + "=" * 30)
     if num_runs == 1:
@@ -1198,8 +1406,12 @@ def main() -> None:
                 else " (prompt carries its own examples, or none)"
             ),
             headline,
-            f"- Responses with no readable hop count (defaulted): "
-            f"{metrics['unparsed_response_rows']} of {len(rows)}",
+            f"- Responses with no readable hop count (recorded as "
+            f"parsing.default_hop={parsing_coverage['default_hop']}, and counted in the "
+            f"accuracies above): {metrics['unparsed_response_rows']} of {len(rows)}, per gold "
+            f"hop {metrics['unparsed_response_rows_per_gold_hop']}",
+            f"- Accuracy is exact-hop against the GOLD depth; the per-hop rows are "
+            f"within-gold-class recall (see accuracy_definitions in metrics.json)",
             f"- Detailed predictions: `{output_dir / detailed_name}`",
             (
                 f"- Predictions keyed by `{predictions_id_field}`: `{predictions_path}` "

--- a/configs/decomposer.json
+++ b/configs/decomposer.json
@@ -10,6 +10,14 @@
   "questions_format": "lines",
   "unguided_hop_placeholder": "Unknown",
 
+  "hop_source": "gold",
+  "hop_predictions": {
+    "file": null,
+    "id_field": "query_id",
+    "hop_field": "predicted_hop"
+  },
+  "_hop_source_note": "'gold' is the MetaQA path's behaviour, unchanged: a guided run injects the hop depth of the question file the question was read from. The router-guided source ('predictions', joined on a query id) is a MuSiQue condition and needs a question source that carries ids, which 'lines' files do not; the field names are declared here anyway so this config states the interface rather than leaving a required key missing.",
+
   "few_shot_exemplar_hop_count": "query",
   "_few_shot_exemplar_hop_count_note": "v1 behaviour, unchanged: in a guided MetaQA run every few-shot exemplar's 'Hop count:' line states the QUERY's hop count. Jahid's 2026-08-19 decision to state each exemplar's own gold step count instead was taken for the MuSiQue conditions (configs/decomposer_musique.json sets 'exemplar_gold'), so it is not applied here: changing it would change MetaQA guided prompts, which no one asked for. Verified 2026-08-19 that this path renders exactly as before.",
 

--- a/configs/decomposer_musique.json
+++ b/configs/decomposer_musique.json
@@ -25,6 +25,14 @@
   "eval_rows_per_hop": 200,
   "_eval_rows_per_hop_note": "Asserted by run_decomposer.py at load time, whether the questions come from questions_template_key or from --retrieval-input, and asserted twice over: (1) the per-hop row counts must be 200/200/200 (600 total), and (2) the loaded question ids must be EXACTLY the ids in the three files behind questions_template_key - counts alone would let a different 600 questions through, and 600 of the wrong questions is not the pinned set. A mismatch is refused, naming the offending hop depths and up to ten offending ids. ADR 0007 pins the set and ADR 0011's stance is that a comparison across different evaluation sets is not a comparison. --allow-unpinned-eval-set is the explicit opt-out for fixture/smoke runs; it records evaluation_set.pinned false in the metrics and such a run is not an experiment arm.",
 
+  "hop_source": "gold",
+  "hop_predictions": {
+    "file": null,
+    "id_field": "query_id",
+    "hop_field": "predicted_hop"
+  },
+  "_hop_source_note": "Where a GUIDED arm's hop count comes from. 'gold' is the default and is what every arm before issue #27 did: the query's own depth, parsed from its id on the retrieval path. A condition may override it with 'predictions' (the router_guided arm below), and then the hop count is read from a router predictions JSONL and joined on the query id - one object per query, with the id and hop field names declared here; they are the defaults components/router/run_router.py writes and the retrieval chain's hop_match reads (ADR 0022 item 5). hop_predictions.file is null on purpose: a routed run names the predictions file it used with --hop-predictions, because that file is a run output (runs/, gitignored) rather than a pinned artifact, and a stale path in a committed config would silently route a later run with an older router. The runner refuses the mismatched combinations: an unimplemented source, 'predictions' in an unguided arm, 'predictions' with no file, and --hop-predictions passed to a 'gold' arm.",
+
   "condition": "unguided",
   "conditions": {
     "unguided": {
@@ -35,13 +43,18 @@
       "guided": true,
       "_note": "Two kinds of hop line, both gold. (1) The QUERY's gold hop count goes into the prompt through the guided mechanism's {hop_count} placeholder: the gold depth of the evaluation file the question was read from, or the depth parsed from its id on the retrieval path - never a prediction, and never a fallback (an id whose hop depth cannot be parsed is refused). (2) Each FEW-SHOT EXEMPLAR's 'Hop count:' line carries THAT EXEMPLAR's own gold hop count, defined as the number of steps in its own gold decomposition (pool_few_shot_decomposition_musique), counted with the shared splitter in src/step_lines.py - Jahid's decision of 2026-08-19 on issue #12, set here by few_shot_exemplar_hop_count. v1 stamped the query's hop count on every exemplar, which made most exemplar hop lines contradict the exemplar shown beneath them (measured: 1740 of 3000 on the 600 oracle_guided prompts of the 2026-08-19 dry run); that behaviour is gone from this config and v1's guided numbers are not directly comparable - see docs/adr/0013. An exemplar with a missing or empty gold decomposition is refused, naming its pool id: there is deliberately no fallback to the query's hop count."
     },
+    "router_guided": {
+      "guided": true,
+      "hop_source": "predictions",
+      "_note": "Issue #27's with-router arm: identical to oracle_guided in every way except where the query's hop count comes from - a router predictions file, joined on the query id, whose prediction OVERRIDES the gold depth even when the two disagree. That disagreement is the whole content of the arm: it is what shows how much of any oracle-guided gain survives an imperfect hop predictor. Nothing falls back: a query with no prediction in the file is a refusal, not a gold-guided query, because a per-query fallback would make this arm a blend of two conditions (the same stance ADR 0022 item 3 takes for hop-matched retrieval). The FEW-SHOT exemplars' own 'Hop count:' lines are unaffected - they state each exemplar's own gold step count, as in every guided arm (few_shot_exemplar_hop_count above), because the exemplars are pool rows and the router predicts for the query. Run it with --hop-predictions <router run>/predictions.jsonl; the run record carries that path and its sha256, plus how often the prediction agreed with the gold depth."
+    },
     "unguided_capped": {
       "guided": false,
       "stop_after_step_lines": 8,
       "_note": "Same prompt as 'unguided'. Generation is stopped once 8 step lines are complete - a transformers StoppingCriteria during decoding, plus a trim of the partial line the criterion can leave behind after it fires. Step lines are counted with the evaluator's own step normalization (src/step_lines.py), after <think>/tail post-processing, so 8 means 8 of the steps that get scored. The supervisor's example in the 2026-08-12 meeting used a cap of 6; 8 is Jahid's plan default and is the value set here - see docs/meetings/2026-08-12-supervisor-meeting-transcript-crosscheck.md and docs/adr/0013."
     }
   },
-  "_conditions_note": "A condition may set only 'guided' and 'stop_after_step_lines' (plus '_note'). Decoding, model and seed are deliberately NOT per-condition: run_decomposer.py rejects any other key so the three arms cannot drift apart.",
+  "_conditions_note": "A condition may set only 'guided', 'hop_source' and 'stop_after_step_lines' (plus '_note'). Decoding, model and seed are deliberately NOT per-condition: run_decomposer.py rejects any other key so the arms cannot drift apart. 'hop_source' is allowed there because it says WHICH hop count the prompt carries (gold or a router's prediction), which is precisely what separates oracle_guided from router_guided.",
 
   "generation_overrides": {
     "max_new_tokens": 1024

--- a/configs/router.json
+++ b/configs/router.json
@@ -8,6 +8,9 @@
   "prompt_file": null,
   "_prompt_file_note": "null: this config does not pin a prompt, so the model folder's own prompt_file (v1's prompt.md) is used and --prompt-file prompt_zero_shot.md selects the zero-shot variant, exactly as before.",
 
+  "response_truncate_at": [],
+  "_response_truncate_at_note": "Empty: v1 parsing, unchanged. The MetaQA prompts end with 'Trace:' and elicit a multi-line response whose 'A:' line comes after the trace, so cutting the response at its first line break would throw the answer away. What protects the MuSiQue prompt (whose 'A:' cue is in the prompt, so its answer is the FIRST thing in the response and anything after it is the model writing its own next question) is configs/router_musique.json's marker list - see clean_response in run_router.py.",
+
   "hops": [1, 2, 3],
   "questions_template_key": "metaqa_questions_template",
   "questions_format": "lines",

--- a/configs/router.json
+++ b/configs/router.json
@@ -1,12 +1,30 @@
 {
-  "_note": "Shared config for components/router/run_router.py. Per-model model_id, prompt file, decoding, loader and response-parsing settings live in components/router/models/<model>/config.json; everything that is not model-specific lives here. v1 carried these as argparse defaults inside each copy of router.py.",
+  "_note": "Shared config for components/router/run_router.py. Per-model model_id, prompt file, decoding, loader and response-parsing settings live in components/router/models/<model>/config.json; everything that is not model-specific lives here. v1 carried these as argparse defaults inside each copy of router.py. This is the MetaQA path and it is unchanged by issue #27: few_shot.enabled and predictions.enabled are false, so the run is the one it was before (v1's static few-shot prompt.md or the shared zero-shot prompt, questions read one per line with no ids). The MuSiQue few-shot-prompted router lives in configs/router_musique.json.",
 
   "seed": 42,
   "num_runs": 1,
   "sample_size_per_hop": null,
 
+  "prompt_file": null,
+  "_prompt_file_note": "null: this config does not pin a prompt, so the model folder's own prompt_file (v1's prompt.md) is used and --prompt-file prompt_zero_shot.md selects the zero-shot variant, exactly as before.",
+
   "hops": [1, 2, 3],
   "questions_template_key": "metaqa_questions_template",
+  "questions_format": "lines",
+  "_questions_format_note": "'lines' is MetaQA's plain-text format: one question per line, no id. A question source with no ids cannot produce a predictions file keyed by query id, which is why predictions.enabled is false below.",
+
+  "few_shot": {
+    "enabled": false,
+    "_note": "Retrieved few-shot exemplars (issue #27) are off here. The MetaQA prompts carry their own hand-written examples inside prompt.md (byte-identical to v1), so there is nothing to retrieve and no exemplar source to name. Enabling this requires a prompt with a {few_shot_examples} placeholder and a retrieval input; the runner refuses the mismatched combinations rather than rendering an empty exemplar block."
+  },
+
+  "predictions": {
+    "enabled": false,
+    "filename": "predictions.jsonl",
+    "id_field": "query_id",
+    "hop_field": "predicted_hop",
+    "_note": "Off on this path: MetaQA questions carry no id to key on. The field names are still declared because they are the interface ADR 0022 item 5 documents (query_id / predicted_hop), and a consumer reads them out of the run's config snapshot."
+  },
 
   "output_subdir_few_shot": "router/average_few_shot",
   "output_subdir_zero_shot": "router/average_zero_shot",

--- a/configs/router_musique.json
+++ b/configs/router_musique.json
@@ -34,10 +34,13 @@
   },
   "_retrieval_note": "input_key names the ONE artifact this condition reads, resolved through datasets.musique_few_shot_top5_pinned600 in configs/paths.json - the repo convention for data outside the tree, no absolute path in a config. It is the ADR 0014 artifact the decomposer conditions read (bi-encoder top-20 -> cross-encoder top-5, typed masking, seed 42, v1 pool of 9,156; 600 rows, one per pinned query). --retrieval-input overrides it, which is how the fixture and smoke runs point at tests/fixtures/retrieval/. The runner records the resolved path AND its sha256 in the config snapshot and the metrics, so two router conditions can be shown to have read the same exemplars. k = 5 matches the decomposer's k on the same artifact; mode 'typed' matches configs/decomposer_musique.json.",
 
+  "response_truncate_at": ["\n"],
+  "_response_truncate_at_note": "The prompt ends with the 'A:' cue, so the model's answer is the FIRST thing in its response and everything after the first line break is the model writing a fresh Q/A pair of its own. The response is therefore cut at that line break before any hop count is read. Without this, a response like '2\\n\\nQ: ...\\nA: 3' returned 3 - another question's answer - as this query's prediction, with parse_fallback false (PR #43 review, C1). Truncation, not the token budget, is what makes the read safe: max_new_tokens is left at the model folder's value because a thinking model needs room to emit and close its <think> block before answering.",
+
   "parsing_overrides": {
-    "answer_regex": "A:\\s*([234])"
+    "answer_regex": null
   },
-  "_parsing_overrides_note": "The per-model parsing block is a v1 asset whose answer_regex reads a single digit in 1-3 (MetaQA's hop depths). MuSiQue's are 2/3/4, so the answer-prefix regex is overridden here rather than by editing a model folder. It must cover every value in 'hops' above: a digit outside the class simply misses this branch and falls through to the hop-derived digit-class search, which is less precise. The runner refuses an override key the model's parsing block does not define.",
+  "_parsing_overrides_note": "answer_regex null: this prompt puts the 'A:' cue in the PROMPT, so the model's response has no 'A:' prefix of its own - a regex requiring one could only ever match a regurgitated exemplar. Nulling it lets the next rule in run_router.py read the leading digit, and that rule builds its digit class from 'hops' above, so it needs no hop-specific constant (the v1 per-model regexes hardcode MetaQA's 1-3). The model folder's parsing block is otherwise untouched: it is a v1 asset. The runner refuses an override key that block does not define, and asserts at load time that the parsing rules cover every value in 'hops' and that parsing.default_hop is one of them.",
 
   "predictions": {
     "enabled": true,
@@ -48,8 +51,8 @@
   },
 
   "output_subdir_few_shot": "router_musique/few_shot",
-  "output_subdir_zero_shot": "router_musique/zero_shot",
   "zero_shot_prompt_marker": "zero_shot",
+  "_output_subdir_note": "Only the few-shot root is declared: this config has no zero-shot arm (few_shot.enabled is true, and a prompt without a {few_shot_examples} placeholder is refused), so a zero-shot output root would be a dead knob. Selecting a zero-shot prompt with this config is refused, naming the missing key. A zero-shot MuSiQue router arm would be its own config.",
 
   "progress_every": 10,
   "model_limits_config": "model_limits.json",

--- a/configs/router_musique.json
+++ b/configs/router_musique.json
@@ -1,0 +1,57 @@
+{
+  "_note": "MuSiQue variant of configs/router.json for components/router/run_router.py: the few-shot-prompted router of issue #27. Same runner and the same per-model folders; only the question source, the hop depths, the prompt, the response-parsing digits and the outputs differ. Nothing here is trained - the router is prompted (ADR 0010 reframes the router as a hop-count regressor and its target encoding / loss / metric are open questions for Jahid and his supervisor; this config takes none of those decisions, it prompts a model to emit a hop count and scores exact-hop accuracy the way the MetaQA path already does). The MetaQA defaults in configs/router.json are untouched.",
+
+  "seed": 42,
+  "num_runs": 1,
+  "sample_size_per_hop": null,
+  "_sample_size_note": "Must stay null: the retrieval artifact is built over the pinned 600 queries of ADR 0007, and a sampled run would write a predictions file that does not cover every query its consumers join on. The runner refuses the combination.",
+
+  "prompt_file": "prompt_few_shot_musique.md",
+  "_prompt_file_note": "The shared retrieved-few-shot prompt in components/router/models/ (not a per-model v1 asset): an instruction, a {few_shot_examples} block filled with retrieved exemplars, and the query. --prompt-file still overrides it. Naming the prompt here rather than relying on a flag is what stops this config from being run with a model folder's MetaQA prompt.md by accident; the runner also refuses a few-shot config whose prompt has no {few_shot_examples} placeholder.",
+
+  "hops": [2, 3, 4],
+  "questions_template_key": "musique_eval_questions_template",
+  "questions_format": "jsonl",
+  "questions_jsonl": {
+    "question_field": "question",
+    "id_field": "id"
+  },
+  "eval_rows_per_hop": 200,
+  "_eval_set_note": "The pinned ADR 0007 evaluation set: 200 questions per hop depth for hops 2/3/4, 600 total, and exactly those ids. Asserted by the shared assertion in run_decomposer.py (assert_pinned_eval_set) - by id, not only by count - because a router prediction file over a different 600 cannot be joined against the decomposition arms it is supposed to route (ADR 0011). On the retrieval path the questions come from the retrieval file, so that file must have been built over exactly those ids. --allow-unpinned-eval-set is the recorded opt-out for fixture and smoke runs, which are not experiment arms.",
+
+  "few_shot": {
+    "enabled": true,
+    "exemplar_hop_source": "pool_id",
+    "_note": "The exemplars are the retrieval artifact's own top-k candidates for that query - the same exemplars the decomposer sees, so 'the router and the decomposer were prompted from the same pool' is true by construction rather than by coincidence. exemplar_hop_source 'pool_id': each exemplar's 'A:' line states the coarse hop depth parsed from its own MuSiQue id ('2hop__...'), which is the same quantity the router is scored against (a query's gold depth is parsed from its id the same way), so the prompt demonstrates the target the metric measures. The alternative - the step count of the exemplar's gold decomposition, which is what the DECOMPOSER's exemplar hop lines state (ADR 0013) - is deliberately not implemented here: it is a different quantity, and choosing it would be a research decision, not an implementation detail. A candidate that IS the query is dropped from the ranked list before the top-k is taken, by pool id and by normalized question text (run_decomposer.is_self_example, imported not copied), so no query can be shown its own answer."
+  },
+
+  "retrieval": {
+    "input": null,
+    "input_key": "musique_few_shot_top5_pinned600",
+    "mode": "typed",
+    "k": 5,
+    "modes": ["raw", "typed", "uniform"]
+  },
+  "_retrieval_note": "input_key names the ONE artifact this condition reads, resolved through datasets.musique_few_shot_top5_pinned600 in configs/paths.json - the repo convention for data outside the tree, no absolute path in a config. It is the ADR 0014 artifact the decomposer conditions read (bi-encoder top-20 -> cross-encoder top-5, typed masking, seed 42, v1 pool of 9,156; 600 rows, one per pinned query). --retrieval-input overrides it, which is how the fixture and smoke runs point at tests/fixtures/retrieval/. The runner records the resolved path AND its sha256 in the config snapshot and the metrics, so two router conditions can be shown to have read the same exemplars. k = 5 matches the decomposer's k on the same artifact; mode 'typed' matches configs/decomposer_musique.json.",
+
+  "parsing_overrides": {
+    "answer_regex": "A:\\s*([234])"
+  },
+  "_parsing_overrides_note": "The per-model parsing block is a v1 asset whose answer_regex reads a single digit in 1-3 (MetaQA's hop depths). MuSiQue's are 2/3/4, so the answer-prefix regex is overridden here rather than by editing a model folder. It must cover every value in 'hops' above: a digit outside the class simply misses this branch and falls through to the hop-derived digit-class search, which is less precise. The runner refuses an override key the model's parsing block does not define.",
+
+  "predictions": {
+    "enabled": true,
+    "filename": "predictions.jsonl",
+    "id_field": "query_id",
+    "hop_field": "predicted_hop",
+    "_note": "The point of this config (issue #27): one JSON object per query, carrying the query id and the predicted hop, so the two consumers can JOIN on the id - the retrieval chain's 'predictions' hop source (hop_match.predictions_id_field / predictions_hop_field in configs/similarity.json, issue #15's router-hop-matched condition) and the decomposer's router_guided condition (hop_predictions in configs/decomposer_musique.json). The field names are the defaults those consumers already expect (ADR 0022 item 5). Keying on question text was rejected there and is not offered here: the masking modes rewrite that field. The file lands under the gitignored runs root with the rest of the run, because data never enters git."
+  },
+
+  "output_subdir_few_shot": "router_musique/few_shot",
+  "output_subdir_zero_shot": "router_musique/zero_shot",
+  "zero_shot_prompt_marker": "zero_shot",
+
+  "progress_every": 10,
+  "model_limits_config": "model_limits.json",
+  "paths_config": "paths.json"
+}

--- a/docs/adr/0022-hop-matched-retrieval-the-implementers-design.md
+++ b/docs/adr/0022-hop-matched-retrieval-the-implementers-design.md
@@ -82,6 +82,13 @@ mixed being the literal absence of the filter. Knobs live in `hop_match` in
    shape (or write a small adapter). Silently keying on question text was rejected: it makes
    an exact-string match load-bearing on the very field the masking modes rewrite.
 
+   *Note added 2026-08-22 (issue #27, ADR [0024](./0024-router-readiness-query-id-keyed-predictions-and-the-router-guided-arm.md)):
+   this gap is closed. `run_router.py` now writes `predictions.jsonl` in exactly the shape
+   documented above — `query_id` / `predicted_hop`, one object per query — whenever its
+   question source carries ids, and `detailed_results.json` carries `query_id` as well. No
+   adapter is needed, and the field names match with no configuration. The decision in this
+   item is unchanged; only its "does not conform" statement of fact is out of date.*
+
 6. **The parsing rule is duplicated, and stays duplicated for now.** This repo already had
    three copies of "hop from id" (`MusiQue/scripts/musique_ids.py`,
    `MusiQue/scripts/score_similarity_results.py`,
@@ -177,6 +184,11 @@ step (this repo sets no torch determinism flags; same caveat as ADR 0021 item 7)
   5. Until one exists, issue #15's "done when" can be met for two of its three conditions
   only. Whether to produce it from the existing router component, from a fine-tuned router
   (ADR 0010), or from a hop predictor yet to be trained is **not** an implementer decision.
+  *(Note added 2026-08-22: the interface is no longer blocked — the existing router component
+  writes conforming predictions since ADR
+  [0024](./0024-router-readiness-query-id-keyed-predictions-and-the-router-guided-arm.md).
+  What is still absent is a predictions **file over the pinned 600**, which needs a real
+  router run; and which router ultimately produces it remains Jahid's decision.)*
 - **A confound to state in the write-up, not to fix in code.** Hop matching necessarily
   shrinks the candidate set: the 4-hop bucket is 1,175 rows against the pool's 9,156, so a
   matched-versus-mixed difference mixes "examples of the same hop depth" with "examples drawn

--- a/docs/adr/0024-router-readiness-query-id-keyed-predictions-and-the-router-guided-arm.md
+++ b/docs/adr/0024-router-readiness-query-id-keyed-predictions-and-the-router-guided-arm.md
@@ -1,0 +1,209 @@
+# 0024. Router Readiness: Query-Id-Keyed Predictions, a Retrieved-Few-Shot Router, and the Router-Guided Decomposer Arm
+
+- **Status**: Accepted (design agent-authored, pending Jahid)
+- **Date**: 2026-08-22
+
+## Context
+
+Issue #27 asks for a few-shot-prompted router and a with-router versus without-router
+evaluation on the pinned MuSiQue set; ADR
+[0023](./0023-jahid-2026-08-22-direction-metric-pipeline-completion-generalisation.md) item 2.2
+makes that comparison the instrument for Jahid's next pipeline decision ("use the router or omit
+it and decompose anyway"). Two things blocked it, both recorded rather than guessed:
+
+- ADR [0022](./0022-hop-matched-retrieval-the-implementers-design.md) item 5 recorded that the
+  router writes `detailed_results.json` keyed by **question text with no query id**, so the
+  `predictions` hop source it documented had no producer — issue #15's router-hop-matched
+  condition was blocked on a file in that shape.
+- `run_decomposer.py`'s guided condition took the hop count from the query's **gold** depth only
+  (parsed from the id, or the per-hop file the question came from). There was no way to feed it a
+  prediction, so the with-router arm did not exist as a runnable configuration.
+
+**That these things get built and measured is Jahid's decision** (issue #27, ADR 0023). How they
+are implemented was not decided by anyone; this record states the implementer's choices so the
+November write-up does not mistake one for a research decision.
+
+**Nothing in this record is a measurement.** No router has been run on the evaluation set, no
+with-router/without-router comparison exists, and no claim about router accuracy or about the
+router's effect on decomposition quality may be made until an `experiments/log.md` entry exists.
+What *was* executed is under "What was verified".
+
+ADR [0010](./0010-keep-the-router-as-a-hop-count-regressor-prioritize-fine-tuning.md) reframed
+the router as a **regressor** and left its target encoding, loss, rounding rule and headline
+metric explicitly open for Jahid and his supervisor. This record does not answer any of them: it
+adds a *prompted* router (nothing is trained) whose output is an integer hop count, and it scores
+that the way the MetaQA path already did (exact-hop accuracy, per hop). A trained regressor can
+later write the same predictions file and drop into the same two consumers unchanged.
+
+## Decision (the implementer's, in three lines)
+
+1. **The router's predictions are a JSONL keyed by query id** — `{query_id, predicted_hop, …}`,
+   one object per query, exactly the shape ADR 0022 item 5 documented for its consumers.
+2. **The few-shot-prompted router is a prompting mode of the existing runner**, whose exemplars
+   are the query's own retrieved candidates from the artifact the decomposer already reads, each
+   labelled with its own gold hop depth, with the query self-excluded.
+3. **The decomposer gains a `hop_source` condition key**: `gold` (every arm that existed before)
+   or `predictions`, and `router_guided` is the condition that sets the latter.
+
+## Implementation conventions (agent-authored)
+
+1. **The predictions file is a join key plus a number, and it carries no question text.**
+   `query_id` and `predicted_hop` are the field names (configurable, defaulting to the values
+   `configs/similarity.json` and `configs/decomposer_musique.json` already expect). Alongside
+   them: `expected_hop`, `correct`, and `parse_fallback` — a flag saying the model's response
+   carried no readable hop count, so the model folder's `parsing.default_hop` was used. v1
+   returned that default silently, so a run's accuracy mixed predictions with defaults and
+   nothing recorded which was which; the flag and the `unparsed_response_rows` count are what
+   make that visible. Question text is deliberately absent: ADR 0022 item 5 rejected keying the
+   join on it, and a field that is present gets keyed on. `detailed_results.json` keeps it, and
+   now also carries `query_id`.
+
+2. **A dry run writes no predictions file.** It generates nothing, so a predictions file from a
+   dry run would be fabricated routing decisions. The metrics say `predictions_file: null` with a
+   note, in the "unmeasured, not zero" style of ADR
+   [0016](./0016-real-run-only-invariants-get-source-level-guards.md). Everything *up to*
+   generation is exercised by the dry run: the query-id integrity check, the exemplar assembly,
+   the prompt. The file's own shape is therefore pinned by a unit test that round-trips it
+   through the consumer (`load_predicted_hops`), not by the CLI.
+
+3. **Missing and duplicated ids fail on both sides.** The router refuses, before a model is
+   loaded, a question source with a blank/absent id or a repeated one (naming the offenders); the
+   consumer refuses a duplicate id (`load_predicted_hops`, already) and a query the file does not
+   cover (`join_predicted_hops`, naming up to ten offending ids). No fallback to the gold depth
+   for the uncovered queries — ADR 0022 item 3's reasoning, on the decomposer's side of the same
+   join: a per-query fallback would make the routed arm a blend of two conditions.
+
+4. **The few-shot exemplars are the retrieval artifact's own candidates, and the labels come from
+   the pool id.** The router reads the same JSONL the decomposer reads (`--retrieval-input`, or
+   `retrieval.input_key`), takes the first k candidates of the configured `<mode>_top_k`, and
+   states each exemplar's coarse hop depth parsed from *its* pool id. Two reasons for the id
+   rather than a step count: it is the same quantity the router is scored against (a query's gold
+   depth is parsed from its id the same way), and it needs no gold decomposition, so a pool row
+   with a missing decomposition cannot silently change the label. `few_shot.exemplar_hop_source`
+   names it, and the only implemented value is `pool_id`; a second one (for instance the step
+   count of the exemplar's gold decomposition, which is what the *decomposer's* exemplar hop
+   lines state per ADR [0013](./0013-guided-vs-unguided-condition-conventions-on-the-musique-set.md))
+   is refused rather than approximated, because choosing it is a research decision.
+
+5. **Self-exclusion is the decomposer's rule, imported, not a second copy.** `is_self_example`
+   (pool id equal to the query id, or whitespace/case-normalized pool question equal to the
+   query's) is imported from `run_decomposer.py`, along with the question-source reader and the
+   pinned-eval-set assertion — the way `run_answerer.py` already imports the last of those. A
+   leakage rule with two copies is a rule that drifts, and ADR 0022 item 6 already records four
+   copies of "hop from id" as this repo's live example of that risk. The cost is a real import
+   dependency from the router component onto the decomposer's runner; the alternative was moving
+   three functions into `src/`, which is a wider edit to a file two queued experiments read.
+
+6. **The router asserts the pinned evaluation set by id.** `eval_rows_per_hop` in
+   `configs/router_musique.json` runs the same assertion the decomposer and the answerer use, so
+   a predictions file over a different 600 questions is refused rather than joined against arms it
+   does not cover (ADR [0007](./0007-musique-evaluation-set-reuses-v1-600-questions-200-per-hop.md),
+   ADR [0011](./0011-comparison-artifact-conventions-and-the-significance-claim-floor.md)).
+   `--allow-unpinned-eval-set` is the recorded opt-out for fixture runs, exactly as elsewhere.
+   `sample_size_per_hop` is refused on the retrieval path for the same reason: a sampled run
+   writes a predictions file that does not cover every query its consumers ask about.
+
+7. **`hop_count` in the decomposer's outputs keeps its meaning; the prompt's number is a new
+   field.** The join sets a row's *prompt* hop count from the prediction and leaves
+   `gold_hop_count` alone, and the per-hop counts and the pinned-set assertion are computed on
+   the gold depth — otherwise a router predicting 3 for a 2-hop query would move that query into
+   the 3-hop row of the results table and the pinned-set assertion would fail on a correctly
+   loaded set. `results.json` therefore carries `hop_count` (gold, unchanged for every existing
+   consumer), `prompt_hop_count` (null in an unguided arm) and `hop_count_source`. The prompt-log
+   file names stay on the gold depth too, so the arms' logs line up file by file; the predicted
+   number is stated in the log header.
+
+8. **The condition block is where the hop source lives.** `hop_source` joins `guided` and
+   `stop_after_step_lines` as the only keys a condition may set, because it says *which* hop count
+   the prompt carries — the single difference between `oracle_guided` and `router_guided`. Model,
+   seed, retrieval and decoding stay shared and un-overridable, so the two arms cannot differ in a
+   second way. Four refusals, all of them a run that would otherwise be filed under the wrong
+   label: an unimplemented source; `predictions` in an unguided arm (no hop count reaches the
+   prompt at all there); `predictions` with no file named; and `--hop-predictions` passed to a
+   `gold` arm, where the file would be ignored while the operator believed the run was routed.
+
+9. **The predictions path is a flag, not a committed config value.**
+   `hop_predictions.file` is null in both decomposer configs. The file is a *run output* under the
+   gitignored runs root, not a pinned artifact, so a path baked into a committed config would
+   silently route a later run with an older router's decisions. The run records the resolved path
+   **and its sha256**, next to the retrieval input's, so "which routing decisions produced this
+   arm" is answerable from the run trail.
+
+10. **Every knob is in a committed config; the MetaQA path is off by default.**
+    `configs/router.json` gains `questions_format: "lines"`, `few_shot.enabled: false` and
+    `predictions.enabled: false` — explicit rather than absent, in this repo's no-silent-default
+    style — so that path renders and runs exactly as before. The v1 model folders are untouched:
+    the new prompt is a *shared* file (`models/prompt_few_shot_musique.md`, named by the MuSiQue
+    config so the mode cannot be run with a MetaQA prompt by forgetting a flag), and MuSiQue's
+    2/3/4 answer digits come from a `parsing_overrides` block rather than an edit to a v1 asset.
+
+## What was verified (and what was not)
+
+Ran 2026-08-22, CPU only, no weights, on this branch:
+
+- `tests/test_router_predictions.py` — **44 tests, all passing**: the predictions rows and their
+  round trip through `load_predicted_hops`, the committed fixture read by the consumer, every id
+  and join refusal, the exemplar assembly (labels, both self-exclusion paths, four refusals),
+  the prompt rendering including that a v1 prompt renders unchanged, that the exemplar `A: <n>`
+  line is readable by the run's own configured parser for hops 2/3/4, `hop_source` resolution
+  with all four refusals, and the join's effect on the prompt hop versus the gold hop.
+- Full suite `python -m unittest discover -s tests` — **354 tests, OK** (310 before this change).
+- `scripts/smoke_test.py` — **39/39 stages**, including the two new ones
+  (`router_dry_run_musique_few_shot`, `decomposer_dry_run_musique_router_guided`).
+- **The routed arm does something different from the oracle arm, on the same nine fixture
+  queries**: with a fabricated predictions file in which three of nine predictions disagree with
+  the gold depth, `router_guided` put the *predicted* hop in all nine prompts (verified row by row
+  against the file) while `oracle_guided` put the gold one, the two arms produced the same query
+  ids in the same order, and the routed run's per-hop counts stayed 3/3/3 on the gold depth.
+- The MetaQA router dry run still exits 0 and reports `few_shot.enabled` false with no
+  predictions file.
+
+Not verified, and not claimed: **any router accuracy number** (no model has been loaded — a dry
+run asserts no parameter count either, the ADR 0016 caveat), **any effect of routing on
+decomposition quality**, and the feasibility of the real 600-query artifact under this path (no
+router predictions file over the pinned set exists yet).
+
+## Consequences
+
+- Issue #27's with/without-router comparison is now a runnable pair of configurations:
+  `oracle_guided` (or `unguided`) against `router_guided`, same model, seed, retrieval artifact and
+  decoding. Producing the numbers is a separate experiment lane with its own log entry; this record
+  produces none.
+- Issue #15's third regime is unblocked: `check_question_similarity.py --hop-source predictions`
+  now has a producer, and the field names match with no adapter.
+- The router component now imports the decomposer's runner (item 5). If those three functions
+  ever move to `src/`, both importers change together.
+- A trained hop predictor (ADR 0010's regressor) inherits the interface rather than defining a new
+  one: whatever produces `{query_id, predicted_hop}` rows drives both consumers. The regressor's
+  own open questions — target encoding, loss, rounding, headline metric — are untouched here.
+- `configs/router.json` and both decomposer configs now require keys they did not before
+  (`questions_format`, `few_shot`, `predictions`; `hop_source`, `hop_predictions`). A config
+  without them is refused loudly by `require()`, which is the intended behaviour and matches what
+  ADR 0022 item 4 did to `configs/similarity.json`.
+- The router's response parsing now reports how often it fell back to a default. If that count is
+  high on a real run, the router's "accuracy" is partly the default's accuracy — a caveat the
+  write-up must carry, and a number that now exists to carry it.
+
+## Alternatives considered
+
+- **Key the predictions on question text** (what today's `detailed_results.json` would allow).
+  Rejected in ADR 0022 item 5 and not revisited: the masking modes rewrite that field.
+- **Write a small adapter from `detailed_results.json` to the documented shape.** Rejected: it
+  would leave the router's own output unjoinable and put the id back on the text it was keyed by,
+  a level of indirection that hides the very field the join needs.
+- **A fixed, hand-written MuSiQue exemplar set for the router** (the shape of v1's MetaQA
+  `prompt.md`). Not implemented: the repo's few-shot method is retrieval (ADR 0006), the retrieval
+  artifact already exists over exactly these queries, and a hand-written set would be a new
+  research asset nobody asked for. It remains the obvious cheaper variant if Jahid wants a
+  static-prompt arm.
+- **Fabricate a predictions file on a dry run so the CLI covers the whole path.** Rejected; see
+  item 2. A unit test round-trip covers the shape without inventing predictions.
+- **Let `hop_count` in `results.json` become the predicted hop** (fewer fields). Rejected; see
+  item 7: it changes the meaning of a field several scripts read, and the pinned-set assertion
+  would fail on a correctly loaded set.
+- **Sampling and per-hop subsets on the router's retrieval path.** Refused rather than supported:
+  a partial predictions file is a refusal on the consuming side anyway, so allowing it upstream
+  would only move the failure later.
+- **Consolidating `is_self_example` / the question reader / the eval-set assertion into `src/`.**
+  Deferred, not rejected: it is the right cleanup, and it touches a file that queued experiments
+  read. Same reasoning as ADR 0022 item 6's parked de-duplication.

--- a/docs/adr/0024-router-readiness-query-id-keyed-predictions-and-the-router-guided-arm.md
+++ b/docs/adr/0024-router-readiness-query-id-keyed-predictions-and-the-router-guided-arm.md
@@ -58,6 +58,46 @@ later write the same predictions file and drop into the same two consumers uncha
    join on it, and a field that is present gets keyed on. `detailed_results.json` keeps it, and
    now also carries `query_id`.
 
+1a. **The response is cut at the answer before a hop count is read, and the parsing rules are
+   asserted to cover the config's hop depths.** *(Added 2026-08-22 in the PR #43 review fix
+   pass — findings C1 and I1. Implementer design, pending Jahid, like the rest of this record.)*
+
+   The retrieved-few-shot prompt ends with the `A:` cue, so the model's answer is the **first**
+   thing in the response and everything after the first line break is the model writing a fresh
+   `Q:`/`A:` pair of its own. Two consequences, both now encoded:
+
+   - **Truncation before parsing.** `response_truncate_at` (per config, because it is a property
+     of the prompt shape) cuts the response at its first line break for the MuSiQue prompt and
+     is empty for the v1 MetaQA prompts, whose responses are multi-line by design. And that
+     config sets `answer_regex` to null: a rule requiring an `A:` prefix can only match a
+     regurgitated exemplar when the prompt consumed the cue itself, so the answer is read as the
+     leading digit by the rule whose digit class is derived from `hops`. Measured on the
+     committed configs: the response `"2\n\nQ: …\nA: 3\n\nQ:"` parsed to **(3, True)** under the
+     first version of this change — another question's answer, returned as this query's
+     prediction with `parse_fallback` false — and parses to **(2, True)** now. `eos_token_id` is
+     also passed to `generate` so a finished model can stop, but that is not what makes the read
+     safe: a model can always keep going, so truncation is the guarantee.
+   - **A coverage assertion, not a prose requirement.** `assert_parsing_covers_hops` refuses, at
+     config-load time and therefore on a dry run too: a hop depth the fallback label table
+     cannot name (v1's tables stopped at three, so a MuSiQue router's "four hops" fell through
+     to `default_hop`), a hop depth above 9 (the digit-class rule is a single-character regex
+     class), and a `default_hop` outside `hops`. The label tables are now derived from the hop
+     depth rather than listed, so they follow the config. This is ADR 0016's rule applied to a
+     config invariant: the earlier version of this record stated the requirement in a config
+     `_note`, and a `_note` does not fail a run.
+
+   **How a defaulted hop is scored, stated once here because it shapes every router number.** An
+   unreadable response is recorded as `parsing.default_hop` **as if it were a prediction** and is
+   **counted in the accuracies** — it is not dropped, and the denominator does not change. That
+   is deliberate (a router that cannot answer has still routed the query, and the pipeline will
+   use that hop), but it means the default's own class is flattered: with `default_hop` 2, every
+   defaulted row is correct for a 2-hop query and wrong for a 3- or 4-hop one. So the count is
+   reported overall *and* per gold hop (`unparsed_response_rows_per_gold_hop`), and
+   `accuracy_definitions` in the metrics says that the per-hop rows are within-gold-class recall
+   rather than precision. Any router accuracy claim in the write-up has to carry that split;
+   whether a defaulted row should instead be excluded, or scored as a refusal, is Jahid's call
+   and is not decided here.
+
 2. **A dry run writes no predictions file.** It generates nothing, so a predictions file from a
    dry run would be fabricated routing decisions. The metrics say `predictions_file: null` with a
    note, in the "unmeasured, not zero" style of ADR
@@ -117,10 +157,16 @@ later write the same predictions file and drop into the same two consumers uncha
    `stop_after_step_lines` as the only keys a condition may set, because it says *which* hop count
    the prompt carries — the single difference between `oracle_guided` and `router_guided`. Model,
    seed, retrieval and decoding stay shared and un-overridable, so the two arms cannot differ in a
-   second way. Four refusals, all of them a run that would otherwise be filed under the wrong
-   label: an unimplemented source; `predictions` in an unguided arm (no hop count reaches the
-   prompt at all there); `predictions` with no file named; and `--hop-predictions` passed to a
-   `gold` arm, where the file would be ignored while the operator believed the run was routed.
+   second way. **Five** refusals, all of them a run that would otherwise be filed under the wrong
+   label: an unimplemented source (an explicit `"hop_source": null` in a condition included — it
+   names no source, so it may not quietly inherit the default); `predictions` in an unguided arm
+   (no hop count reaches the prompt at all there); `predictions` together with
+   `few_shot_exemplar_hop_count: "query"`, which would stamp the *prediction* on all k exemplars
+   and so resurrect ADR 0013's defect with a prediction where the gold depth used to be —
+   unreachable from the committed configs, which is exactly why it is a guard and not a fix
+   *(added 2026-08-22, PR #43 review I3)*; `predictions` with no file named; and
+   `--hop-predictions` passed to a `gold` arm, where the file would be ignored while the operator
+   believed the run was routed.
 
 9. **The predictions path is a flag, not a committed config value.**
    `hop_predictions.file` is null in both decomposer configs. The file is a *run output* under the
@@ -139,17 +185,30 @@ later write the same predictions file and drop into the same two consumers uncha
 
 ## What was verified (and what was not)
 
-Ran 2026-08-22, CPU only, no weights, on this branch:
+Ran 2026-08-22, CPU only, no weights, on this branch. Counts are from the **PR #43 review fix
+pass**; the first version of this record cited 44 / 354, and the earlier count that mattered most
+was also *wrong about what it checked* — it asserted the response shape `A: <n>`, which the
+retrieved-few-shot prompt cannot produce, and that is the mistake finding C1 exposed. The
+response-shape checks below are written against the shape the prompt actually elicits.
 
-- `tests/test_router_predictions.py` — **44 tests, all passing**: the predictions rows and their
+- `tests/test_router_predictions.py` — **62 tests, all passing**: the predictions rows and their
   round trip through `load_predicted_hops`, the committed fixture read by the consumer, every id
-  and join refusal, the exemplar assembly (labels, both self-exclusion paths, four refusals),
-  the prompt rendering including that a v1 prompt renders unchanged, that the exemplar `A: <n>`
-  line is readable by the run's own configured parser for hops 2/3/4, `hop_source` resolution
-  with all four refusals, and the join's effect on the prompt hop versus the gold hop.
-- Full suite `python -m unittest discover -s tests` — **354 tests, OK** (310 before this change).
+  and join refusal, the exemplar assembly (labels, both self-exclusion paths, four refusals, and
+  the post-filter assertion), the prompt rendering including that a v1 prompt renders unchanged,
+  the **response parsing** (the answer is the leading digit; a response that answers and then
+  regurgitates a `Q:`/`A:` pair parses to the answer; a leading newline does not truncate the
+  answer away; a `<think>` preamble is stripped; a hop named in words is read rather than
+  defaulted; v1 multi-line parsing unchanged with no markers configured), the parsing-coverage
+  assertion and its four refusals, `hop_source` resolution with all five refusals, the accuracy
+  definitions and the per-gold-hop default counts, and the join's effect on the prompt hop versus
+  the gold hop.
+- Full suite `python -m unittest discover -s tests` — **372 tests, OK** (310 before this change).
 - `scripts/smoke_test.py` — **39/39 stages**, including the two new ones
   (`router_dry_run_musique_few_shot`, `decomposer_dry_run_musique_router_guided`).
+- `python tests/test_decomposer_conditions.py --skip-data-checks` — **258 checks passed**.
+- **The C1 regression, measured on the committed configs**: response
+  `"2\n\nQ: Who founded the press in Marlow Bay?\nA: 3\n\nQ:"` → `(3, True)` with the first
+  version's parsing (an `A:`-prefix regex over the untruncated response), `(2, True)` now.
 - **The routed arm does something different from the oracle arm, on the same nine fixture
   queries**: with a fabricated predictions file in which three of nine predictions disagree with
   the gold depth, `router_guided` put the *predicted* hop in all nine prompts (verified row by row
@@ -180,9 +239,14 @@ router predictions file over the pinned set exists yet).
   (`questions_format`, `few_shot`, `predictions`; `hop_source`, `hop_predictions`). A config
   without them is refused loudly by `require()`, which is the intended behaviour and matches what
   ADR 0022 item 4 did to `configs/similarity.json`.
-- The router's response parsing now reports how often it fell back to a default. If that count is
-  high on a real run, the router's "accuracy" is partly the default's accuracy — a caveat the
-  write-up must carry, and a number that now exists to carry it.
+- The router's response parsing now reports how often it fell back to a default, overall and per
+  gold hop. If that count is high on a real run, the router's "accuracy" is partly the default's
+  accuracy — a caveat the write-up must carry, and a number that now exists to carry it.
+- A new prompt for this component brings an obligation with it: state its
+  `response_truncate_at`, and check that its answer position matches the parsing rules. The
+  coverage assertion catches a hop-depth gap automatically; it cannot catch a prompt whose answer
+  is not where the parsing looks for it. That check is a test against the response shape the
+  prompt elicits (`TestResponseParsing`), and it is the shape of test the next prompt needs.
 
 ## Alternatives considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,6 +50,8 @@ When **not** to write one:
 | [0020](./0020-prior-work-re-analysis-convention.md) | Prior-Work Re-Analysis Convention | Accepted |
 | [0021](./0021-clustering-pool-construction-strategy.md) | Clustering-Based Pool Construction: The Implementer's Design | Accepted (design agent-authored, pending Jahid) |
 | [0022](./0022-hop-matched-retrieval-the-implementers-design.md) | Hop-Matched Retrieval: The Implementer's Design | Accepted (design agent-authored, pending Jahid) |
+| [0023](./0023-jahid-2026-08-22-direction-metric-pipeline-completion-generalisation.md) | Jahid's 2026-08-22 Direction: Composite Replacement, Pipeline Completion Order, Generalisation Framing | Accepted (Jahid, 2026-08-22, in session; marked items pending supervisor confirmation) |
+| [0024](./0024-router-readiness-query-id-keyed-predictions-and-the-router-guided-arm.md) | Router Readiness: Query-Id-Keyed Predictions, a Retrieved-Few-Shot Router, and the Router-Guided Decomposer Arm | Accepted (design agent-authored, pending Jahid) |
 
 ---
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -65,6 +65,11 @@ WORK = RUNS_ROOT / "work"
 #: not contain, so those stages pass this one instead (see the stages' comment).
 MUSIQUE_CONDITIONS_RETRIEVAL = FIXTURES / "retrieval" / "top5_musique_conditions.jsonl"
 
+#: Fabricated router predictions over the same nine fixture queries, in the shape
+#: run_router.py writes (query_id + predicted_hop). Three of the nine deliberately disagree
+#: with the gold hop depth, which is what the router_guided arm exists to carry through.
+MUSIQUE_HOP_PREDICTIONS = FIXTURES / "router" / "hop_predictions_musique.jsonl"
+
 MUSIQUE_SCRIPTS = REPO_ROOT / "MusiQue" / "scripts"
 SCRIPTS = REPO_ROOT / "scripts"
 COMPONENTS = REPO_ROOT / "components"
@@ -110,6 +115,7 @@ def _stages() -> list[Stage]:
     plots_dir = WORK / "sweep_plots"
     analysis_dir = WORK / "router_analysis"
     router_dry = WORK / "router_dry"
+    router_musique = WORK / "router_musique"
     decomposer_dry = WORK / "decomposer_dry"
     decomposer_musique = WORK / "decomposer_musique"
     finetune_dry = WORK / "finetune_dry"
@@ -452,6 +458,32 @@ def _stages() -> list[Stage]:
             ],
             note="router prompt assembly + artifacts, no weights loaded",
         ),
+        # The few-shot-prompted router of issue #27. --retrieval-input for the same reason
+        # the MuSiQue decomposer stages pass it (the config's key names the real v1
+        # artifact), and --allow-unpinned-eval-set because the fixtures hold 3 rows per hop
+        # rather than the pinned 200 of ADR 0007. A dry run writes no predictions file - it
+        # generates nothing - so what this stage covers is the whole path up to generation:
+        # the query-id integrity check, the exemplar assembly with self-exclusion, and the
+        # prompt. The predictions file's own shape is pinned by
+        # tests/test_router_predictions.py (round-tripped through load_predicted_hops).
+        Stage(
+            name="router_dry_run_musique_few_shot",
+            cmd=[
+                sys.executable, COMPONENTS / "router" / "run_router.py",
+                "--model", "qwen2_5_0_5b", "--config", "router_musique.json",
+                "--retrieval-input", MUSIQUE_CONDITIONS_RETRIEVAL,
+                "--dry-run", "--dry-run-limit", "9", "--allow-unpinned-eval-set",
+                "--output-root", router_musique,
+            ],
+            expect_dir_globs=[
+                (router_musique, "*/metrics.json"),
+                (router_musique, "*/config.json"),
+                (router_musique, "*/notes.md"),
+                (router_musique, "*/prompts_log/prompt_idx0001.txt"),
+            ],
+            note="few-shot-prompted router: retrieved exemplars labelled with their own hop "
+            "depth, query excluded from its own exemplars, no weights loaded",
+        ),
         Stage(
             name="decomposer_dry_run_retrieval",
             cmd=[
@@ -565,6 +597,21 @@ def _stages() -> list[Stage]:
             ],
             expect_dir_globs=[(decomposer_musique / "unguided_capped", "*/results.json")],
             note="MuSiQue conditions: step-line cap configured (no generation in a dry run)",
+        ),
+        Stage(
+            name="decomposer_dry_run_musique_router_guided",
+            cmd=[
+                sys.executable, COMPONENTS / "decomposer" / "run_decomposer.py",
+                "--model", "mistral_7b_instruct", "--config", "decomposer_musique.json",
+                "--condition", "router_guided", "--dry-run", "--dry-run-limit", "9",
+                "--retrieval-input", MUSIQUE_CONDITIONS_RETRIEVAL,
+                "--hop-predictions", MUSIQUE_HOP_PREDICTIONS,
+                "--allow-unpinned-eval-set",
+                "--output-root", decomposer_musique / "router_guided",
+            ],
+            expect_dir_globs=[(decomposer_musique / "router_guided", "*/results.json")],
+            note="MuSiQue conditions: the hop count in the prompt comes from a router "
+            "predictions file, joined by query id (issue #27)",
         ),
         # The MuSiQue answering backend of issue #16: execute a decomposition and score the
         # answer it leads to. Dry runs, so the join, the context assembly and the [#k]

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -76,6 +76,18 @@ retrieval/
                                # 4hop1__d003_c's candidate 4hop1__t010_j repeats the query's
                                # question text under a different id.
 pool_sweep_summary/            # a sweep summary CSV for the plotting script
+router/
+  hop_predictions_musique.jsonl # fabricated ROUTER PREDICTIONS in the shape run_router.py
+                               # writes (query_id + predicted_hop, plus the gold depth and
+                               # the parse-fallback flag): one row per dev_sample fixture
+                               # question (9), ids matching them exactly. Three of the nine
+                               # deliberately DISAGREE with the gold hop parsed from the id
+                               # (2hop__d004_d -> 3, 3hop2__d005_e -> 2, 4hop2__d007_h -> 3),
+                               # which is what makes the decomposer's router_guided arm and
+                               # issue #15's router-hop-matched retrieval do something
+                               # visibly different from the oracle. One row carries
+                               # parse_fallback true, i.e. a defaulted hop rather than a
+                               # predicted one. Not a measurement of any router.
 router_runs/                   # two completed router runs for the analysis script
 decomposer_run/                # a run directory with analysis/ dumps
 ```

--- a/tests/fixtures/router/hop_predictions_musique.jsonl
+++ b/tests/fixtures/router/hop_predictions_musique.jsonl
@@ -1,0 +1,9 @@
+{"query_id": "2hop__d001_a", "predicted_hop": 2, "expected_hop": 2, "correct": true, "parse_fallback": false}
+{"query_id": "2hop__d004_d", "predicted_hop": 3, "expected_hop": 2, "correct": false, "parse_fallback": false}
+{"query_id": "2hop__d009_b", "predicted_hop": 2, "expected_hop": 2, "correct": true, "parse_fallback": false}
+{"query_id": "3hop1__d002_b", "predicted_hop": 3, "expected_hop": 3, "correct": true, "parse_fallback": false}
+{"query_id": "3hop2__d005_e", "predicted_hop": 2, "expected_hop": 3, "correct": false, "parse_fallback": true}
+{"query_id": "3hop1__d011_f", "predicted_hop": 3, "expected_hop": 3, "correct": true, "parse_fallback": false}
+{"query_id": "4hop1__d003_c", "predicted_hop": 4, "expected_hop": 4, "correct": true, "parse_fallback": false}
+{"query_id": "4hop2__d007_h", "predicted_hop": 3, "expected_hop": 4, "correct": false, "parse_fallback": false}
+{"query_id": "4hop3__d013_i", "predicted_hop": 4, "expected_hop": 4, "correct": true, "parse_fallback": false}

--- a/tests/test_decomposer_conditions.py
+++ b/tests/test_decomposer_conditions.py
@@ -11,9 +11,11 @@ order they run in.
 What it covers:
 
 1. **Config resolution** - ``configs/decomposer_musique.json`` resolves to the MuSiQue
-   question template, hops [2, 3, 4] and three conditions (``unguided``,
-   ``oracle_guided``, ``unguided_capped``) whose only differences are the hop information
-   in the prompt and the step-line budget.
+   question template, hops [2, 3, 4] and the conditions (``unguided``, ``oracle_guided``,
+   ``unguided_capped``, and issue #27's ``router_guided``) whose only differences are the hop
+   information in the prompt and the step-line budget. The end-to-end checks below cover the
+   three arms of issue #12; ``router_guided`` needs a predictions file and is covered end to
+   end in ``tests/test_router_predictions.py``.
 2. **MetaQA defaults unchanged** - ``configs/decomposer.json`` still has guided=false,
    hops [1, 2, 3], the MetaQA template and no conditions block.
 3. **The prompt invariant** - every model folder that ships an unguided prompt has one that
@@ -154,24 +156,36 @@ def check_conditions(cfg: dict) -> None:
     print("[conditions]")
     conditions = require(cfg, "conditions")
     check(
-        "three conditions, named as briefed",
-        sorted(conditions) == ["oracle_guided", "unguided", "unguided_capped"],
+        "the three conditions briefed for issue #12, plus issue #27's router_guided",
+        sorted(conditions) == [
+            "oracle_guided", "router_guided", "unguided", "unguided_capped"
+        ],
         str(sorted(conditions)),
     )
 
-    # Hand-computed expectation per arm: (guided, stop_after_step_lines).
+    # Hand-computed expectation per arm: (guided, stop_after_step_lines, hop_source).
+    # hop_source is the arm's own key when it sets one, else the config's default; it is what
+    # separates oracle_guided (the gold depth) from router_guided (a router's prediction).
     expected = {
-        "unguided": (False, None),
-        "oracle_guided": (True, None),
-        "unguided_capped": (False, 8),
+        "unguided": (False, None, "gold"),
+        "oracle_guided": (True, None, "gold"),
+        "unguided_capped": (False, 8, "gold"),
+        "router_guided": (True, None, "predictions"),
     }
-    for name, (want_guided, want_cap) in expected.items():
+    for name, (want_guided, want_cap, want_hop_source) in expected.items():
         got_name, block = rd.resolve_condition(cfg, name)
         check(f"condition {name} resolves", got_name == name)
         guided = bool(block["guided"])
         cap = block.get("stop_after_step_lines")
+        hop_source = block.get("hop_source") or require(cfg, "hop_source")
         check(f"condition {name} guided={want_guided}", guided is want_guided, repr(guided))
         check(f"condition {name} cap={want_cap}", cap == want_cap, repr(cap))
+        check(
+            f"condition {name} hop_source={want_hop_source}",
+            hop_source == want_hop_source,
+            repr(hop_source),
+        )
+    check("the config's default hop source is gold", require(cfg, "hop_source") == "gold")
 
     default_name, _ = rd.resolve_condition(cfg, None)
     check("default condition is unguided", default_name == "unguided", str(default_name))
@@ -1050,6 +1064,10 @@ def test_conditions_end_to_end() -> None:
                         "hit_max_new_tokens", "stopped_at_step_line_cap",
                         # the cost fields of issue #13 (PR #24), same shape in every arm
                         "prompt_tokens", "completion_tokens", "latency_seconds",
+                        # issue #27: hop_count stays the GOLD depth in every arm, and these
+                        # two say what the prompt actually stated and where it came from
+                        # (null / "gold" in these three arms; the prediction in router_guided)
+                        "prompt_hop_count", "hop_count_source",
                     }
                     for r in arm["results"]
                 ),

--- a/tests/test_router_predictions.py
+++ b/tests/test_router_predictions.py
@@ -1,0 +1,721 @@
+#!/usr/bin/env python3
+"""Checks for the measurable router (issue #27). CPU only, no weights, no network.
+
+Everything here runs on hand-written synthetic rows (or the fabricated fixtures under
+``tests/fixtures/``); the CLI checks use ``--dry-run``, which loads no model.
+
+What it covers:
+
+1. **Predictions keyed by query id** — the router's predictions file is built from the query
+   id, and the file it writes is *exactly* what the consumer reads: the round trip through
+   ``src/hop_matching.py::load_predicted_hops`` is asserted, so the producer and the two
+   consumers (issue #15's ``predictions`` hop source, the decomposer's ``router_guided``
+   condition) cannot drift apart silently.
+2. **Join integrity, loudly** — a row with no query id and a repeated query id are refused
+   on the producing side (before a model is loaded) *and* on the consuming side, and every
+   refusal names the offenders. A query with no prediction is refused, never filled in from
+   the gold depth.
+3. **The few-shot router's prompt construction** — k exemplars per query, each labelled with
+   its own gold hop depth parsed from its pool id, with the query itself excluded by id and
+   by normalized question text (the decomposer's rule, imported not copied). The exemplar
+   block's ``A: <n>`` line is checked to be readable by the run's own response parser, so the
+   prompt and the parsing cannot disagree.
+4. **The decomposer's router-predictions consumption** — ``hop_source`` resolution and all
+   four of its refusals, and that the join moves the *prompt's* hop count while leaving the
+   gold depth (and therefore the per-hop reporting and the pinned-set assertion) alone.
+5. **End to end on the fixtures** — the few-shot router and the ``router_guided`` decomposer
+   arm both run to completion in ``--dry-run``, the routed arm's prompts carry the predicted
+   hop where ``oracle_guided`` carries the gold one, and the unchanged MetaQA router path
+   still runs.
+
+Run::
+
+    .venv/bin/python -m unittest tests.test_router_predictions -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+for _path in (
+    REPO_ROOT / "src",
+    REPO_ROOT / "components" / "decomposer",
+    REPO_ROOT / "components" / "router",
+):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+import hop_matching as HM  # noqa: E402
+import run_decomposer as rd  # noqa: E402
+import run_router as rr  # noqa: E402
+from run_config import PATHS_CONFIG_ENV, load_config  # noqa: E402
+
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+RETRIEVAL_FIXTURE = FIXTURES / "retrieval" / "top5_musique_conditions.jsonl"
+PREDICTIONS_FIXTURE = FIXTURES / "router" / "hop_predictions_musique.jsonl"
+ROUTER_RUNNER = REPO_ROOT / "components" / "router" / "run_router.py"
+DECOMPOSER_RUNNER = REPO_ROOT / "components" / "decomposer" / "run_decomposer.py"
+SMOKE_PATHS = "configs/smoke_paths.json"
+
+#: The fixture tree holds 3 rows per hop, not the pinned 200 of ADR 0007, so every CLI check
+#: here opts out of the pinned-set assertion explicitly. A real arm never passes this.
+UNPINNED = "--allow-unpinned-eval-set"
+
+#: mistral_7b_instruct is the decomposer folder used end to end: it ships the parity-guarded
+#: unguided prompt configs/decomposer_musique.json requires. qwen2_5_0_5b is the router
+#: folder: the smallest one, and no weights are loaded in a dry run anyway.
+DECOMPOSER_MODEL = "mistral_7b_instruct"
+ROUTER_MODEL = "qwen2_5_0_5b"
+
+
+def run_cli(cmd: list[str]) -> subprocess.CompletedProcess:
+    """Run a runner against the fixture tree, as the smoke test does."""
+    env = dict(os.environ)
+    env[PATHS_CONFIG_ENV] = SMOKE_PATHS
+    return subprocess.run(
+        [sys.executable, *[str(c) for c in cmd]],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def only_run_dir(root: Path) -> Path:
+    """The single timestamped run directory a runner wrote under ``root``."""
+    dirs = sorted(p for p in root.iterdir() if p.is_dir())
+    if len(dirs) != 1:
+        raise AssertionError(f"expected exactly one run dir under {root}, found {dirs}")
+    return dirs[0]
+
+
+def candidate(pool_id: str, question: str, score: float = 0.9) -> dict:
+    """One synthetic retrieval candidate, in the shape the retrieval chain writes."""
+    return {
+        "pool_id": pool_id,
+        "pool_index": 0,
+        "pool_question": question,
+        "pool_few_shot_decomposition_musique": ["Step one?", "Step two?"],
+        "score": score,
+    }
+
+
+def retrieval_row(query_id: str, question: str, candidates: list[dict]) -> dict:
+    return {"query_id": query_id, "query_question": question, "typed_top_k": candidates}
+
+
+def inference_row(query_id: str | None, gold_hop: int) -> dict:
+    """A decomposer inference row, in the shape run_decomposer builds before the join."""
+    return {
+        "query_id": query_id,
+        "question": f"question for {query_id}",
+        "hop_count": gold_hop,
+        "gold_hop_count": gold_hop,
+        "retrieval_examples": [],
+    }
+
+
+# --------------------------------------------------------------- predictions file
+
+
+class TestPredictionRows(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rows = [
+            {"query_id": "2hop__a", "question": "q1", "expected_hop": 2},
+            {"query_id": "3hop1__b", "question": "q2", "expected_hop": 3},
+            {"query_id": "4hop2__c", "question": "q3", "expected_hop": 4},
+        ]
+
+    def test_rows_carry_the_query_id_and_the_prediction(self) -> None:
+        out = rr.build_prediction_rows(
+            self.rows, [2, 2, 4], [True, False, True],
+            id_field="query_id", hop_field="predicted_hop",
+        )
+        self.assertEqual([r["query_id"] for r in out], ["2hop__a", "3hop1__b", "4hop2__c"])
+        self.assertEqual([r["predicted_hop"] for r in out], [2, 2, 4])
+        self.assertEqual([r["correct"] for r in out], [True, False, True])
+        # The middle row's hop came from parsing.default_hop, not from the response.
+        self.assertEqual([r["parse_fallback"] for r in out], [False, True, False])
+
+    def test_field_names_come_from_the_config(self) -> None:
+        out = rr.build_prediction_rows(
+            self.rows, [2, 3, 4], [True, True, True], id_field="id", hop_field="hop",
+        )
+        self.assertEqual(sorted(out[0]), ["correct", "expected_hop", "hop", "id",
+                                          "parse_fallback"])
+
+    def test_no_question_text_in_the_predictions_file(self) -> None:
+        # ADR 0022 item 5 rejected keying this join on question text; the text is therefore
+        # not carried in the file that gets joined.
+        out = rr.build_prediction_rows(
+            self.rows, [2, 3, 4], [True, True, True],
+            id_field="query_id", hop_field="predicted_hop",
+        )
+        for row in out:
+            self.assertNotIn("question", row)
+
+    def test_misaligned_predictions_are_a_bug_not_a_file(self) -> None:
+        with self.assertRaises(AssertionError):
+            rr.build_prediction_rows(
+                self.rows, [2, 3], [True, True],
+                id_field="query_id", hop_field="predicted_hop",
+            )
+
+    def test_round_trip_through_the_consumer(self) -> None:
+        """What the router writes is what ``load_predicted_hops`` reads. The contract."""
+        out = rr.build_prediction_rows(
+            self.rows, [2, 4, 4], [True, True, True],
+            id_field="query_id", hop_field="predicted_hop",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "predictions.jsonl"
+            rr.write_predictions_jsonl(path, out)
+            loaded = HM.load_predicted_hops(
+                path, id_field="query_id", hop_field="predicted_hop"
+            )
+        self.assertEqual(loaded, {"2hop__a": 2, "3hop1__b": 4, "4hop2__c": 4})
+
+    def test_committed_fixture_is_readable_by_the_consumer(self) -> None:
+        loaded = HM.load_predicted_hops(
+            PREDICTIONS_FIXTURE, id_field="query_id", hop_field="predicted_hop"
+        )
+        self.assertEqual(len(loaded), 9)
+        # Three of the nine deliberately disagree with the gold depth parsed from the id.
+        disagree = [
+            qid for qid, hop in loaded.items() if HM.parse_hop_from_id(qid) != hop
+        ]
+        self.assertEqual(len(disagree), 3, disagree)
+
+
+class TestQueryIdIntegrity(unittest.TestCase):
+    def test_unique_ids_pass(self) -> None:
+        rr.assert_query_ids(
+            [{"query_id": "2hop__a"}, {"query_id": "3hop1__b"}],
+            source="fixture", reason="because",
+        )
+
+    def test_a_missing_id_is_refused_by_index(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rr.assert_query_ids(
+                [{"query_id": "2hop__a"}, {"query_id": None}, {"query_id": "  "}],
+                source="fixture", reason="because",
+            )
+        message = str(ctx.exception)
+        self.assertIn("2 of 3", message)
+        self.assertIn("index 1", message)
+        self.assertIn("index 2", message)
+
+    def test_a_duplicate_id_is_refused_and_named(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rr.assert_query_ids(
+                [{"query_id": "2hop__a"}, {"query_id": "2hop__a"}],
+                source="fixture", reason="because",
+            )
+        self.assertIn("2hop__a", str(ctx.exception))
+
+    def test_a_duplicated_router_output_is_refused_on_read(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "predictions.jsonl"
+            rr.write_predictions_jsonl(
+                path,
+                [
+                    {"query_id": "2hop__a", "predicted_hop": 2},
+                    {"query_id": "2hop__a", "predicted_hop": 3},
+                ],
+            )
+            with self.assertRaises(SystemExit) as ctx:
+                HM.load_predicted_hops(
+                    path, id_field="query_id", hop_field="predicted_hop"
+                )
+        self.assertIn("2hop__a", str(ctx.exception))
+
+
+# ------------------------------------------------------------ few-shot prompting
+
+
+class TestFewShotPromptConstruction(unittest.TestCase):
+    def setUp(self) -> None:
+        self.row = retrieval_row(
+            "2hop__q1",
+            "Who leads the union that organised the strike?",
+            [
+                candidate("2hop__p1", "Who leads the party that won the election?"),
+                candidate("3hop1__p2", "What is the capital of the country?"),
+                candidate("4hop2__p3", "What is the population of the town?"),
+            ],
+        )
+
+    def test_exemplars_are_labelled_with_their_own_hop_depth(self) -> None:
+        examples, dropped = rr.examples_from_retrieval_row(
+            self.row, mode="typed", k=3, exemplar_hop_source="pool_id"
+        )
+        self.assertEqual(dropped, 0)
+        self.assertEqual([ex["hop_count"] for ex in examples], [2, 3, 4])
+        self.assertEqual([ex["pool_id"] for ex in examples],
+                         ["2hop__p1", "3hop1__p2", "4hop2__p3"])
+
+    def test_the_query_is_excluded_from_its_own_exemplars_by_id(self) -> None:
+        row = retrieval_row(
+            "2hop__q1",
+            "Who leads the union?",
+            [
+                candidate("2hop__q1", "A differently worded copy of the query"),
+                candidate("2hop__p1", "Who leads the party?"),
+                candidate("3hop1__p2", "What is the capital?"),
+            ],
+        )
+        examples, dropped = rr.examples_from_retrieval_row(
+            row, mode="typed", k=2, exemplar_hop_source="pool_id"
+        )
+        self.assertEqual(dropped, 1)
+        self.assertEqual([ex["pool_id"] for ex in examples], ["2hop__p1", "3hop1__p2"])
+
+    def test_the_query_is_excluded_by_normalized_question_text(self) -> None:
+        row = retrieval_row(
+            "2hop__q1",
+            "Who leads the union?",
+            [
+                candidate("2hop__other", "  who LEADS the   union? "),
+                candidate("2hop__p1", "Who leads the party?"),
+            ],
+        )
+        examples, dropped = rr.examples_from_retrieval_row(
+            row, mode="typed", k=1, exemplar_hop_source="pool_id"
+        )
+        self.assertEqual(dropped, 1)
+        self.assertEqual([ex["pool_id"] for ex in examples], ["2hop__p1"])
+
+    def test_too_few_usable_candidates_is_refused_with_counts(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rr.examples_from_retrieval_row(
+                self.row, mode="typed", k=5, exemplar_hop_source="pool_id"
+            )
+        message = str(ctx.exception)
+        self.assertIn("only 3 usable", message)
+        self.assertIn("k=5", message)
+
+    def test_an_unparseable_pool_id_is_refused(self) -> None:
+        row = retrieval_row(
+            "2hop__q1", "Q?", [candidate("no_hop_prefix", "Some pool question?")]
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            rr.examples_from_retrieval_row(
+                row, mode="typed", k=1, exemplar_hop_source="pool_id"
+            )
+        self.assertIn("no_hop_prefix", str(ctx.exception))
+
+    def test_an_exemplar_without_a_question_is_refused(self) -> None:
+        broken = candidate("2hop__p1", "x")
+        broken["pool_question"] = "   "
+        row = retrieval_row("2hop__q1", "Q?", [broken])
+        with self.assertRaises(SystemExit) as ctx:
+            rr.examples_from_retrieval_row(
+                row, mode="typed", k=1, exemplar_hop_source="pool_id"
+            )
+        self.assertIn("pool_question", str(ctx.exception))
+
+    def test_an_unknown_exemplar_hop_source_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rr.examples_from_retrieval_row(
+                self.row, mode="typed", k=1, exemplar_hop_source="gold_step_count"
+            )
+        self.assertIn("gold_step_count", str(ctx.exception))
+
+    def test_the_block_shape_is_question_then_hop_count(self) -> None:
+        examples, _ = rr.examples_from_retrieval_row(
+            self.row, mode="typed", k=2, exemplar_hop_source="pool_id"
+        )
+        block = rr.format_few_shot_examples(examples)
+        self.assertEqual(
+            block,
+            "Q: Who leads the party that won the election?\nA: 2\n\n"
+            "Q: What is the capital of the country?\nA: 3",
+        )
+
+    def test_the_prompt_fills_both_placeholders(self) -> None:
+        template = (
+            REPO_ROOT / "components" / "router" / "models" / "prompt_few_shot_musique.md"
+        ).read_text(encoding="utf-8")
+        examples, _ = rr.examples_from_retrieval_row(
+            self.row, mode="typed", k=2, exemplar_hop_source="pool_id"
+        )
+        prompt = rr.build_prompt(
+            template, "Who leads the union?", rr.format_few_shot_examples(examples)
+        )
+        self.assertNotIn("{few_shot_examples}", prompt)
+        self.assertNotIn("{question}", prompt)
+        self.assertIn("A: 2", prompt)
+        self.assertIn("Q: Who leads the union?", prompt)
+        # The query's own line is last and unanswered: the model has to fill it in.
+        self.assertTrue(prompt.rstrip().endswith("A:"), prompt[-40:])
+
+    def test_a_v1_prompt_renders_exactly_as_before(self) -> None:
+        self.assertEqual(rr.build_prompt("Q: {question}\nA:", "why?"), "Q: why?\nA:")
+        self.assertEqual(rr.build_prompt("Q: {{question}}", "why?"), "Q: why?")
+        self.assertEqual(rr.build_prompt("no placeholders", "why?"), "no placeholders")
+
+    def test_the_exemplar_answer_line_is_readable_by_the_run_s_parser(self) -> None:
+        """The prompt format and the response parsing must agree, or 4-hop is unreadable."""
+        cfg = load_config("router_musique.json")
+        model_cfg = load_config(
+            REPO_ROOT / "components" / "router" / "models" / ROUTER_MODEL / "config.json"
+        )
+        parsing = rr.apply_overrides(
+            dict(model_cfg["parsing"]),
+            cfg["parsing_overrides"],
+            block="parsing",
+            src="test",
+        )
+        parsing["hops"] = cfg["hops"]
+        for hop in cfg["hops"]:
+            self.assertEqual(rr.parse_hop_response(f" {hop}", "q", parsing), (hop, True))
+            self.assertEqual(rr.parse_hop_response(f"A: {hop}", "q", parsing), (hop, True))
+        # Nothing readable: the configured default, flagged as not parsed.
+        hop, parsed = rr.parse_hop_response("no idea", "q", parsing)
+        self.assertEqual(hop, int(parsing["default_hop"]))
+        self.assertFalse(parsed)
+
+    def test_unknown_override_keys_are_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rr.apply_overrides(
+                {"answer_regex": "x"}, {"answr_regex": "y"}, block="parsing", src="test"
+            )
+        self.assertIn("answr_regex", str(ctx.exception))
+
+
+class TestRouterConfigs(unittest.TestCase):
+    def test_musique_router_config(self) -> None:
+        cfg = load_config("router_musique.json")
+        self.assertEqual(cfg["hops"], [2, 3, 4])
+        self.assertEqual(cfg["questions_format"], "jsonl")
+        self.assertEqual(cfg["questions_template_key"], "musique_eval_questions_template")
+        self.assertEqual(cfg["eval_rows_per_hop"], 200)
+        self.assertEqual(cfg["seed"], 42)
+        self.assertIsNone(cfg["sample_size_per_hop"])
+        self.assertTrue(cfg["few_shot"]["enabled"])
+        self.assertIn(cfg["few_shot"]["exemplar_hop_source"], rr.EXEMPLAR_HOP_SOURCES)
+        self.assertTrue(cfg["predictions"]["enabled"])
+        self.assertEqual(cfg["predictions"]["id_field"], "query_id")
+        self.assertEqual(cfg["predictions"]["hop_field"], "predicted_hop")
+        self.assertEqual(cfg["prompt_file"], "prompt_few_shot_musique.md")
+        self.assertEqual(cfg["retrieval"]["input_key"], "musique_few_shot_top5_pinned600")
+
+    def test_the_predictions_field_names_are_the_consumers_defaults(self) -> None:
+        router = load_config("router_musique.json")["predictions"]
+        similarity = load_config("similarity.json")["hop_match"]
+        decomposer = load_config("decomposer_musique.json")["hop_predictions"]
+        self.assertEqual(router["id_field"], similarity["predictions_id_field"])
+        self.assertEqual(router["hop_field"], similarity["predictions_hop_field"])
+        self.assertEqual(router["id_field"], decomposer["id_field"])
+        self.assertEqual(router["hop_field"], decomposer["hop_field"])
+
+    def test_metaqa_router_config_unchanged(self) -> None:
+        cfg = load_config("router.json")
+        self.assertEqual(cfg["hops"], [1, 2, 3])
+        self.assertEqual(cfg["questions_format"], "lines")
+        self.assertFalse(cfg["few_shot"]["enabled"])
+        self.assertFalse(cfg["predictions"]["enabled"])
+        self.assertIsNone(cfg["prompt_file"])
+        self.assertNotIn("eval_rows_per_hop", cfg)
+        self.assertNotIn("parsing_overrides", cfg)
+
+
+# ------------------------------------------ the decomposer's side of the join
+
+
+class TestHopSourceResolution(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = load_config("decomposer_musique.json")
+
+    def resolve(self, condition_name, *, guided=True, cli=None):
+        name, block = rd.resolve_condition(self.cfg, condition_name)
+        return rd.resolve_hop_source(
+            name, block, self.cfg, guided=guided, cli_predictions=cli
+        )
+
+    def test_hop_source_is_a_permitted_condition_key(self) -> None:
+        self.assertIn("hop_source", rd._CONDITION_KEYS)
+
+    def test_oracle_guided_is_gold(self) -> None:
+        record = self.resolve("oracle_guided")
+        self.assertEqual(record["source"], "gold")
+        self.assertIsNone(record["predictions_file"])
+
+    def test_router_guided_takes_the_file_from_the_cli(self) -> None:
+        record = self.resolve("router_guided", cli="runs/router/predictions.jsonl")
+        self.assertEqual(record["source"], "predictions")
+        self.assertEqual(record["predictions_file"], "runs/router/predictions.jsonl")
+        self.assertEqual(record["id_field"], "query_id")
+        self.assertEqual(record["hop_field"], "predicted_hop")
+
+    def test_router_guided_without_a_file_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            self.resolve("router_guided")
+        self.assertIn("--hop-predictions", str(ctx.exception))
+
+    def test_predictions_in_an_unguided_arm_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            self.resolve("router_guided", guided=False, cli="p.jsonl")
+        self.assertIn("unguided", str(ctx.exception))
+
+    def test_a_predictions_file_on_a_gold_arm_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            self.resolve("oracle_guided", cli="p.jsonl")
+        self.assertIn("would be ignored", str(ctx.exception))
+
+    def test_an_unknown_hop_source_is_refused(self) -> None:
+        cfg = dict(self.cfg)
+        cfg["hop_source"] = "similarity_vote"
+        with self.assertRaises(SystemExit) as ctx:
+            rd.resolve_hop_source(None, {}, cfg, guided=True, cli_predictions=None)
+        self.assertIn("similarity_vote", str(ctx.exception))
+
+    def test_the_metaqa_config_defaults_to_gold(self) -> None:
+        cfg = load_config("decomposer.json")
+        record = rd.resolve_hop_source(None, {}, cfg, guided=True, cli_predictions=None)
+        self.assertEqual(record["source"], "gold")
+
+
+class TestJoinPredictedHops(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rows = [
+            inference_row("2hop__a", 2),
+            inference_row("3hop1__b", 3),
+            inference_row("4hop2__c", 4),
+        ]
+
+    def test_the_prompt_hop_moves_and_the_gold_hop_does_not(self) -> None:
+        record = rd.join_predicted_hops(
+            self.rows,
+            {"2hop__a": 3, "3hop1__b": 3, "4hop2__c": 2},
+            predictions_path=Path("p.jsonl"),
+            id_field="query_id",
+        )
+        self.assertEqual([r["hop_count"] for r in self.rows], [3, 3, 2])
+        self.assertEqual([r["gold_hop_count"] for r in self.rows], [2, 3, 4])
+        self.assertEqual(record["rows_joined"], 3)
+        self.assertEqual(record["rows_agreeing_with_gold_hop"], 1)
+        self.assertEqual(record["rows_disagreeing_with_gold_hop"], 2)
+        self.assertEqual(record["predictions_unused"], 0)
+
+    def test_unused_predictions_are_counted(self) -> None:
+        record = rd.join_predicted_hops(
+            self.rows,
+            {"2hop__a": 2, "3hop1__b": 3, "4hop2__c": 4, "2hop__spare": 2},
+            predictions_path=Path("p.jsonl"),
+            id_field="query_id",
+        )
+        self.assertEqual(record["predictions_unused"], 1)
+        self.assertEqual(record["predictions_in_file"], 4)
+
+    def test_a_missing_prediction_is_refused_and_named(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rd.join_predicted_hops(
+                self.rows,
+                {"2hop__a": 2},
+                predictions_path=Path("p.jsonl"),
+                id_field="query_id",
+            )
+        message = str(ctx.exception)
+        self.assertIn("2 of 3", message)
+        self.assertIn("3hop1__b", message)
+        self.assertIn("4hop2__c", message)
+        # No row may have been silently filled in from the gold depth.
+        self.assertEqual([r["hop_count"] for r in self.rows], [2, 3, 4])
+
+    def test_a_row_without_a_query_id_is_refused(self) -> None:
+        rows = [inference_row("2hop__a", 2), inference_row(None, 3)]
+        with self.assertRaises(SystemExit) as ctx:
+            rd.join_predicted_hops(
+                rows,
+                {"2hop__a": 2},
+                predictions_path=Path("p.jsonl"),
+                id_field="query_id",
+            )
+        self.assertIn("no query id", str(ctx.exception))
+
+
+# ------------------------------------------------------------------ end to end
+
+
+class TestRouterCliDryRun(unittest.TestCase):
+    def test_few_shot_router_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "router"
+            proc = run_cli([
+                ROUTER_RUNNER, "--model", ROUTER_MODEL,
+                "--config", "router_musique.json",
+                "--retrieval-input", RETRIEVAL_FIXTURE,
+                "--dry-run", "--dry-run-limit", "9", UNPINNED,
+                "--output-root", out,
+            ])
+            self.assertEqual(proc.returncode, 0, proc.stdout[-3000:] + proc.stderr[-3000:])
+            run_dir = only_run_dir(out)
+            metrics = json.loads((run_dir / "metrics.json").read_text())
+            self.assertTrue(metrics["dry_run"])
+            self.assertEqual(metrics["total_questions_loaded"], 9)
+            self.assertEqual(metrics["questions_per_hop"],
+                             {"2hop": 3, "3hop": 3, "4hop": 3})
+            self.assertEqual(metrics["prompts_assembled"], 9)
+            self.assertTrue(metrics["few_shot"]["enabled"])
+            self.assertEqual(metrics["few_shot"]["k"], 5)
+            # The two planted self-example rows in the fixture (same id, and the same
+            # question text under another id) must both have been dropped.
+            self.assertEqual(metrics["few_shot"]["self_examples_dropped"], 2)
+            self.assertEqual(metrics["few_shot"]["rows_with_a_self_example_dropped"], 2)
+            # A dry run predicts nothing, so it writes no predictions file and says so.
+            self.assertIsNone(metrics["predictions_file"])
+            self.assertIn("not written", metrics["predictions_note"])
+            self.assertIsNone(metrics["accuracy_metrics"])
+            self.assertFalse(metrics["model_size"]["ceiling_asserted"])
+
+            snapshot = json.loads((run_dir / "config.json").read_text())
+            self.assertTrue(snapshot["predictions"]["enabled"])
+            self.assertEqual(snapshot["predictions"]["id_field"], "query_id")
+            self.assertIsNotNone(snapshot["retrieval"]["input_sha256"])
+
+            prompt = (run_dir / "prompts_log" / "prompt_idx0001.txt").read_text()
+            self.assertIn("Few-shot exemplars (5)", prompt)
+            # Every exemplar states a hop count, and the query's own line is unanswered.
+            self.assertEqual(prompt.count("\nA: "), 5)
+            self.assertTrue(prompt.rstrip().endswith("A:"), prompt[-40:])
+
+    def test_metaqa_router_dry_run_still_works(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "router"
+            proc = run_cli([
+                ROUTER_RUNNER, "--model", ROUTER_MODEL,
+                "--dry-run", "--dry-run-limit", "3",
+                "--output-root", out,
+            ])
+            self.assertEqual(proc.returncode, 0, proc.stdout[-3000:] + proc.stderr[-3000:])
+            metrics = json.loads((only_run_dir(out) / "metrics.json").read_text())
+            self.assertFalse(metrics["few_shot"]["enabled"])
+            self.assertIsNone(metrics["predictions_file"])
+            self.assertEqual(metrics["prompts_assembled"], 3)
+
+    def test_a_few_shot_config_without_exemplars_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = run_cli([
+                ROUTER_RUNNER, "--model", ROUTER_MODEL,
+                "--config", "router_musique.json",
+                "--dry-run", UNPINNED, "--output-root", Path(tmp) / "router",
+            ])
+            # The fixture tree has no file behind retrieval.input_key, so the run refuses
+            # rather than silently prompting zero-shot under a few-shot label.
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("retrieval", (proc.stdout + proc.stderr).lower())
+
+    def test_the_v1_prompt_is_refused_by_the_few_shot_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = run_cli([
+                ROUTER_RUNNER, "--model", ROUTER_MODEL,
+                "--config", "router_musique.json",
+                "--prompt-file", "prompt.md",
+                "--retrieval-input", RETRIEVAL_FIXTURE,
+                "--dry-run", UNPINNED, "--output-root", Path(tmp) / "router",
+            ])
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("few_shot_examples", proc.stdout + proc.stderr)
+
+
+class TestDecomposerRouterGuidedDryRun(unittest.TestCase):
+    def decomposer_cmd(self, condition: str, out: Path, *extra) -> list:
+        return [
+            DECOMPOSER_RUNNER, "--model", DECOMPOSER_MODEL,
+            "--config", "decomposer_musique.json", "--condition", condition,
+            "--retrieval-input", RETRIEVAL_FIXTURE,
+            "--dry-run", "--dry-run-limit", "9", UNPINNED,
+            "--output-root", out, *extra,
+        ]
+
+    def test_router_guided_uses_the_predicted_hop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            routed_out, oracle_out = Path(tmp) / "routed", Path(tmp) / "oracle"
+            routed = run_cli(self.decomposer_cmd(
+                "router_guided", routed_out, "--hop-predictions", PREDICTIONS_FIXTURE
+            ))
+            self.assertEqual(routed.returncode, 0,
+                             routed.stdout[-3000:] + routed.stderr[-3000:])
+            oracle = run_cli(self.decomposer_cmd("oracle_guided", oracle_out))
+            self.assertEqual(oracle.returncode, 0,
+                             oracle.stdout[-3000:] + oracle.stderr[-3000:])
+
+            routed_dir, oracle_dir = only_run_dir(routed_out), only_run_dir(oracle_out)
+            routed_rows = json.loads((routed_dir / "results.json").read_text())
+            oracle_rows = json.loads((oracle_dir / "results.json").read_text())
+            predicted = HM.load_predicted_hops(
+                PREDICTIONS_FIXTURE, id_field="query_id", hop_field="predicted_hop"
+            )
+
+            self.assertEqual(len(routed_rows), 9)
+            for row in routed_rows:
+                self.assertEqual(row["hop_count_source"], "predictions")
+                # The prompt states the prediction; the row stays filed under its gold depth.
+                self.assertEqual(row["prompt_hop_count"], predicted[row["query_id"]])
+                self.assertEqual(row["hop_count"], HM.parse_hop_from_id(row["query_id"]))
+            for row in oracle_rows:
+                self.assertEqual(row["hop_count_source"], "gold")
+                self.assertEqual(row["prompt_hop_count"], row["hop_count"])
+
+            # The two arms are the same run except for that number: same ids, same order.
+            self.assertEqual([r["query_id"] for r in routed_rows],
+                             [r["query_id"] for r in oracle_rows])
+
+            metrics = json.loads((routed_dir / "metrics.json").read_text())
+            self.assertEqual(metrics["rows_loaded_per_hop"], {"2": 3, "3": 3, "4": 3})
+            join = metrics["hop_source"]["join"]
+            self.assertEqual(join["rows_joined"], 9)
+            self.assertEqual(join["rows_agreeing_with_gold_hop"], 6)
+            self.assertEqual(join["rows_disagreeing_with_gold_hop"], 3)
+            self.assertIsNotNone(metrics["hop_source"]["predictions_file_sha256"])
+
+            # The prompts differ from the oracle arm's exactly where the prediction does.
+            def prompt_of(run_dir: Path, index: int, hop: int) -> str:
+                return (
+                    run_dir / "prompts_log" / f"prompt_idx{index:04d}_hop{hop}.txt"
+                ).read_text()
+
+            self.assertIn("Hop count in prompt: 3 (source: predictions)",
+                          prompt_of(routed_dir, 2, 2))
+            self.assertIn("Hop count in prompt: 2 (source: gold)",
+                          prompt_of(oracle_dir, 2, 2))
+
+    def test_a_predictions_file_missing_a_query_is_refused(self) -> None:
+        rows = [
+            json.loads(line)
+            for line in PREDICTIONS_FIXTURE.read_text().splitlines()
+            if line.strip()
+        ]
+        dropped = rows[-1]["query_id"]
+        with tempfile.TemporaryDirectory() as tmp:
+            partial = Path(tmp) / "partial.jsonl"
+            partial.write_text(
+                "".join(json.dumps(r) + "\n" for r in rows[:-1]), encoding="utf-8"
+            )
+            proc = run_cli(self.decomposer_cmd(
+                "router_guided", Path(tmp) / "routed", "--hop-predictions", partial
+            ))
+            self.assertNotEqual(proc.returncode, 0)
+            output = proc.stdout + proc.stderr
+            self.assertIn("no prediction", output)
+            self.assertIn(dropped, output)
+
+    def test_a_predictions_file_on_the_oracle_arm_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = run_cli(self.decomposer_cmd(
+                "oracle_guided", Path(tmp) / "oracle",
+                "--hop-predictions", PREDICTIONS_FIXTURE,
+            ))
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("would be ignored", proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_router_predictions.py
+++ b/tests/test_router_predictions.py
@@ -17,13 +17,20 @@ What it covers:
    the gold depth.
 3. **The few-shot router's prompt construction** — k exemplars per query, each labelled with
    its own gold hop depth parsed from its pool id, with the query itself excluded by id and
-   by normalized question text (the decomposer's rule, imported not copied). The exemplar
-   block's ``A: <n>`` line is checked to be readable by the run's own response parser, so the
-   prompt and the parsing cannot disagree.
-4. **The decomposer's router-predictions consumption** — ``hop_source`` resolution and all
-   four of its refusals, and that the join moves the *prompt's* hop count while leaving the
+   by normalized question text (the decomposer's rule, imported not copied).
+4. **The response parsing this prompt needs** — the prompt ends with the ``A:`` cue, so the
+   answer is the *leading* digit of the response and everything after the first line break is
+   the model writing its own next question. A response that answers and then regurgitates a
+   fresh ``Q:``/``A:`` pair must parse to the answer, not to the regurgitation (PR #43 review,
+   C1); a hop named in words must be read rather than defaulted (I1); and the config-level
+   guard that the parsing rules cover every hop depth, with ``default_hop`` among them, is
+   asserted here and by every run including a dry one.
+5. **The decomposer's router-predictions consumption** — ``hop_source`` resolution and all
+   five of its refusals, and that the join moves the *prompt's* hop count while leaving the
    gold depth (and therefore the per-hop reporting and the pinned-set assertion) alone.
-5. **End to end on the fixtures** — the few-shot router and the ``router_guided`` decomposer
+6. **How the accuracy numbers are defined where they are reported**, and defaulted rows
+   broken out per gold hop.
+7. **End to end on the fixtures** — the few-shot router and the ``router_guided`` decomposer
    arm both run to completion in ``--dry-run``, the routed arm's prompts carry the predicted
    hop where ``oracle_guided`` carries the gold one, and the unchanged MetaQA router path
    still runs.
@@ -40,6 +47,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -360,33 +368,159 @@ class TestFewShotPromptConstruction(unittest.TestCase):
         self.assertEqual(rr.build_prompt("Q: {{question}}", "why?"), "Q: why?")
         self.assertEqual(rr.build_prompt("no placeholders", "why?"), "no placeholders")
 
-    def test_the_exemplar_answer_line_is_readable_by_the_run_s_parser(self) -> None:
-        """The prompt format and the response parsing must agree, or 4-hop is unreadable."""
-        cfg = load_config("router_musique.json")
-        model_cfg = load_config(
-            REPO_ROOT / "components" / "router" / "models" / ROUTER_MODEL / "config.json"
-        )
-        parsing = rr.apply_overrides(
-            dict(model_cfg["parsing"]),
-            cfg["parsing_overrides"],
-            block="parsing",
-            src="test",
-        )
-        parsing["hops"] = cfg["hops"]
-        for hop in cfg["hops"]:
-            self.assertEqual(rr.parse_hop_response(f" {hop}", "q", parsing), (hop, True))
-            self.assertEqual(rr.parse_hop_response(f"A: {hop}", "q", parsing), (hop, True))
-        # Nothing readable: the configured default, flagged as not parsed.
-        hop, parsed = rr.parse_hop_response("no idea", "q", parsing)
-        self.assertEqual(hop, int(parsing["default_hop"]))
-        self.assertFalse(parsed)
-
     def test_unknown_override_keys_are_refused(self) -> None:
         with self.assertRaises(SystemExit) as ctx:
             rr.apply_overrides(
                 {"answer_regex": "x"}, {"answr_regex": "y"}, block="parsing", src="test"
             )
         self.assertIn("answr_regex", str(ctx.exception))
+
+
+def musique_parsing() -> dict:
+    """The parsing rules a real `router_musique.json` run assembles, from the committed files.
+
+    Built here rather than hand-written so the checks below read what a run would read: the
+    model folder's v1 block, the config's overrides, its hops and its truncation markers.
+    """
+    cfg = load_config("router_musique.json")
+    model_cfg = load_config(
+        REPO_ROOT / "components" / "router" / "models" / ROUTER_MODEL / "config.json"
+    )
+    parsing = rr.apply_overrides(
+        dict(model_cfg["parsing"]), cfg["parsing_overrides"], block="parsing", src="test"
+    )
+    parsing["hops"] = cfg["hops"]
+    parsing["truncate_at"] = list(cfg["response_truncate_at"])
+    return parsing
+
+
+class TestResponseParsing(unittest.TestCase):
+    """The response shape this prompt actually produces, and what must not be read from it."""
+
+    def setUp(self) -> None:
+        self.parsing = musique_parsing()
+        self.hops = self.parsing["hops"]
+
+    def test_the_answer_is_the_leading_digit(self) -> None:
+        # The prompt ends with "A:", so the cue is consumed and the response STARTS with the
+        # model's answer. (The previous version of this check asserted an "A: <n>" response,
+        # a shape this prompt cannot produce - PR #43 review, C1.)
+        for hop in self.hops:
+            self.assertEqual(rr.parse_hop_response(f" {hop}", "q", self.parsing), (hop, True))
+            self.assertEqual(rr.parse_hop_response(f"{hop}\n", "q", self.parsing), (hop, True))
+
+    def test_a_regurgitated_exemplar_answer_is_not_the_prediction(self) -> None:
+        """The C1 regression: the answer is this query's, not the next one the model invents."""
+        for hop in self.hops:
+            other = next(h for h in self.hops if h != hop)
+            response = f"{hop}\n\nQ: Who founded the town that hosts the press?\nA: {other}\n\nQ:"
+            self.assertEqual(
+                rr.parse_hop_response(response, "q", self.parsing), (hop, True), response
+            )
+
+    def test_a_leading_newline_does_not_truncate_the_answer_away(self) -> None:
+        # Order of operations: strip the outer whitespace first, THEN cut at the marker.
+        self.assertEqual(rr.parse_hop_response("\n3\n\nQ: x\nA: 4", "q", self.parsing), (3, True))
+
+    def test_a_think_block_is_stripped_before_the_answer_is_read(self) -> None:
+        self.assertEqual(
+            rr.parse_hop_response("<think>maybe 4?</think>\n2\n\nQ: x", "q", self.parsing),
+            (2, True),
+        )
+
+    def test_a_hop_named_in_words_is_read_not_defaulted(self) -> None:
+        """I1: with the v1 1/2/3 tables, "four hops" scored as parsing.default_hop."""
+        parsing = dict(self.parsing, answer_regex=None, fallback_labels="hop_words")
+        self.assertEqual(rr.parse_hop_response("four hops", "q", parsing), (4, True))
+        self.assertEqual(rr.parse_hop_response("this is 4-hop", "q", parsing), (4, True))
+        parsing = dict(self.parsing, answer_regex=None, fallback_labels="number_words")
+        self.assertEqual(rr.parse_hop_response("FOUR", "q", parsing), (4, True))
+
+    def test_an_unreadable_response_is_the_default_and_is_flagged(self) -> None:
+        hop, parsed = rr.parse_hop_response("no idea", "q", self.parsing)
+        self.assertEqual(hop, int(self.parsing["default_hop"]))
+        self.assertFalse(parsed)
+
+    def test_v1_parsing_is_unchanged_when_no_marker_is_configured(self) -> None:
+        """The MetaQA path: multi-line responses, and its own answer_regex still leads."""
+        cfg = load_config("router.json")
+        self.assertEqual(cfg["response_truncate_at"], [])
+        model_cfg = load_config(
+            REPO_ROOT / "components" / "router" / "models" / ROUTER_MODEL / "config.json"
+        )
+        parsing = dict(model_cfg["parsing"], hops=cfg["hops"], truncate_at=[])
+        # v1 shape: the trace comes first, the answer after it, on a later line.
+        self.assertEqual(
+            rr.parse_hop_response("Brad Pitt -> movies -> directors\nA: 2", "q", parsing),
+            (2, True),
+        )
+
+
+class TestParsingCoverageAssertion(unittest.TestCase):
+    """I1: the parsing rules must be able to express every hop depth the config may predict."""
+
+    def base(self, **over) -> dict:
+        parsing = {
+            "answer_regex": None,
+            "fallback_labels": "hop_words",
+            "default_hop": 2,
+            "truncate_at": [],
+        }
+        parsing.update(over)
+        return parsing
+
+    def test_the_committed_configs_pass(self) -> None:
+        for name in ("router.json", "router_musique.json"):
+            cfg = load_config(name)
+            model_cfg = load_config(
+                REPO_ROOT / "components" / "router" / "models" / ROUTER_MODEL / "config.json"
+            )
+            parsing = rr.apply_overrides(
+                dict(model_cfg["parsing"]),
+                cfg.get("parsing_overrides"),
+                block="parsing",
+                src=name,
+            )
+            record = rr.assert_parsing_covers_hops(parsing, cfg["hops"], src=name)
+            self.assertTrue(record["asserted"])
+            self.assertEqual(sorted(record["labels_per_hop"]), sorted(cfg["hops"]))
+            self.assertIn(record["default_hop"], cfg["hops"])
+
+    def test_a_default_hop_outside_hops_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rr.assert_parsing_covers_hops(self.base(default_hop=1), [2, 3, 4], src="test")
+        self.assertIn("default_hop=1", str(ctx.exception))
+
+    def test_a_two_digit_hop_depth_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rr.assert_parsing_covers_hops(self.base(), [2, 10], src="test")
+        self.assertIn("10", str(ctx.exception))
+
+    def test_a_hop_the_number_word_table_cannot_name_is_refused(self) -> None:
+        """With v1's 1/2/3 table and MuSiQue's hops, the gap is a refusal, not a default."""
+        with unittest.mock.patch.dict(
+            rr._NUMBER_WORDS, {"ONE": 1, "TWO": 2, "THREE": 3}, clear=True
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                rr.assert_parsing_covers_hops(
+                    self.base(fallback_labels="number_words"), [2, 3, 4], src="test"
+                )
+        self.assertIn("[4]", str(ctx.exception))
+
+    def test_number_words_cover_every_single_digit_hop(self) -> None:
+        for hop in range(1, rr.MAX_PARSEABLE_HOP + 1):
+            record = rr.assert_parsing_covers_hops(
+                self.base(fallback_labels="number_words", default_hop=hop), [hop], src="test"
+            )
+            self.assertEqual(record["labels_per_hop"][hop][0].isalpha(), True)
+            self.assertTrue(rr.hop_word_labels(hop))
+
+    def test_an_unknown_fallback_table_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            rr.assert_parsing_covers_hops(
+                self.base(fallback_labels="roman_numerals"), [2, 3], src="test"
+            )
+        self.assertIn("roman_numerals", str(ctx.exception))
 
 
 class TestRouterConfigs(unittest.TestCase):
@@ -405,6 +539,13 @@ class TestRouterConfigs(unittest.TestCase):
         self.assertEqual(cfg["predictions"]["hop_field"], "predicted_hop")
         self.assertEqual(cfg["prompt_file"], "prompt_few_shot_musique.md")
         self.assertEqual(cfg["retrieval"]["input_key"], "musique_few_shot_top5_pinned600")
+        # C1: the response is cut at the answer, and the "A:"-prefix regex is off because
+        # this prompt consumes that cue itself.
+        self.assertEqual(cfg["response_truncate_at"], ["\n"])
+        self.assertIsNone(cfg["parsing_overrides"]["answer_regex"])
+        # N2: no dead zero-shot output root - this config has no zero-shot arm.
+        self.assertNotIn("output_subdir_zero_shot", cfg)
+        self.assertIn("output_subdir_few_shot", cfg)
 
     def test_the_predictions_field_names_are_the_consumers_defaults(self) -> None:
         router = load_config("router_musique.json")["predictions"]
@@ -424,6 +565,34 @@ class TestRouterConfigs(unittest.TestCase):
         self.assertIsNone(cfg["prompt_file"])
         self.assertNotIn("eval_rows_per_hop", cfg)
         self.assertNotIn("parsing_overrides", cfg)
+        # No truncation on this path: its responses are multi-line by design, so v1 parsing
+        # is untouched.
+        self.assertEqual(cfg["response_truncate_at"], [])
+        self.assertIn("output_subdir_zero_shot", cfg)
+
+
+class TestAccuracyReporting(unittest.TestCase):
+    """I2: the accuracy numbers carry their definitions, and defaults are broken out."""
+
+    def test_definitions_cover_every_reported_accuracy_key(self) -> None:
+        metrics = rr.compute_metrics(
+            [2, 3, 2], [2, 3, 4], 42, "stub/model", "run", [2, 3, 4]
+        )
+        self.assertAlmostEqual(metrics["overall_accuracy"], 2 / 3)
+        self.assertEqual(metrics["hop_4_accuracy"], 0.0)
+        self.assertEqual(metrics["hop_4_total"], 1)
+        for key in ("gold_hop_count", "overall_accuracy", "hop_<h>_accuracy",
+                    "hop_<h>_total", "unparsed_response_rows"):
+            self.assertIn(key, rr.ACCURACY_DEFINITIONS)
+        # The per-hop rows are recall, and the definition has to say so - it is the reading a
+        # routing table invites.
+        self.assertIn("recall", rr.ACCURACY_DEFINITIONS["hop_<h>_accuracy"])
+
+    def test_defaulted_rows_are_counted_per_gold_hop(self) -> None:
+        per_hop = rr.unparsed_rows_per_hop(
+            [2, 3, 4, 4], [True, False, False, False], [2, 3, 4]
+        )
+        self.assertEqual(per_hop, {"2": 0, "3": 1, "4": 2})
 
 
 # ------------------------------------------ the decomposer's side of the join
@@ -468,6 +637,31 @@ class TestHopSourceResolution(unittest.TestCase):
         with self.assertRaises(SystemExit) as ctx:
             self.resolve("oracle_guided", cli="p.jsonl")
         self.assertIn("would be ignored", str(ctx.exception))
+
+    def test_a_condition_with_an_explicit_null_hop_source_is_refused(self) -> None:
+        """N4: a null reads as "this arm names no source", not as "inherit the default"."""
+        cfg = dict(self.cfg)
+        cfg["conditions"] = dict(cfg["conditions"], nulled={"guided": True, "hop_source": None})
+        name, block = rd.resolve_condition(cfg, "nulled")
+        with self.assertRaises(SystemExit) as ctx:
+            rd.resolve_hop_source(name, block, cfg, guided=True, cli_predictions=None)
+        self.assertIn("hop_source", str(ctx.exception))
+
+    def test_predictions_with_query_exemplar_hop_lines_is_refused(self) -> None:
+        """I3: that mode would stamp the PREDICTION on every exemplar (ADR 0013's defect)."""
+        cfg = dict(self.cfg)
+        cfg["few_shot_exemplar_hop_count"] = "query"
+        name, block = rd.resolve_condition(cfg, "router_guided")
+        with self.assertRaises(SystemExit) as ctx:
+            rd.resolve_hop_source(name, block, cfg, guided=True, cli_predictions="p.jsonl")
+        message = str(ctx.exception)
+        self.assertIn("few_shot_exemplar_hop_count", message)
+        self.assertIn("exemplar_gold", message)
+
+    def test_the_committed_musique_config_uses_exemplar_gold(self) -> None:
+        # The combination above is unreachable from the committed configs, which is what
+        # makes the refusal a guard rather than a fix.
+        self.assertEqual(self.cfg["few_shot_exemplar_hop_count"], "exemplar_gold")
 
     def test_an_unknown_hop_source_is_refused(self) -> None:
         cfg = dict(self.cfg)
@@ -574,6 +768,11 @@ class TestRouterCliDryRun(unittest.TestCase):
             self.assertIn("not written", metrics["predictions_note"])
             self.assertIsNone(metrics["accuracy_metrics"])
             self.assertFalse(metrics["model_size"]["ceiling_asserted"])
+            # The parsing-coverage guard runs with no weights, so a dry run proves the
+            # config's hops are all expressible and default_hop is one of them (I1).
+            self.assertTrue(metrics["parsing_coverage"]["asserted"])
+            self.assertEqual(metrics["parsing_coverage"]["digit_class"], "[234]")
+            self.assertIn(metrics["parsing_coverage"]["default_hop"], [2, 3, 4])
 
             snapshot = json.loads((run_dir / "config.json").read_text())
             self.assertTrue(snapshot["predictions"]["enabled"])
@@ -611,6 +810,18 @@ class TestRouterCliDryRun(unittest.TestCase):
             # rather than silently prompting zero-shot under a few-shot label.
             self.assertNotEqual(proc.returncode, 0)
             self.assertIn("retrieval", (proc.stdout + proc.stderr).lower())
+
+    def test_a_zero_shot_prompt_has_no_output_root_in_this_config(self) -> None:
+        """N2: the removed knob becomes a named refusal, not a KeyError or a silent path."""
+        proc = run_cli([
+            ROUTER_RUNNER, "--model", ROUTER_MODEL,
+            "--config", "router_musique.json",
+            "--prompt-file", "prompt_zero_shot.md",
+            "--retrieval-input", RETRIEVAL_FIXTURE,
+            "--dry-run", UNPINNED,
+        ])
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("output_subdir_zero_shot", proc.stdout + proc.stderr)
 
     def test_the_v1_prompt_is_refused_by_the_few_shot_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Refs #27 (the with/without-router evaluation run itself is a separate experiment lane, so this does not close it). Also unblocks the `predictions` hop source of #15 / ADR 0022 item 5, and serves ADR 0023 item 2.2.

**Nothing here is a measurement.** No router has been run: no accuracy number, no effect on decomposition quality, no log entry. Everything below was executed CPU-only with no weights loaded.

## What changed and why

**1. `components/router/run_router.py` — predictions keyed by query id.** A run whose question source carries ids (`questions_format: jsonl`) writes `predictions.jsonl`: one object per query with `query_id` / `predicted_hop` (names from config), plus `expected_hop`, `correct` and `parse_fallback`. That is exactly the shape ADR 0022 item 5 documented and could not find a producer for, so the two consumers join on the id with no adapter: the retrieval chain's `--hop-source predictions` and the decomposer's new `router_guided` arm. `detailed_results.json` now carries `query_id` too. A blank/absent or repeated id is refused *before* a model loads; `parse_fallback` and `unparsed_response_rows` are new because v1 returned `parsing.default_hop` silently, so a run's accuracy mixed predictions with defaults and nothing recorded which. A dry run writes no predictions file — it generates nothing, and fabricating routing decisions is not a smoke test; the file's shape is pinned instead by a unit test that round-trips it through `load_predicted_hops`.

**2. A retrieved-few-shot prompting mode + `configs/router_musique.json`.** Exemplars are the query's own candidates from the retrieval artifact the decomposer already reads (`--retrieval-input` / `retrieval.input_key`), each labelled with **its own** gold hop depth parsed from its pool id, with the query dropped from its own exemplars by id and by normalized question text — `run_decomposer.is_self_example`, imported rather than copied. Nothing is trained. New shared prompt `components/router/models/prompt_few_shot_musique.md` (the v1 per-model prompts are untouched; MuSiQue's 2/3/4 answer digits come from a `parsing_overrides` block, not an edit to a v1 asset). The config asserts the pinned ADR 0007 set by id, so a predictions file over a different 600 is refused rather than joined against arms it does not cover.

**3. `components/decomposer/run_decomposer.py` — the guided condition could only take gold hop counts; now it can take a router's.** `hop_source` joins `guided`/`stop_after_step_lines` as a condition key, and `router_guided` sets it to `predictions`: the hop count comes from a predictions JSONL joined on the query id (`--hop-predictions`) and overrides the gold depth even when they disagree. Nothing falls back — a query the file does not cover is refused with the offending ids named. `hop_count` in `results.json` keeps its meaning (the **gold** depth, so no existing consumer changes and a prediction cannot move a row into another hop's table); `prompt_hop_count` and `hop_count_source` are new, and `metrics.json` gains a `hop_source` block with the predictions path, its sha256 and the gold-agreement counts.

**4. Tests, fixtures, docs.** `tests/test_router_predictions.py` (44 tests), `tests/fixtures/router/hop_predictions_musique.jsonl` (9 hand-written rows over the fixture ids, 3 deliberately disagreeing with gold, 1 flagged as a defaulted hop — synthetic, no dataset rows), two new smoke stages, ADR 0024, forward notes on ADR 0022 items 5 and 9's consequence, README updates, and the ADR index gained the missing 0023 row plus 0024. `tests/test_decomposer_conditions.py` was updated for the fourth condition and the two new result fields.

## Evidence (ran-X-observed-Y, all CPU, no weights)

- `python -m unittest discover -s tests` → **Ran 354 tests, OK** (310 on `main` + 44 new).
- `python tests/test_decomposer_conditions.py --skip-data-checks` → **258 checks passed**.
- `python scripts/smoke_test.py` → **39/39 stages passed**, including `router_dry_run_musique_few_shot` and `decomposer_dry_run_musique_router_guided`.
- Few-shot router dry run on the fixtures (9 queries): 5 exemplars per prompt, each `A: <hop>` from its pool id, **2 self-examples dropped** (the two planted fixture cases), `predictions_file: null` with the "dry run predicts nothing" note.
- `router_guided` vs `oracle_guided` dry runs on the same 9 fixture queries: the routed arm put the **predicted** hop in all 9 prompts (row-by-row equal to the predictions file, 6 agreeing with gold / 3 disagreeing), the oracle arm put the gold one, same query ids in the same order, and the routed run's per-hop counts stayed 3/3/3 on the **gold** depth.
- Refusals exercised end to end: a predictions file missing one query (names it), `--hop-predictions` on the oracle arm, a few-shot config with no exemplar source, and a few-shot config pointed at a v1 prompt with no `{few_shot_examples}`.
- Parameter ceiling: **not asserted anywhere in this verification** — every run was a dry run, so no model was loaded (the ADR 0016 caveat). The router's assertion path (`assert_within_ceiling`, `router_max_params` = 8e9) is unchanged.

## For the lead to decide

1. **A zero-shot MuSiQue router arm is not included.** `configs/router_musique.json` requires the few-shot prompt; running it with `prompt_zero_shot.md` is refused rather than silently prompting zero-shot under a few-shot label. A zero-shot-on-MuSiQue comparison arm would be one more config — not in the brief, so not added.
2. **`few_shot.exemplar_hop_source` has one implemented value (`pool_id`).** Labelling exemplars by their gold *step count* instead (what the decomposer's exemplar hop lines state, ADR 0013) is a different quantity and a research choice; refused rather than guessed.
3. **The router component now imports `run_decomposer.py`** for the self-exclusion rule, the question reader and the pinned-set assertion (`run_answerer.py` already does this for the last). Consolidating those three into `src/` is the obvious cleanup and is deliberately deferred — same reasoning as ADR 0022 item 6.
4. ADR 0024 is agent-authored implementer design, **pending Jahid**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)