### PR TITLE
Decomposition-quality suite as the reported primary; composite frozen as legacy (Refs #40)

### DIFF
--- a/configs/decomposition_junk_battery.json
+++ b/configs/decomposition_junk_battery.json
@@ -1,0 +1,35 @@
+{
+  "_note": "Config for scripts/decomposition_junk_battery.py, the junk battery behind the acceptance criteria of the decomposition report card (docs/analysis/2026-08-23-decomposition-quality-metric-specification.md section 3.3, ADR 0029). It is a TOOL, not an experiment: it scores no system of the thesis, takes no experiments/log.md entry, needs no GPU and takes no runs/run.lock. The junk systems are baselines built out of the gold column, in the same sense as the 'Copy' row Break prints in its own results table. The metric's parameters (the GED cost guards, the decomp_mean component list and its GED clamp) are deliberately NOT duplicated here - they are read from evaluator_config, so this battery gates the metric the pipeline actually runs rather than a second copy of it.",
+
+  "seed": 42,
+  "evaluator_config": "musique_eval.json",
+  "gold_key": "musique_dev_gold_clean",
+
+  "_eval_set_note": "The junk baselines are scored on the ADR 0007 pinned evaluation set (200 questions per hop depth), because that is the set every committed arm was scored on and A2/A4/A5 are all junk-versus-arm comparisons - a junk row over the full 2411-row dev gold and an arm row over the pinned 600 would not be a comparison at all (CLAUDE.md, evidence discipline). The gold file supplies the decompositions; these files supply which items. The script additionally CHECKS that each real arm's per-item file covers exactly the scored set and refuses otherwise. --eval-set all-gold scores every gold row instead and is not comparable to any arm.",
+  "eval_set": {
+    "questions_key": "musique_eval_questions_template",
+    "hops": [2, 3, 4]
+  },
+
+  "_fixed_junk_steps_note": "The constant step texts J3 and J4 predict for EVERY item. They are here rather than in the script because they are parameters of the measurement and a run's numbers cannot be reproduced without them, and they are deliberately REFERENCE-FREE: a junk system that emitted '#k' would score nonzero chain_validity and blunt the A2 assertion that measures precisely the opposite. They are also deliberately unrelated to any MuSiQue gold text. J3 takes the first, J4 takes the first three. Changing them changes every junk number below, so change them only with the ADR 0029 table.",
+  "fixed_junk_steps": [
+    "What is the first fact?",
+    "What is the second fact?",
+    "What is the third fact?"
+  ],
+
+  "_real_arms_note": "The committed arms the junk baselines are compared against, by their per-item files under the (gitignored) runs root. These are the nine arms exp-011 re-scored under the Break-faithful columns at commit a99b573 - the only committed artifacts that carry every column this battery needs on the ADR 0007 pinned 600. Nothing here is re-scored: the files are read and aggregated, and decomp_mean plus the two direction columns are DERIVED from the columns already in them by the evaluator's own functions. On a machine without runs/, pass --no-real-arms to run the junk half only (A2/A4/A5 are then reported as not evaluated, because each of them is a statement about junk versus a real arm).",
+  "real_arms": [
+    { "name": "exp004_unguided", "per_item": "exp-011/exp004_unguided/eval_per_item.json" },
+    { "name": "exp004_oracle_guided", "per_item": "exp-011/exp004_oracle_guided/eval_per_item.json" },
+    { "name": "exp004_unguided_capped", "per_item": "exp-011/exp004_unguided_capped/eval_per_item.json" },
+    { "name": "exp005_unguided", "per_item": "exp-011/exp005_unguided/eval_per_item.json" },
+    { "name": "exp005_oracle_guided", "per_item": "exp-011/exp005_oracle_guided/eval_per_item.json" },
+    { "name": "exp005_unguided_capped", "per_item": "exp-011/exp005_unguided_capped/eval_per_item.json" },
+    { "name": "exp008_full_train", "per_item": "exp-011/exp008_full_train/eval_per_item.json" },
+    { "name": "exp009_mixed", "per_item": "exp-011/exp009_mixed/eval_per_item.json" },
+    { "name": "exp009_oracle_hop_matched", "per_item": "exp-011/exp009_oracle_hop_matched/eval_per_item.json" }
+  ],
+
+  "paths_config": "paths.json"
+}

--- a/configs/musique_eval.json
+++ b/configs/musique_eval.json
@@ -7,6 +7,7 @@
   "out_prefix": "eval",
   "limit": null,
 
+  "_composite_score_status_note": "LEGACY. composite_score and the [#k]-only _REF_RX behind its reference_validity_micro term are FROZEN, byte-identical to the form every committed number was produced under (nine arms, exp-010's 33 sweep cells, both v1 re-analysis notes). It is NOT the reported primary - the six-term decomposition_report_card is - and it is deliberately NOT repaired: correcting the regex would move every committed value under an unchanged name while leaving the actual defect in place, because even a corrected reference-validity term is a micro-pooled rate with a MODEL-DEPENDENT denominator inside an aggregate-of-aggregates (issue #40, docs/analysis/2026-08-23-decomposition-quality-metric-specification.md section 5 option 1, ADR 0029). Do not change these weights or that regex to 'fix' the metric; the replacement is the suite. Whether the composite is retired outright is issue #6 item 5, Jahid's with his supervisor.",
   "composite_score_weights": {
     "step_f1_macro": 0.4,
     "ordered_step_accuracy_macro": 0.3,
@@ -20,6 +21,21 @@
     "ged": {
       "max_nodes_for_optimizer": 16,
       "per_item_time_budget_seconds": 20.0
+    }
+  },
+
+  "decomposition_suite": {
+    "_note": "The reported primary is an UNBLENDED six-term suite (decomposition_report_card): Break EM, SARI, GED (lower is better), chain_validity, hop-count EM, and the over/under-decomposition pair kept split and never summed. All six were already computed before this block existed; the suite is registration, direction metadata, guards and reporting, not new metric mathematics, so no committed number moves. The suite's MEMBERSHIP is deliberately not a knob: it is a metric definition and lives in the script (DECOMPOSITION_SUITE_TERMS), next to the code that computes each term. What lives here is the one thing that is a parameter - the contingency blend. See docs/METRICS.md section 2.3 and ADR 0029.",
+    "decomp_mean": {
+      "_note": "The BLENDED CONTINGENCY of the specification's section 2.3 (P3), reported beside the suite and never as the suite. It exists for the case where one blended number is required; the recommendation remains the suite plus ged_macro. Equal weights by construction and there is NO weighted variant: GLUE's unweighted average is the only weighting form the survey found a precedent for, and any unequal weighting would need a Dynascore-style unit conversion that nothing in this repo estimates. ged_clamp is a JUDGMENT CALL with no source: GED is a distance, unbounded above (measured above 1.0 for junk predictions), so an additive blend has to clamp it before flipping direction - the term is 1 - min(ged_clamp, ged). Alternatives considered and not taken: 1/(1+ged), exp(-ged), or leaving GED out of the blend (ADR 0029). The blend SHIPS only because scripts/decomposition_junk_battery.py measured every junk baseline below every real arm on it; an additive blend containing SARI hands junk a nonzero floor, which is the same failure family as issue #40, and a junk baseline outranking a real arm disqualifies the blend rather than prompting a weight tweak. Changing components or ged_clamp means re-running that battery.",
+      "components": [
+        "break_exact_match",
+        "sari",
+        "ged",
+        "chain_validity",
+        "hop_count_exact_match"
+      ],
+      "ged_clamp": 1.0
     }
   },
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -352,9 +352,12 @@ The acceptance criteria are tests in
 - **A1** J6 scores the extremum on every term.
 - **A2** every real arm beats J1–J4 on `ged_macro`, `chain_validity_macro` and
   `break_exact_match_rate`.
-- **A3** SARI is **exempt** from A2 by design and its margin is recorded instead: its floor on
-  this data is high (Break's own published `Copy` row scores SARI 0.431), so it separates junk
-  by a small margin from a high floor.
+- **A3** SARI is **exempt from A2's assertion** by design and its margin is recorded instead:
+  its floor on this data is high (Break's own published `Copy` row scores SARI 0.431), so it
+  separates junk by a small margin from a high floor. The *ordering* — every real arm above
+  every junk baseline on `sari_macro` — is still gated: it carries a `passed` like every other
+  verdict and drives the battery's exit code, so an arm that falls below the junk floor is
+  caught rather than reported.
 - **A4** the **hard gate** on `decomp_mean`: every junk baseline must rank below every real
   arm. Failing it disqualifies the blend — it is not a prompt to re-tune weights, because the
   legacy composite's weights were never the disease.
@@ -535,10 +538,17 @@ Compares two runs **on the same evaluation set**. Parameters live in
 - **McNemar** (`_mcnemar`, `_mcnemar_exact_p`) for the five binary metrics `exact_match`,
   `hop_count_exact_match`, `break_exact_match`, `over_decomposition` and
   `under_decomposition` (the last two added with the §2.3 suite, so the ADR 0017 asymmetry
-  can be significance-tested at all): with b = #(a correct, b wrong) and c = #(a wrong, b correct),
+  can be significance-tested at all): with b = the discordant items whose indicator is 1 for
+  a and 0 for b (`discordant_only_in_a`) and c the reverse (`discordant_only_in_b`),
   the exact two-sided p-value is `min(1, 2 * BinomialCDF(min(b, c); b + c, 0.5))`, computed
   with exact integer arithmetic. With no discordant pairs p = 1.0. `significant` is
-  `p < alpha`.
+  `p < alpha`. **What a 1 means follows the row's direction**, so the same two counts are
+  repeated under a direction-specific name and the name is only ever emitted where it is
+  true: on the three higher-is-better rows a 1 is a correct item, so b = #(a correct, b
+  wrong) and the pair also appears as `correct_only_in_a` / `correct_only_in_b`; on the two
+  lower-is-better rate rows a 1 is the **error occurring**, so b = #(a errs, b does not) and
+  the pair appears as `error_only_in_a` / `error_only_in_b` instead. The run note's McNemar
+  cell prints the neutral `b=` / `c=`, with the reading spelled out beneath the table.
 - **How much evidence there is, recorded next to the verdicts.** Every row carries `n` and
   `underpowered`; each McNemar row also carries `min_attainable_p_value` — the smallest p
   its discordant count m = b + c could have produced, `min(1, 2 · 0.5^m)`, reached when all
@@ -582,11 +592,15 @@ Compares two runs **on the same evaluation set**. Parameters live in
   run note says so too.
 - **A compared metric the inputs do not carry is skipped and named**, not silently omitted:
   `statistics_not_available_in_inputs` in the metrics JSON, plus a `NOT COMPARED` line in the
-  run note. On v2 artifacts it is empty (the §2.1 / §2.2 columns are **required** — a
-  per-item file written before them gets the existing "re-run the evaluation to regenerate
-  them" refusal). It is non-empty only for `--v1-per-item` inputs, which predate those
-  columns; computing them there from the stored steps would be a *re-score of v1 output*
-  rather than a comparison of what v1 measured.
+  run note. Two kinds of input reach it, and the note names both: a `--v1-per-item`
+  prior-work file, which predates the §2.1 / §2.2 columns (those columns are **required** of
+  a v2 file — one written before them gets the existing "re-run the evaluation to regenerate
+  them" refusal); and a **v2 file scored before the §2.3 suite existed**, which is missing
+  `over_decomposition` / `under_decomposition` / `decomp_mean` because those three are
+  computed on every run but deliberately *not* required of a compared file (ADR 0029 — nine
+  committed arms and 33 sweep cells predate them, and this is the common case until they are
+  re-scored). Either way, computing the missing columns here from the stored steps would be
+  a *re-score of that input* rather than a comparison of what it measured.
 - **v1 prior-work inputs** (`--v1-per-item`, `--v1-alignment`; ADR
   [0020](adr/0020-prior-work-re-analysis-convention.md)). `--compare` can read v1's
   bare-list per-item files — the format that predates

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -8,7 +8,8 @@ a bug.
 
 Every metric here is **string-level**: no model is in the loop (`METRIC_DEFINITIONS`
 `not_a_semantic_metric`). Two decompositions that mean the same thing but word a step
-differently score as a mismatch. That still holds for the metrics added in §2.1 and §2.2:
+differently score as a mismatch. That still holds for the metrics added in §2.1, §2.2 and
+§2.3:
 the graph edit distance is computed by `networkx`, a graph library, and every candidate that
 would have put a *model* in the scoring loop is left out — whether the supervisor's
 "no closed commercial model may judge decomposition quality" extends to open-weight scorers
@@ -25,6 +26,13 @@ overall and per gold hop depth, in the same style as `per_gold_hop_metrics` belo
 are string-level too — no model scores anything on either side. The two halves share one
 reading of "a step" (`src/step_lines.py`), pinned against each other by
 `tests/test_answer_musique.py::TestStepReadingMatchesTheDecompositionEvaluator`.
+
+**What leads the report.** The reported primary is the six-term suite of §2.3
+(`decomposition_report_card`) — six unblended numbers, always printed together. The weighted
+`composite_score` of §4 is **legacy**: frozen byte-identical so committed numbers stay
+quotable, and not repaired. Whether any of this becomes the *thesis*-primary metric is
+[issue #6](https://github.com/AhmadiJahid/Thesis---QAv2/issues/6) item 5 — Jahid's decision
+with his supervisor. This file describes what is measured and reported, not what is adopted.
 
 ## 1. How rows are built
 
@@ -74,9 +82,10 @@ Unless stated otherwise, an aggregate is the **macro average**: the metric is co
 item and the per-item values are averaged over evaluated rows (`_aggregate`). Four keys are
 not macro averages: `reference_validity_micro` pools counts across all rows;
 `predicted_hop_distribution` / `gold_hop_distribution` are item counts per hop count;
-`ged_fallback_counts` is an item count per fallback reason (§2.2); and
+`ged_fallback_counts` is an item count per fallback reason (§2.2);
+`chain_validity_gold_unchained_items` is an item count (§2.3); and
 `composite_score` is computed from the aggregate values, not averaged from per-item ones
-(§4).
+(§4). **Every term of the reported suite (§2.3) is a macro average**, and the run asserts it.
 
 | metrics JSON key | definition (function) |
 |---|---|
@@ -94,7 +103,8 @@ not macro averages: `reference_validity_micro` pools counts across all rows;
 | `step_count_exact_rate` | fraction of rows with len(pred) == len(gold), i.e. exactly 1 − `over_decomposition_rate` − `under_decomposition_rate`. **Not** `hop_count_exact_match_rate`: this one is against len(gold steps), that one against the gold `hop_count` field (§1). The two are equal whenever the gold passes the load-time assertion, but they are different definitions and only one of them belongs next to the over/under rates |
 | `hop_count_exact_match_rate`, `hop_count_abs_error_mae` | predicted hop count = number of predicted steps; gold hop count = the gold row's `hop_count` when it is a positive int, else the gold step count |
 | `predicted_hop_distribution`, `gold_hop_distribution` | counts of items per hop count |
-| `chain_validity_macro` | see §2.1 |
+| `chain_validity_macro`, `chain_validity_gold_unchained_items` | see §2.1, §2.3 |
+| `over_decomposition` / `under_decomposition` (per item), `decomp_mean` (per item), `decomp_mean_macro`, `decomposition_report_card`, `decomp_mean_policy` | see §2.3 |
 | `break_exact_match_rate`, `sari_macro`, `ged_macro`, `ged_fallback_counts` | see §2.2 |
 | `per_gold_hop_metrics` | the **entire** aggregate block above, recomputed per gold hop depth (2, 3, 4, …) — including the five directional step-count metrics and everything in §2.1 / §2.2 |
 
@@ -251,6 +261,112 @@ rather than "fixed" — fixing it would be inventing a metric. `break_exact_matc
 reversal in both cases, which is the survey's §4 item 2 in one sentence: an order-sensitive
 metric has to stay in the reported set.
 
+### 2.3 The reported primary — `decomposition_report_card`, a suite and not a composite
+
+Read off `DECOMPOSITION_SUITE_TERMS` and `_report_card`. It is **registration and reporting,
+not new metric mathematics**: every term below was already computed by §2, so nothing moved
+when the card was added. The specification is
+[`docs/analysis/2026-08-23-decomposition-quality-metric-specification.md`](analysis/2026-08-23-decomposition-quality-metric-specification.md)
+§2.1 and the implementer's record is ADR
+[0029](adr/0029-the-decomposition-quality-suite-the-implementers-registration.md).
+
+The finding it rests on is that **the decomposition literature does not composite** — Break
+reports four metrics side by side, EntailmentBank four dimensions, Spider three, and where a
+single number is used it is one member of the family made stricter, never a blend over it.
+
+| # | term (metrics JSON key) | per-item column | better | range | what it prices | provenance |
+|---|---|---|---|---|---|---|
+| 1 | `break_exact_match_rate` | `break_exact_match` | ⇑ | {0,1} | whole-plan verbatim identity of the `@@SEP@@`-joined string | literature (§2.2) |
+| 2 | `sari_macro` | `sari` | ⇑ | [0,1] | n-gram edit quality vs the question | literature (§2.2) |
+| 3 | `ged_macro` | `ged` | **⇓** | [0,∞) | wording, chaining and step count in one distance | literature (§2.2) |
+| 4 | `chain_validity_macro` | `chain_validity` | ⇑ | [0,1] | did the plan chain where the gold requires it | house repair (§2.1) |
+| 5 | `hop_count_exact_match_rate` | `hop_count_exact_match` | ⇑ | {0,1} | granularity: the right number of steps | house |
+| 6a | `under_decomposition_rate` | `under_decomposition` | **⇓** | {0,1} | a length error in the direction ADR 0017 calls **not** tolerable | house |
+| 6b | `over_decomposition_rate` | `over_decomposition` | **⇓** | {0,1} | a length error in the direction ADR 0017 calls tolerable | house |
+
+Rules that are part of the metric, not decoration:
+
+1. **All six are reported together, with directions.** A note or table quoting fewer than six
+   is not reporting this metric. The run note prints the whole card, because the note is what
+   gets quoted into `experiments/log.md`.
+2. **Terms 6a and 6b are a pair and are never summed.** ADR 0017 records the supervisor's
+   judgment that over-decomposition is tolerable and under-decomposition is not; summing them
+   erases exactly that. (`step_count_exact_rate` is `1 −` the two of them and is separate.)
+   Both are *lower-is-better* — the asymmetry is in how heavily a reader weighs them, not in
+   their sign, and registering `over_decomposition` as higher-is-better would make `favours`
+   name the wrong system in §5.
+3. **Every term has a per-item value**, so every one takes the full §5 battery — bootstrap CI,
+   paired t-test, and McNemar for the binary terms 1, 5, 6a and 6b. The 1-of-3-tests weakness
+   is now the legacy composite's alone.
+4. **No term may be a ratio pooled across items.** Every term is a macro mean over a
+   denominator fixed by the *evaluation set*, never by what the model emitted — the structural
+   fix for the issue #40 defect class. `_assert_suite_terms_are_macro_means` **checks** this at
+   the point of reporting and aborts the run if a term ever drifts from the mean of its column;
+   `reference_validity_micro` and `composite_score` are named in the card as excluded, with the
+   reason.
+5. **The one conditional-credit branch left is counted.** `chain_validity_gold_unchained_items`
+   is the number of items whose *gold* emits no `#k` and which therefore score 1.0 on term 4
+   for free. It is 0 on the pinned 600 and on the fixture, and the counter exists so a future
+   gold cannot reintroduce free credit silently.
+
+**Where one number is structurally required** (ranking a 33-cell sweep, model selection, an
+abstract sentence), it is **`ged_macro`** — a member of the suite, not a function over it, the
+shape Break/QDMR's NormEM and EntailmentBank's *Overall AllCorrect* both have. Three caveats
+travel with it in the card every time it is printed: (a) **lower is better**; (b) it is
+order-light and on a 2-step plan order-**blind** (a reversed gold measured GED 0.2875 on the
+pinned 600, better than every real arm), which is why terms 1, 5 and 6 must stay beside it;
+(c) absolute values are **not** comparable to published Break GED (no spaCy lemmatizer, and a
+MuSiQue rather than a QDMR target).
+
+**`decomp_mean` — the blended contingency, reported beside the suite and never as it.** Per
+item, the unweighted mean of five [0,1] higher-is-better terms: `break_exact_match`, `sari`,
+`1 − min(ged_clamp, ged)`, `chain_validity`, `hop_count_exact_match`. Equal weights, and there
+is **no weighted variant** — an unequal weighting would need a unit conversion nothing here
+estimates. The component list and the clamp live in `configs/musique_eval.json` under
+`decomposition_suite.decomp_mean`, so a run's snapshot records the blend it was scored under.
+The GED clamp is a **judgment call with no source**: GED is unbounded above, so an additive
+blend has to clamp it before flipping direction. It has a per-item value, so unlike the legacy
+composite it takes all three tests. It exists only for the case where a single blended number
+is required; the recommendation remains the suite plus `ged_macro`, and adopting any of it as
+the *thesis*-primary metric is issue #6 item 5 — Jahid's with his supervisor.
+
+### 2.4 The junk battery — `scripts/decomposition_junk_battery.py`
+
+Break prints a trivial `Copy` baseline (question echo) in its own results table, scored beside
+the real systems. This is that practice as a pass/fail gate, and it is what stops a repeat of
+issue #40, where junk outranked the deployable baseline under the legacy composite and it took
+two analysis notes to notice.
+
+Six systems built out of the gold column, scored with the evaluator's own `score_item` (there
+is no second copy of any metric): **J1** empty, **J2** question echo (= Break's `Copy`),
+**J3** one fixed step, **J4** three fixed steps, **J5** gold reversed, **J6** gold itself. The
+fixed step texts are in `configs/decomposition_junk_battery.json` and are deliberately
+reference-free. The junk rows are scored on the **ADR 0007 pinned set**, and each committed
+arm's per-item file is *checked* to cover exactly that set before it is placed beside them —
+comparing across two evaluation sets is not a comparison.
+
+The acceptance criteria are tests in
+[`tests/test_decomposition_metrics.py`](../tests/test_decomposition_metrics.py)
+(`TestJunkBattery`), asserted over the fixture gold so they run in the smoke test:
+
+- **A1** J6 scores the extremum on every term.
+- **A2** every real arm beats J1–J4 on `ged_macro`, `chain_validity_macro` and
+  `break_exact_match_rate`.
+- **A3** SARI is **exempt** from A2 by design and its margin is recorded instead: its floor on
+  this data is high (Break's own published `Copy` row scores SARI 0.431), so it separates junk
+  by a small margin from a high floor.
+- **A4** the **hard gate** on `decomp_mean`: every junk baseline must rank below every real
+  arm. Failing it disqualifies the blend — it is not a prompt to re-tune weights, because the
+  legacy composite's weights were never the disease.
+- **A5** order sensitivity survives, carried by `break_exact_match` and
+  `ordered_step_accuracy`; **GED is not allowed to carry it**.
+- **A6** no pre-existing metric moved — the legacy composite and its inputs keep their golden
+  values, and `_REF_RX` keeps its bracketed pattern.
+
+It is a **tool, not an experiment** (ADR 0027 point 5): it scores no system of the thesis,
+takes no `experiments/log.md` entry, needs no GPU and takes no `runs/run.lock`. Re-run it
+rather than quoting a remembered number; the measured table is in ADR 0029 with the SHA.
+
 ## 3. ROUGE-L — the answer to the supervisor's question
 
 Read off `_rouge_l`, `_join_steps` and `_tokenize`, verbatim behaviour:
@@ -271,7 +387,22 @@ Read off `_rouge_l`, `_join_steps` and `_tokenize`, verbatim behaviour:
   this is the repo's own implementation, so it is not numerically comparable to a
   `rouge-score` / `pyrouge` number without checking their tokenizers.
 
-## 4. Composite score
+## 4. Composite score — **LEGACY, frozen**
+
+> **Status: `legacy`.** It is **not** the reported primary — §2.3 is — and it is deliberately
+> **not repaired**. It is computed, reported and stamped `composite_score_status: "legacy"` in
+> every metrics JSON so that nine committed arms, exp-010's 33 sweep cells and both v1
+> re-analysis notes stay valid and quotable. **Frozen for reproducibility, not because it is
+> correct.** Whether it is retired outright is issue #6 item 5, Jahid's with his supervisor.
+>
+> Why frozen rather than fixed (specification §5 option 1, ADR 0029): its 0.2-weight
+> `reference_validity_micro` term reads references with `_REF_RX = r"\[#(\d+)\]"`, and
+> MuSiQue's gold writes **bare** `#k` — 1200 bare references and 0 bracketed across the pinned
+> 600 — so the term has never measured reference validity on this data. Correcting the regex
+> would move every committed number under an unchanged name **and still leave a micro-pooled
+> rate with a model-dependent denominator inside an aggregate-of-aggregates**: the defect
+> *class*, not just this instance. The replacement is `chain_validity` (§2.1), which is term 4
+> of the suite. **Do not "fix" `_REF_RX`.**
 
 `_composite_score` combines **aggregate** values (not per-item ones):
 
@@ -293,12 +424,12 @@ snapshot and metrics JSON):
 | `composite_score_weights.step_count_error` | 0.1 |
 | `composite_step_count_error_scale` | 3.0 |
 
-**The composite is unchanged by the metrics of §2.1 and §2.2.** None of `chain_validity`,
-`break_exact_match`, `sari` or `ged` enters this formula, and neither
-`reference_validity_micro` nor its `[#k]`-only regex was touched, so every committed
-`composite_score` still has the value it was published with. Whether the composite keeps
-leading — or is repaired, or retired — is issue #6 item 5, Jahid's with his supervisor; the
-code measures, it does not adopt.
+**The composite is unchanged by the metrics of §2.1, §2.2 and §2.3.** None of
+`chain_validity`, `break_exact_match`, `sari`, `ged`, the two direction columns or
+`decomp_mean` enters this formula, and neither `reference_validity_micro` nor its `[#k]`-only
+regex was touched, so every committed `composite_score` still has the value it was published
+with. What §2.3 changed is which number *leads the report*, not what any number is; the code
+measures and reports, it does not adopt.
 
 The weights are a **choice, not a result**: they were hard-coded literals in v1 and were
 promoted to config in v2 so a run records them. Jahid's supervisor flagged this score as
@@ -372,8 +503,8 @@ Compares two runs **on the same evaluation set**. Parameters live in
   `config_weights_match_per_item_files`, and the run note prints a WARNING line when they
   disagree.
 - **Paired bootstrap CIs** (`_paired_bootstrap`, `_statistics_for`) for `rouge_l_f1`,
-  `step_f1`, `ordered_step_accuracy`, `sari`, `ged`, `chain_validity` and `composite_score`
-  (`BOOTSTRAP_STATISTICS`). Each of the 10000 resamples
+  `step_f1`, `ordered_step_accuracy`, `sari`, `ged`, `chain_validity`, `decomp_mean` and
+  `composite_score` (`BOOTSTRAP_STATISTICS`). Each of the 10000 resamples
   draws n item indices with replacement (`numpy.random.default_rng(seed)`) and applies the
   **same** indices to both systems; every statistic is recomputed from the resampled items.
   The interval is the [alpha/2, 1−alpha/2] percentile of the difference **system_a minus
@@ -390,18 +521,21 @@ Compares two runs **on the same evaluation set**. Parameters live in
   single-block draw (pinned by `TestBootstrapChunking`, which also asserts equality with
   `chunk_size == iterations`, i.e. the un-chunked path).
 - **Direction, carried in the data** (`LOWER_IS_BETTER_STATISTICS`, `_direction`,
-  `_favours`). `ged` is a **distance** — lower is better — and it is the only one in the
-  report, so a bare `-0.16` on that row means the *opposite* of what it means on every other
-  row. Every bootstrap, McNemar and t-test row therefore carries `direction`
+  `_favours`). Three compared metrics are lower-is-better — `ged`, a graph edit **distance**,
+  and the two length-error rates `under_decomposition` / `over_decomposition` — so a bare
+  `-0.16` on one of those rows means the *opposite* of what it means on every other row. Every bootstrap, McNemar and t-test row therefore carries `direction`
   (`higher_is_better` / `lower_is_better`) and, when it is significant, `favours`
   (`system_a` / `system_b`) with the direction already applied (null otherwise); **both**
   metrics JSONs — a comparison's and a scoring run's `eval_metrics.json` — list
-  `lower_is_better_statistics` (the per-item column names, whose aggregate is
-  `<name>_macro`), so a program never has to read prose to learn the direction; and the run
-  note's table has a `better` column plus a sentence saying which way `ged` reads, with each
-  significant verdict annotated `yes (favours a|b)`.
-- **McNemar** (`_mcnemar`, `_mcnemar_exact_p`) for the three binary metrics `exact_match`,
-  `hop_count_exact_match` and `break_exact_match`: with b = #(a correct, b wrong) and c = #(a wrong, b correct),
+  `lower_is_better_statistics` (the per-item column names; their aggregate keys are in the
+  report card of §2.3 — `ged` → `ged_macro`, `under_decomposition` →
+  `under_decomposition_rate`), so a program never has to read prose to learn the direction;
+  and the run note's table has a `better` column plus a sentence saying which rows read the
+  other way, with each significant verdict annotated `yes (favours a|b)`.
+- **McNemar** (`_mcnemar`, `_mcnemar_exact_p`) for the five binary metrics `exact_match`,
+  `hop_count_exact_match`, `break_exact_match`, `over_decomposition` and
+  `under_decomposition` (the last two added with the §2.3 suite, so the ADR 0017 asymmetry
+  can be significance-tested at all): with b = #(a correct, b wrong) and c = #(a wrong, b correct),
   the exact two-sided p-value is `min(1, 2 * BinomialCDF(min(b, c); b + c, 0.5))`, computed
   with exact integer arithmetic. With no discordant pairs p = 1.0. `significant` is
   `p < alpha`.
@@ -419,11 +553,11 @@ Compares two runs **on the same evaluation set**. Parameters live in
   chosen in config, not a statistical standard** — it exists so a tiny evaluation set
   cannot print a bare `significant: true`; its value is Jahid's and his supervisor's to set.
 - **Paired t-test** (`_paired_t_test`, `_paired_t_test_row`, `scipy.stats.ttest_rel`) over
-  the same per-item differences, the same pairing and the same aligned items, for the nine
+  the same per-item differences, the same pairing and the same aligned items, for the twelve
   compared metrics that **have** a per-item value: `rouge_l_f1`, `step_f1`,
-  `ordered_step_accuracy`, `sari`, `ged`, `chain_validity`, `exact_match`,
-  `hop_count_exact_match`, `break_exact_match`
-  (`T_TEST_STATISTICS`). Each row carries `t_statistic`, `degrees_of_freedom` (n − 1) and
+  `ordered_step_accuracy`, `sari`, `ged`, `chain_validity`, `decomp_mean`, `exact_match`,
+  `hop_count_exact_match`, `break_exact_match`, `over_decomposition`, `under_decomposition`
+  (`T_TEST_STATISTICS`) — i.e. every term of the §2.3 suite. Each row carries `t_statistic`, `degrees_of_freedom` (n − 1) and
   `p_value`, with `significant` = `p_value < alpha` and the same `underpowered` flag as the
   rest. `composite_score` gets **no** t-test: its reference term is a micro rate and its
   step-count term a MAE, so there is no per-item composite difference to test — only its
@@ -547,6 +681,10 @@ applied anywhere.
 .venv/bin/python scripts/musique_decompositions_evaluator.py \
     --compare <v1>/eval_typed_unguided_per_item.json <v1>/eval_raw_unguided_per_item.json \
     --v1-per-item --v1-alignment normalized_question --run-dir runs/<out>
+
+# the junk battery of §2.4 (a tool, not an experiment: no log entry, no GPU, no run.lock)
+.venv/bin/python scripts/decomposition_junk_battery.py --json <out>.json
+.venv/bin/python scripts/decomposition_junk_battery.py --limit 20   # tiny run
 ```
 
 The hand-computed checks for all of the above are in

--- a/docs/adr/0026-break-faithful-metrics-the-implementers-conventions.md
+++ b/docs/adr/0026-break-faithful-metrics-the-implementers-conventions.md
@@ -2,6 +2,12 @@
 
 - **Status**: Accepted (implementer design, pending Jahid)
 - **Date**: 2026-08-22
+- **Amended 2026-08-23 by [0029](./0029-the-decomposition-quality-suite-the-implementers-registration.md)**:
+  the four columns this record landed as *additive* — Break EM, SARI, GED and
+  `chain_validity` — are now four of the six terms of the **reported primary**
+  (`decomposition_report_card`), and the legacy `composite_score` they were kept out of is
+  marked `legacy` and frozen. **How any metric here is computed does not change**, and every
+  convention below still binds; what changed is which numbers lead the report.
 
 ## Context
 

--- a/docs/adr/0029-the-decomposition-quality-suite-the-implementers-registration.md
+++ b/docs/adr/0029-the-decomposition-quality-suite-the-implementers-registration.md
@@ -1,0 +1,250 @@
+# 0029. The Decomposition-Quality Suite: Six Unblended Terms as the Reported Primary, and the Composite Frozen as Legacy
+
+- **Status**: Accepted (implementer registration, pending Jahid and his supervisor)
+- **Date**: 2026-08-23
+- **Amends** [0026](./0026-break-faithful-metrics-the-implementers-conventions.md) — the four
+  columns that ADR landed as *additive* are now four of the six terms of the **reported
+  primary**; nothing about how they are computed changes.
+
+## Context
+
+[ADR 0023](./0023-jahid-2026-08-22-direction-metric-pipeline-completion-generalisation.md)
+item 1 ("bring something better from the literature") and
+[ADR 0028](./0028-jahid-2026-08-23-delegations-pool-choice-router-call-composite-authorized.md)
+item 3 authorized replacing or repairing the decomposition-quality composite; Jahid
+re-confirmed it in session on 2026-08-23. The defect is
+[issue #40](https://github.com/AhmadiJahid/Thesis---QAv2/issues/40): the composite's
+0.2-weight `reference_validity_micro` term is a **micro-pooled rate whose denominator is
+produced by the model**, and its `_REF_RX` matches only bracketed `[#k]` while MuSiQue's gold
+writes bare `#k` — so on five of seven committed arms the denominator was empty and the term
+scored 1.0 by rule, and on the other two, 2 of 600 items owned the whole denominator. Under
+that composite, three fixed junk steps scored 0.2778 and a question echo 0.2333 against
+exp-004 `unguided`'s 0.2098: **junk outranked the deployable baseline on its own evaluation
+set**, and it took two analysis notes to notice.
+
+The analyst lane then surveyed the literature and produced the specification this record
+implements:
+[`docs/analysis/2026-08-23-decomposition-quality-metric-specification.md`](../analysis/2026-08-23-decomposition-quality-metric-specification.md).
+Its headline finding is a negative one and it is the load-bearing fact here: **the
+decomposition literature does not composite — it reports a suite.** Break reports four metrics
+side by side (and prints a trivial `Copy` baseline in the same table), EntailmentBank four
+dimensions × two aggregations, Spider three metrics, ONUS a four-column panel, SubQuestRater
+three separate criteria. Where the field does use a single number it is **one member of the
+family made stricter** (QDMR's NormEM) or **one strict column selected on** (EntailmentBank's
+*Overall AllCorrect*) — never a blend over the family. No decomposition paper found in three
+independent passes reports a weighted linear blend of sub-metrics.
+
+This ADR records what the implementer built. It is **not** an adoption: whether any of it
+becomes the *thesis*-primary metric is [issue #6](https://github.com/AhmadiJahid/Thesis---QAv2/issues/6)
+item 5, Jahid's decision with his supervisor.
+
+## Decision
+
+**1. The reported primary is an unblended six-term suite, `decomposition_report_card`.** Six
+terms, all macro means over every evaluated item, all reported together with their direction,
+their range, their provenance and the `n` they were averaged over:
+
+| # | metrics JSON key | per-item column | better | provenance |
+|---|---|---|---|---|
+| 1 | `break_exact_match_rate` | `break_exact_match` | ⇑ | literature (Break) |
+| 2 | `sari_macro` | `sari` | ⇑ | literature (Break / Xu et al.) |
+| 3 | `ged_macro` | `ged` | **⇓** | literature (Break) |
+| 4 | `chain_validity_macro` | `chain_validity` | ⇑ | house repair (ADR 0026) |
+| 5 | `hop_count_exact_match_rate` | `hop_count_exact_match` | ⇑ | house |
+| 6a | `under_decomposition_rate` | `under_decomposition` | **⇓** | house (ADR 0017) |
+| 6b | `over_decomposition_rate` | `over_decomposition` | **⇓** | house (ADR 0017) |
+
+All six were already computed at the commit the specification was written against, so this is
+**registration, direction metadata, guards and reporting — not new metric mathematics**, and
+no committed number moves. A report quoting fewer than six is not reporting this metric; the
+run note prints the whole card, because the note is what gets quoted into
+`experiments/log.md`. Terms 6a and 6b are a **pair and are never summed** — ADR 0017 records
+that over-decomposition is tolerable and under-decomposition is not, and one "wrong length"
+figure erases exactly that.
+
+**2. `ged_macro` is the single number where one is structurally required**, and it carries
+three mandatory caveats every time it is printed. It is a *member* of the suite, not a
+function over it — the shape both single-number precedents in the field have. The caveats,
+emitted in the report card beside the value:
+
+- **(a) lower is better** — it is a distance, where terms 1, 2, 4 and 5 are scores;
+- **(b) it is order-light, and on a 2-step plan order-blind** — the reversed gold measured GED
+  0.2875 on the pinned 600, *better than every real arm* — which is why terms 1, 5 and 6 must
+  stay reported beside it;
+- **(c) absolute values are not comparable to published Break GED** — this port has no spaCy
+  lemmatizer in the node substitution cost (ADR 0026 item 3), and it scores against MuSiQue
+  gold rather than QDMR annotations.
+
+It was chosen on three measured properties (it is a published metric of the field's flagship
+decomposition benchmark; it is the only single candidate substantially correlated with every
+house metric; it ranks every junk system below every real arm) plus one structural one (it is
+per-item, so it takes the whole ADR 0009 battery). `break_exact_match_rate` is the
+literature-canonical alternative and is rejected for this job only because it floors at
+0.048–0.102 across every committed arm and so cannot order a 33-cell sweep.
+
+**3. `composite_score` and `_REF_RX` are FROZEN as legacy, byte-identical, and deliberately
+not repaired.** They are still computed, still reported, and now stamped
+`composite_score_status: "legacy"` in every metrics JSON, marked legacy in
+`configs/musique_eval.json`, and marked legacy in `docs/METRICS.md` §4.
+
+The reason to preserve, because it is the part most likely to be re-litigated: **even a
+corrected regex leaves a micro-pooled rate with a model-dependent denominator inside an
+aggregate-of-aggregates.** That is the defect *class*, not just its instance — fixing the
+regex would convert a term that measures nothing into a term that measures the wrong shape,
+while moving the value of a metric under an unchanged name. Freezing keeps every committed
+number quotable: nine arms, exp-010's 33 sweep cells, both v1 re-analysis notes. **Frozen for
+reproducibility, not because it is correct.** Retiring it outright is issue #6 item 5.
+
+**4. `decomp_mean` is a blended contingency, gated by measurement, and it is not part of the
+suite.** Per item, the unweighted mean of five [0,1] higher-is-better terms
+(`break_exact_match`, `sari`, `1 − min(ged_clamp, ged)`, `chain_validity`,
+`hop_count_exact_match`). Equal weights and **no weighted variant**: GLUE's unweighted average
+is the only weighting form with a precedent, and an unequal weighting would need a
+Dynascore-style unit conversion nothing in this repo estimates. Components and clamp live in
+`configs/musique_eval.json` so a run snapshot records them.
+
+It ships **only because its own gate passed empirically.** An additive blend containing SARI
+hands junk a nonzero floor (SARI's floor on this data is 0.29 and Break's own published `Copy`
+row scores 0.431), which is the same failure family as issue #40 — so a junk baseline
+outranking a real arm would have **disqualified** the blend rather than prompting a weight
+tweak. The composite's weights were never the disease; its free-credit term was, and a weight
+tweak would have hidden that.
+
+**5. The junk battery is a committed script, and its acceptance criteria are tests.**
+`scripts/decomposition_junk_battery.py` + `configs/decomposition_junk_battery.json` build six
+systems out of the gold column — J1 empty, J2 question echo (Break's own `Copy`), J3 one fixed
+step, J4 three fixed steps, J5 gold reversed, J6 gold — score them with the evaluator's own
+`score_item`, and print the report card for each beside every committed arm. Per ADR 0027 it
+is a **tool, not an experiment**: it scores no system of the thesis, takes no
+`experiments/log.md` entry, needs no GPU and takes no `runs/run.lock`, and it carries a tiny
+mode (`--limit`, `--eval-set all-gold`, `--no-real-arms`) so the full path is smoke-testable.
+A1–A6 are asserted over the fixture gold in
+`tests/test_decomposition_metrics.py::TestJunkBattery`.
+
+**6. Three guards ship with the suite**, each replacing an argument with a check:
+
+- **Every headline term is asserted to be the macro mean of its per-item column** at the point
+  of reporting (`_assert_suite_terms_are_macro_means`); a term that ever drifts aborts the run.
+  `reference_validity_micro` and `composite_score` are named in the card as excluded, with the
+  reason.
+- **`chain_validity_gold_unchained_items`** counts the items whose *gold* emits no `#k` and
+  which therefore score 1.0 on term 4 for free. It is 0 on the pinned 600 by construction, but
+  a future gold could reintroduce free credit silently — which is exactly how issue #40
+  happened.
+- **Every term reports its `n_items`**, so "no term is decided by a handful of items" is
+  auditable rather than argued.
+
+## The measured junk battery
+
+Printed by `scripts/decomposition_junk_battery.py` at commit `222862f` (working tree carrying
+this change), seed 42, on the **ADR 0007 pinned 600** — all fifteen rows on the same 600
+items, with each arm's per-item file checked to cover exactly that set. The nine real arms are
+the ones exp-011 re-scored under the Break-faithful columns; nothing was re-scored here, and
+`decomp_mean` and the two direction columns are derived from the columns already in those
+files. Re-run the script rather than quoting this table from memory.
+
+| system | break EM ⇑ | SARI ⇑ | GED ⇓ | chain ⇑ | hop EM ⇑ | under ⇓ | over ⇓ | decomp_mean ⇑ |
+|---|---|---|---|---|---|---|---|---|
+| J1 empty | 0.0000 | 0.2911 | 1.0000 | 0.0000 | 0.0000 | 1.0000 | 0.0000 | 0.0582 |
+| J2 question echo (`Copy`) | 0.0000 | 0.4676 | 0.9011 | 0.0000 | 0.0000 | 1.0000 | 0.0000 | 0.1133 |
+| J3 one fixed step | 0.0000 | 0.3141 | 0.9546 | 0.0000 | 0.0000 | 1.0000 | 0.0000 | 0.0719 |
+| J4 three fixed steps | 0.0000 | 0.3262 | 1.0421 | 0.0000 | 0.3333 | 0.3333 | 0.3333 | 0.1412 |
+| J5 gold reversed | 0.0000 | 0.9414 | 0.2875 | 0.2328 | 1.0000 | 0.0000 | 0.0000 | 0.5774 |
+| J6 gold | 1.0000 | 1.0000 | 0.0000 | 1.0000 | 1.0000 | 0.0000 | 0.0000 | 1.0000 |
+| exp004 unguided | 0.0533 | 0.5850 | 0.4715 | 0.9686 | 0.5083 | 0.2017 | 0.2900 | 0.5288 |
+| exp004 oracle_guided | 0.0500 | 0.5890 | 0.4414 | 0.9712 | 0.5900 | 0.0617 | 0.3483 | 0.5517 |
+| exp004 unguided_capped | 0.0533 | 0.5849 | 0.4708 | 0.9686 | 0.5083 | 0.2017 | 0.2900 | 0.5289 |
+| exp005 unguided | 0.0517 | 0.5979 | 0.4910 | 0.8605 | 0.5200 | 0.1150 | 0.3650 | 0.5085 |
+| exp005 oracle_guided | 0.0600 | 0.6033 | 0.4241 | 0.8697 | 0.8733 | 0.0333 | 0.0933 | 0.5965 |
+| exp005 unguided_capped | 0.0517 | 0.5978 | 0.4909 | 0.8605 | 0.5200 | 0.1150 | 0.3650 | 0.5085 |
+| exp008 full_train | 0.1017 | 0.6823 | 0.3094 | 0.9942 | 0.7100 | 0.2567 | 0.0333 | 0.6357 |
+| exp009 mixed | 0.0533 | 0.5851 | 0.4713 | 0.9686 | 0.5150 | 0.2000 | 0.2850 | 0.5301 |
+| exp009 oracle_hop_matched | 0.0483 | 0.5879 | 0.4540 | 0.9686 | 0.6000 | 0.1300 | 0.2700 | 0.5503 |
+
+Verdicts as printed: **A1 PASS · A2 PASS · A3 ordering holds (junk max SARI 0.4676 on J2, real
+min 0.5849 on exp004 `unguided_capped`, margin +0.1173), exempt from A2 by design · A4 PASS ·
+A5 PASS.**
+
+**The A4 gate, stated as the number it turns on:** the best junk baseline scores
+`decomp_mean` **0.1412** (J4) against a real-arm worst of **0.5085** (exp005 `unguided` /
+`unguided_capped`) — margin **+0.3673** — and every one of J1–J4 ranks below every one of the
+nine arms. The blend is therefore **not disqualified** and ships as a contingency.
+
+Two things this table is worth reading for beyond the gate. First, it **independently
+reproduces** every junk figure the analyst's survey measured at commit `efb8530` from a
+different implementation path — GED junk floor 0.9011, SARI empty 0.2911, reversed-gold GED
+0.2875, chain-validity junk 0.0000, real-arm GED worst 0.4910, real-arm chain worst 0.8605,
+SARI junk max 0.4676 versus real min 0.5849. (J3/J4's SARI differ from that note's 0.3229 /
+0.3361 because the fixed step texts are this repo's, committed in the battery config; the
+note's were never recorded.) Second, **J5 is the argument for the suite in one row**: a
+content-perfect, maximally mis-ordered plan scores GED 0.2875 and SARI 0.9414 — better than
+every real arm on both — and is caught only by `break_exact_match` (0.0000) and
+`ordered_step_accuracy`. A single number cannot carry that; six can.
+
+## Consequences
+
+- **A run reports six numbers where it reported one.** That is the intended cost: six numbers
+  read weaker in an abstract than one, and the ordering rule for a multi-cell sweep now has to
+  be stated (`ged_macro`) rather than assumed.
+- **Every headline term now takes the full ADR 0009 battery.** The 1-of-3-tests weakness is the
+  legacy composite's alone. The comparison grew from 7 bootstrap / 3 McNemar / 9 t-tests to 8 /
+  5 / 12 — the counts are in `tests_reported` and no correction for multiple comparisons is
+  applied to any of them, exactly as before.
+- **The ADR 0017 asymmetry became testable.** Until the two direction columns existed, the
+  over/under rates were aggregate-only and no paired test could be run on either.
+- **Old per-item files still compare.** The three new columns are computed on every run but are
+  **not required** of a file being compared: nine committed arms and 33 sweep cells were scored
+  before they existed, and requiring them would refuse those files instead of comparing what
+  they carry. What is missing is named in `statistics_not_available_in_inputs`. Verified on a
+  real 600-item paired comparison of two exp-011 arms: every statistic byte-identical, the
+  three new columns reported as unavailable.
+- **A re-score buys the new columns, and only those.** Any arm re-scored from its existing
+  `results.json` gains `over_decomposition`, `under_decomposition`, `decomp_mean` and the
+  report card; every pre-existing value, including `composite_score`, is unchanged. It is
+  CPU-only, needs no GPU and no `run.lock` — the exp-011 precedent.
+- **`_REF_RX` is now guarded by a test and a comment that both say why not to fix it.** A future
+  contributor "correcting" it would silently invalidate 33 sweep cells and nine arms.
+- **Nothing here is adopted.** The thesis-primary metric is issue #6 item 5. If the supervisor
+  asks for one blended number, `decomp_mean` exists and has passed its gate; if he asks for one
+  number full stop, it is `ged_macro` with its three caveats; the recommendation on the table is
+  the suite.
+
+## Alternatives considered
+
+- **Repair the composite in place** (replace `reference_validity_micro` with
+  `chain_validity_macro` at the same 0.2 weight and re-score everything). Rejected as the
+  primary move: it keeps an aggregate-of-aggregates with no per-item value and one of three
+  tests, it invalidates the comparability of every published composite, and it moves a
+  published reading — the Qwen/Mistral chaining ranking *reverses* under the no-free-credit
+  convention. It stays available as the specification's §5 option 2 if Jahid wants it.
+- **Silently correct `_REF_RX`.** Rejected outright: it changes the value of a metric under an
+  unchanged name and leaves the pooled-denominator defect intact.
+- **A weighted blend with tuned weights.** Rejected: no decomposition paper found in three
+  passes reports one, and measured on this repo's own metric the "typed beats uniform" ordering
+  fails in ~27–28% of weightings on the 4-simplex. Equal weighting is the only weighting with a
+  precedent, and `decomp_mean` uses it.
+- **A per-item harmonic mean (the RAGAS form).** Rejected arithmetically: `break_exact_match` is
+  0 on ~90–95% of items in every committed arm, and a harmonic mean containing a 0 is 0, so it
+  would be identically 0 almost everywhere. Taken over aggregate column means instead, it
+  reintroduces the aggregate-of-aggregates problem. (Recorded so it is not re-derived; note that
+  the best-known industry composite of this shape was itself retired at RAGAS `v0.1.0`.)
+- **`suite_win_rate` (the HELM-style, weight-free cross-arm ordering of the specification's
+  §2.4).** Not built. It is cross-arm, so it belongs in a reporting script rather than in a
+  scoring run, it has no per-item value and therefore supports no significance claim, and it
+  applies HELM's *per metric across scenarios* form *across metrics*, which is the
+  specification's own adaptation rather than a published one. Out of scope for this change; the
+  specification's definition stands if a sweep ever needs it.
+- **Registering `over_decomposition` as higher-is-better** (following §2.5 item 1 literally,
+  which names only `under_decomposition` for the lower-is-better registry). Rejected: it would
+  stamp every `over_decomposition` comparison row `higher_is_better` and make `favours` name the
+  wrong system on it. §2.1 of the same specification prints the pair as "under ⇓, over ⇓ but
+  tolerated", so both are registered as lower-is-better and the tolerance is carried by the two
+  rates staying split — never by calling more over-decomposition better.
+- **Making the suite membership a config knob.** Rejected: the membership is a metric
+  definition, and a definition that can be edited per run is not a definition. It lives in
+  `DECOMPOSITION_SUITE_TERMS` beside the code computing each term. Only the contingency blend's
+  parameters — a genuine choice with no source — live in config.
+- **Requiring the three new columns of every compared per-item file.** Rejected: it would refuse
+  every committed artifact at `--compare` until a full re-score landed, including the in-flight
+  exp-014 significance work, and gain nothing the `statistics_not_available_in_inputs` record
+  does not already give.

--- a/docs/adr/0029-the-decomposition-quality-suite-the-implementers-registration.md
+++ b/docs/adr/0029-the-decomposition-quality-suite-the-implementers-registration.md
@@ -136,9 +136,13 @@ A1–A6 are asserted over the fixture gold in
 
 ## The measured junk battery
 
-Printed by `scripts/decomposition_junk_battery.py` at commit `222862f` (working tree carrying
-this change), seed 42, on the **ADR 0007 pinned 600** — all fifteen rows on the same 600
-items, with each arm's per-item file checked to cover exactly that set. The nine real arms are
+Printed by `scripts/decomposition_junk_battery.py` from the code of commit **`87e3765`**
+(clean tree; the run stamped `f3b4d87`, a later commit on this branch whose only difference
+from `87e3765` is this ADR file — a record citing the SHA it was measured at can never cite
+its own commit, so the code SHA is what is quoted), seed 42,
+on the **ADR 0007 pinned 600** (the gold file holds 2411 rows; 0 pinned questions had no gold
+row) — all fifteen rows on the same 600 items, with each arm's per-item file checked to cover
+exactly that set. The nine real arms are
 the ones exp-011 re-scored under the Break-faithful columns; nothing was re-scored here, and
 `decomp_mean` and the two direction columns are derived from the columns already in those
 files. Re-run the script rather than quoting this table from memory.

--- a/docs/adr/0029-the-decomposition-quality-suite-the-implementers-registration.md
+++ b/docs/adr/0029-the-decomposition-quality-suite-the-implementers-registration.md
@@ -119,7 +119,12 @@ is a **tool, not an experiment**: it scores no system of the thesis, takes no
 `experiments/log.md` entry, needs no GPU and takes no `runs/run.lock`, and it carries a tiny
 mode (`--limit`, `--eval-set all-gold`, `--no-real-arms`) so the full path is smoke-testable.
 A1–A6 are asserted over the fixture gold in
-`tests/test_decomposition_metrics.py::TestJunkBattery`.
+`tests/test_decomposition_metrics.py::TestJunkBattery`, and every verdict the script computes
+on the real 600 — **A3's SARI ordering included** — carries a `passed` and drives the exit
+code. SARI's exemption is from A2's junk-separation *assertion* (its floor is high by
+construction, so the margin is reported rather than asserted as separation); it is not an
+exemption from the gate, so an arm that ever falls below the junk SARI floor fails the battery
+instead of being reported by it.
 
 **6. Three guards ship with the suite**, each replacing an argument with a check:
 
@@ -165,9 +170,12 @@ files. Re-run the script rather than quoting this table from memory.
 | exp009 mixed | 0.0533 | 0.5851 | 0.4713 | 0.9686 | 0.5150 | 0.2000 | 0.2850 | 0.5301 |
 | exp009 oracle_hop_matched | 0.0483 | 0.5879 | 0.4540 | 0.9686 | 0.6000 | 0.1300 | 0.2700 | 0.5503 |
 
-Verdicts as printed: **A1 PASS · A2 PASS · A3 ordering holds (junk max SARI 0.4676 on J2, real
-min 0.5849 on exp004 `unguided_capped`, margin +0.1173), exempt from A2 by design · A4 PASS ·
-A5 PASS.**
+Verdicts as printed: **A1 PASS · A2 PASS · A3 PASS — ordering_holds=True (junk max SARI 0.4676
+on J2, real min 0.5849 on exp004 `unguided_capped`, margin +0.1173), exempt from the A2
+assertion by design; the ordering is gated · A4 PASS · A5 PASS.** (The A3 line gained its
+PASS/FAIL when the ordering was put behind the exit code — the PR #48 review's nit 1. The
+battery was re-run on the same pinned 600 with that change and every row of the table above,
+and every verdict, reproduced digit-for-digit.)
 
 **The A4 gate, stated as the number it turns on:** the best junk baseline scores
 `decomp_mean` **0.1412** (J4) against a real-arm worst of **0.5085** (exp005 `unguided` /
@@ -195,7 +203,15 @@ every real arm on both — and is caught only by `break_exact_match` (0.0000) an
   5 / 12 — the counts are in `tests_reported` and no correction for multiple comparisons is
   applied to any of them, exactly as before.
 - **The ADR 0017 asymmetry became testable.** Until the two direction columns existed, the
-  over/under rates were aggregate-only and no paired test could be run on either.
+  over/under rates were aggregate-only and no paired test could be run on either. It also made
+  McNemar's discordant counts polarity-dependent: on the two rate rows a 1 is the **error**
+  occurring, not a correct item, so the counts are emitted neutrally as
+  `discordant_only_in_a` / `discordant_only_in_b` on every row, and the direction-specific
+  name is only ever written where it is true (`correct_only_in_*` on the three
+  higher-is-better rows, `error_only_in_*` on the two lower-is-better ones). A single pair of
+  names would have read backwards on half the rows (PR #48 review, Important 1); no value
+  moved, and the committed metrics JSONs, which carry only higher-is-better rows, keep their
+  existing key.
 - **Old per-item files still compare.** The three new columns are computed on every run but are
   **not required** of a file being compared: nine committed arms and 33 sweep cells were scored
   before they existed, and requiring them would refuse those files instead of comparing what

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,7 +56,7 @@ When **not** to write one:
 | [0026](./0026-break-faithful-metrics-the-implementers-conventions.md) | Break-Faithful Metrics (EM / SARI / GED) and the Repaired Chain Validity: The Implementer's Conventions | Accepted (implementer design, pending Jahid) |
 | [0027](./0027-a-number-that-justifies-a-constant-is-a-committed-script.md) | A Number That Justifies a Config Constant Is a Committed Script, Not Prose | Accepted (implementer convention, pending Jahid) |
 | [0028](./0028-jahid-2026-08-23-delegations-pool-choice-router-call-composite-authorized.md) | Jahid's 2026-08-23 Delegations: Pool Choice and the Router Call Move to the Lead; the Composite Replacement Is Authorized to Implement | Accepted (Jahid, 2026-08-23) |
-| 0029 | *(reserved — decomposition-metric-suite ADR, in flight on `feature/40-decomposition-metric-suite`)* | pending |
+| [0029](./0029-the-decomposition-quality-suite-the-implementers-registration.md) | The Decomposition-Quality Suite: Six Unblended Terms as the Reported Primary, and the Composite Frozen as Legacy | Accepted (implementer registration, pending Jahid and his supervisor) |
 | [0030](./0030-remove-the-router-from-the-decomposition-critical-path.md) | Remove the Router from the Decomposition Pipeline's Critical Path | Accepted (lead, 2026-08-23; supervisor may overturn) |
 
 ---

--- a/scripts/decomposition_junk_battery.py
+++ b/scripts/decomposition_junk_battery.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""
+The junk battery behind the decomposition report card's acceptance criteria.
+
+Break prints a trivial ``Copy`` baseline in its own results table (TACL 2020, Table 9): a
+system that echoes the input question, scored beside the real ones. That practice is the
+cheapest guard there is against the issue #40 pathology — under the legacy composite, three
+fixed junk steps scored **0.2778** and a question echo **0.2333** against exp-004
+``unguided``'s **0.2098**, i.e. junk outranked the deployable baseline on its own evaluation
+set, and it took two analysis notes to notice.
+
+This script builds six junk systems out of the gold column, scores them with the evaluator's
+own :func:`score_item` (no second copy of any metric), and prints the whole report card for
+each of them beside every real arm's, plus the pass/fail verdicts:
+
+    A1  the gold itself scores the extremum on every term
+    A2  every real arm beats J1-J4 on ged_macro, chain_validity_macro, break_exact_match_rate
+    A3  SARI is EXEMPT from A2 by design - its junk floor on this data is high (Break's own
+        published Copy row scores SARI 0.431) - so the margin is recorded, not asserted
+    A4  the additive blend decomp_mean must rank every junk system below every real arm.
+        This is a HARD GATE: failing it disqualifies the blend rather than prompting a
+        weight tweak, because the composite's weights were never the disease
+    A5  order sensitivity survives: the reversed gold (J5) is caught by break_exact_match
+        and ordered_step_accuracy, NOT by GED, which is order-light
+
+It is a **tool, not an experiment** (ADR 0027 point 5): it scores no system of the thesis, it
+takes no ``experiments/log.md`` entry, it needs no GPU and it takes no ``runs/run.lock``. The
+junk systems are baselines built from the gold, in the same sense as Break's ``Copy`` row.
+What it prints is what ADR 0029 records, at the SHA it prints.
+
+The same construction functions are imported by
+``tests/test_decomposition_metrics.py::TestJunkBattery``, which asserts A1-A6 over the
+committed fixture gold — so the battery is smoke-testable at 4 items before it is run over
+600.
+
+Run::
+
+    .venv/bin/python scripts/decomposition_junk_battery.py                     # full
+    .venv/bin/python scripts/decomposition_junk_battery.py --limit 20          # tiny
+    .venv/bin/python scripts/decomposition_junk_battery.py --json out.json
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from run_artifacts import now_iso  # noqa: E402
+from run_config import load_config, load_paths, require, resolve_path, runs_path  # noqa: E402
+from seeding import set_global_seed  # noqa: E402
+
+EVALUATOR = REPO_ROOT / "scripts" / "musique_decompositions_evaluator.py"
+
+
+def _import_evaluator() -> Any:
+    """Import the evaluator by path, as ``scripts/ged_cost_benchmark.py`` does."""
+    name = "musique_decompositions_evaluator"
+    spec = importlib.util.spec_from_file_location(name, EVALUATOR)
+    if spec is None or spec.loader is None:  # pragma: no cover - import plumbing
+        raise SystemExit(f"cannot import {EVALUATOR}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+EVAL = _import_evaluator()
+
+
+# --------------------------------------------------------------------------------------
+# The six junk systems. Each is a function from (question, gold steps, junk step texts) to
+# the steps the junk system "predicts". They are written out here rather than described,
+# for the same reason the GED benchmark's shapes are: a baseline IS the measurement's
+# definition, and prose cannot state one precisely enough to re-derive its numbers.
+# --------------------------------------------------------------------------------------
+
+JunkSystem = Callable[[str, list[str], list[str]], list[str]]
+
+#: What each junk system is, printed with its row so a table cannot be read without them.
+JUNK_DESCRIPTIONS: dict[str, str] = {
+    "J1_empty": "empty prediction: zero steps",
+    "J2_question_echo": "the question verbatim as a single step (= Break's own 'Copy')",
+    "J3_one_fixed_step": "one constant step, the same string for every item",
+    "J4_three_fixed_steps": "three constant steps, the same strings for every item",
+    "J5_gold_reversed": "the gold steps in reverse order (content-perfect, mis-ordered)",
+    "J6_gold": "the gold decomposition verbatim (the anchor)",
+}
+
+JUNK_SYSTEMS: dict[str, JunkSystem] = {
+    "J1_empty": lambda question, gold, junk: [],
+    "J2_question_echo": lambda question, gold, junk: [question],
+    "J3_one_fixed_step": lambda question, gold, junk: list(junk[:1]),
+    "J4_three_fixed_steps": lambda question, gold, junk: list(junk[:3]),
+    "J5_gold_reversed": lambda question, gold, junk: list(reversed(gold)),
+    "J6_gold": lambda question, gold, junk: list(gold),
+}
+
+#: The junk systems A2 and A4 are asserted against: J5 and J6 are built FROM the gold and
+#: are not junk in that sense (J6 is the anchor, J5 is the order probe).
+JUNK_BASELINES = ("J1_empty", "J2_question_echo", "J3_one_fixed_step", "J4_three_fixed_steps")
+
+#: The columns a real arm's committed per-item file must carry for this battery to read it.
+#: Every one of them predates this script; nothing here re-scores a committed arm.
+_REAL_ARM_COLUMNS = (
+    "break_exact_match",
+    "sari",
+    "ged",
+    "chain_validity",
+    "hop_count_exact_match",
+    "ordered_step_accuracy",
+    "step_count_signed_error",
+)
+
+#: The report card terms this battery prints and compares, in the specification's order.
+_SUITE_KEYS = tuple(term.aggregate_key for term in EVAL.DECOMPOSITION_SUITE_TERMS)
+
+#: The three terms A2 asserts on. SARI is deliberately NOT among them (A3).
+A2_TERMS = ("ged_macro", "chain_validity_macro", "break_exact_match_rate")
+
+
+def _lower_is_better(aggregate_key: str) -> bool:
+    for term in EVAL.DECOMPOSITION_SUITE_TERMS:
+        if term.aggregate_key == aggregate_key:
+            return term.per_item_column in EVAL.LOWER_IS_BETTER_STATISTICS
+    return False
+
+
+def _beats(aggregate_key: str, candidate: float, other: float) -> bool:
+    """Is ``candidate`` strictly better than ``other`` on this term, direction applied?"""
+    return candidate < other if _lower_is_better(aggregate_key) else candidate > other
+
+
+def _pinned_eval_questions(paths_cfg: dict[str, Any], cfg: dict[str, Any]) -> set[str]:
+    """The normalized questions of the pinned evaluation set (ADR 0007: 200 per hop)."""
+    template = require(paths_cfg, "datasets." + require(cfg, "eval_set.questions_key"))
+    out: set[str] = set()
+    for hop in require(cfg, "eval_set.hops"):
+        path = resolve_path(
+            str(template).format(hop=hop), Path(paths_cfg["data_root_resolved"])
+        )
+        if not path.exists():
+            raise SystemExit(f"pinned evaluation set file not found: {path}")
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                question = json.loads(line).get("question")
+                if isinstance(question, str) and question.strip():
+                    out.add(EVAL._normalize_question(question))
+    if not out:
+        raise SystemExit("the pinned evaluation set files carry no questions.")
+    return out
+
+
+def _assert_same_eval_set(
+    scored_keys: set[str], arm_name: str, arm_items: list[dict[str, Any]], path: Path
+) -> None:
+    """Refuse to put a real arm beside the junk rows unless it is the SAME evaluation set.
+
+    A junk baseline scored over 2411 gold rows and an arm scored over the pinned 600 are not
+    comparable, and every A2/A4/A5 verdict is a junk-versus-arm comparison — so this is
+    checked rather than assumed (CLAUDE.md, evidence discipline).
+    """
+    arm_keys = {EVAL._normalize_question(str(item["question"])) for item in arm_items}
+    if arm_keys == scored_keys:
+        return
+    raise SystemExit(
+        f"real arm {arm_name!r} was not evaluated on the same set as the junk baselines.\n"
+        f"  arm: {path} ({len(arm_keys)} items)\n"
+        f"  junk baselines: {len(scored_keys)} items\n"
+        f"  only in the arm: {len(arm_keys - scored_keys)}; "
+        f"only in the junk set: {len(scored_keys - arm_keys)}\n"
+        f"Comparing across two evaluation sets is not a comparison. Item text is not printed "
+        f"here: dataset content does not go into an error message (CLAUDE.md)."
+    )
+
+
+def _junk_predictions(
+    gold_by_question: dict[str, dict[str, Any]],
+    system: JunkSystem,
+    junk_steps: list[str],
+) -> list[dict[str, Any]]:
+    """One prediction row per gold row, built by ``system`` from that row's own gold.
+
+    The question is the gold's RAW text, not the normalized join key: J2 is Break's ``Copy``,
+    which copies the input question "without introducing any modifications", and SARI reads
+    the question as its source — a lowercased echo would be a different system.
+    """
+    return [
+        {
+            "query_id": key,
+            "question": gold["question"],
+            "decomposition": system(gold["question"], list(gold["steps"]), junk_steps),
+        }
+        for key, gold in gold_by_question.items()
+    ]
+
+
+def _score_system(
+    predictions: list[dict[str, Any]],
+    gold_by_question: dict[str, dict[str, Any]],
+    ged_policy: dict[str, Any],
+    decomp_policy: dict[str, Any],
+) -> dict[str, Any]:
+    """Score one junk system with the evaluator's own per-item function and aggregate it."""
+    rows, missing = EVAL._build_eval_rows(predictions, gold_by_question)
+    if missing:
+        raise SystemExit(
+            f"{missing} junk prediction(s) matched no gold row, which cannot happen when the "
+            f"predictions are built from the gold — the question join changed."
+        )
+    items = [
+        EVAL.score_item(
+            row,
+            ged_max_nodes=ged_policy["max_nodes_for_optimizer"],
+            ged_time_budget=ged_policy["per_item_time_budget_seconds"],
+            decomp_mean_components=tuple(decomp_policy["components"]),
+            ged_clamp=decomp_policy["ged_clamp"],
+        )
+        for row in rows
+    ]
+    return _row_of(EVAL._aggregate(items), len(items))
+
+
+def _row_of(aggregate: dict[str, Any], n_items: int) -> dict[str, Any]:
+    row = {key: float(aggregate[key]) for key in _SUITE_KEYS}
+    row["decomp_mean_macro"] = float(aggregate["decomp_mean_macro"])
+    row["ordered_step_accuracy_macro"] = float(aggregate["ordered_step_accuracy_macro"])
+    row["n_items"] = n_items
+    return row
+
+
+def _real_arm_row(
+    path: Path, decomp_policy: dict[str, Any]
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Read a committed per-item file and aggregate it into the same shape.
+
+    Read, never re-scored: the per-item columns are the ones the arm was scored with, and
+    ``decomp_mean`` / the two direction columns are DERIVED from them by the same functions
+    the evaluator uses — so an arm scored before those columns existed still gets a row.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
+        raise SystemExit(
+            f"{path}: not a '{EVAL.PER_ITEM_SCHEMA}' per-item file (no 'items' list)."
+        )
+    items = payload["items"]
+    if not items:
+        raise SystemExit(f"{path}: no items.")
+    for i, item in enumerate(items):
+        missing = [c for c in (*_REAL_ARM_COLUMNS, "question") if c not in item]
+        if missing:
+            raise SystemExit(
+                f"{path}: row {i} is missing {missing}, so this arm cannot be placed beside "
+                f"the junk baselines. Re-score it with the evaluator."
+            )
+    enriched = []
+    for item in items:
+        signed = int(item["step_count_signed_error"])
+        enriched.append(
+            {
+                **item,
+                "over_decomposition": 1.0 if signed > 0 else 0.0,
+                "under_decomposition": 1.0 if signed < 0 else 0.0,
+                "decomp_mean": EVAL.decomp_mean(
+                    item, tuple(decomp_policy["components"]), decomp_policy["ged_clamp"]
+                ),
+            }
+        )
+    return _row_of(EVAL._aggregate(enriched), len(enriched)), items
+
+
+def _verdicts(rows: dict[str, dict[str, Any]], real_names: list[str]) -> dict[str, Any]:
+    """A1-A5, computed from the rows rather than asserted in prose."""
+    gold = rows["J6_gold"]
+    a1_expected = {
+        "break_exact_match_rate": 1.0,
+        "sari_macro": 1.0,
+        "ged_macro": 0.0,
+        "chain_validity_macro": 1.0,
+        "hop_count_exact_match_rate": 1.0,
+        "under_decomposition_rate": 0.0,
+        "over_decomposition_rate": 0.0,
+    }
+    a1_failures = [
+        f"{key}: {gold[key]!r} != {value!r}"
+        for key, value in a1_expected.items()
+        if abs(gold[key] - value) > 1e-9
+    ]
+
+    a2_failures: list[str] = []
+    for term in A2_TERMS:
+        for junk in JUNK_BASELINES:
+            for arm in real_names:
+                if not _beats(term, rows[arm][term], rows[junk][term]):
+                    a2_failures.append(
+                        f"{term}: real arm {arm} ({rows[arm][term]:.4f}) does not beat "
+                        f"{junk} ({rows[junk][term]:.4f})"
+                    )
+
+    junk_sari = {j: rows[j]["sari_macro"] for j in JUNK_BASELINES}
+    real_sari = {a: rows[a]["sari_macro"] for a in real_names}
+    a3 = {
+        "exempt_from_a2": True,
+        "why": (
+            "SARI's floor on this data is far above 0 (an additive blend containing it hands "
+            "junk a nonzero floor), and Break's own published Copy row scores SARI 0.431 "
+            "against its best model's 0.748. The ordering is recorded and the MARGIN is "
+            "reported; it is not asserted"
+        ),
+        "junk_max": max(junk_sari.values()),
+        "junk_max_system": max(junk_sari, key=junk_sari.get),
+        "real_min": min(real_sari.values()) if real_sari else None,
+        "real_min_arm": min(real_sari, key=real_sari.get) if real_sari else None,
+        "margin": (min(real_sari.values()) - max(junk_sari.values())) if real_sari else None,
+        "ordering_holds": (
+            bool(min(real_sari.values()) > max(junk_sari.values())) if real_sari else None
+        ),
+    }
+
+    a4_failures = [
+        f"decomp_mean_macro: {junk} ({rows[junk]['decomp_mean_macro']:.4f}) ranks at or "
+        f"above real arm {arm} ({rows[arm]['decomp_mean_macro']:.4f})"
+        for junk in JUNK_BASELINES
+        for arm in real_names
+        if not rows[arm]["decomp_mean_macro"] > rows[junk]["decomp_mean_macro"]
+    ]
+
+    reversed_row = rows["J5_gold_reversed"]
+    a5_failures = []
+    if reversed_row["break_exact_match_rate"] != 0.0:
+        a5_failures.append(
+            f"break_exact_match_rate on the reversed gold is "
+            f"{reversed_row['break_exact_match_rate']!r}, not 0.0"
+        )
+    for arm in real_names:
+        if reversed_row["ordered_step_accuracy_macro"] >= rows[arm]["ordered_step_accuracy_macro"]:
+            a5_failures.append(
+                f"ordered_step_accuracy_macro: the reversed gold "
+                f"({reversed_row['ordered_step_accuracy_macro']:.4f}) is not below real arm "
+                f"{arm} ({rows[arm]['ordered_step_accuracy_macro']:.4f})"
+            )
+
+    return {
+        "A1_gold_anchors": {"passed": not a1_failures, "failures": a1_failures},
+        "A2_junk_is_beaten": {
+            "passed": not a2_failures,
+            "terms": list(A2_TERMS),
+            "failures": a2_failures,
+        },
+        "A3_sari_exempt": a3,
+        "A4_blend_gate": {
+            "passed": not a4_failures,
+            "metric": "decomp_mean_macro",
+            "hard_gate": (
+                "failing this DISQUALIFIES the blend; it is not a prompt to re-tune weights"
+            ),
+            "failures": a4_failures,
+        },
+        "A5_order_sensitivity": {
+            "passed": not a5_failures,
+            "ged_may_not_carry_it": (
+                "GED is order-light and on a 2-step plan order-blind, so this assertion rests "
+                "on break_exact_match and ordered_step_accuracy"
+            ),
+            "reversed_gold_ged_macro": reversed_row["ged_macro"],
+            "failures": a5_failures,
+        },
+    }
+
+
+def _git_commit() -> dict[str, Any]:
+    """The SHA this table was printed at, and whether the tree was dirty (ADR 0027 point 2)."""
+    def run(*args: str) -> str:
+        return subprocess.run(
+            ["git", *args], cwd=str(REPO_ROOT), capture_output=True, text=True, check=False
+        ).stdout.strip()
+
+    return {"commit": run("rev-parse", "HEAD"), "dirty": bool(run("status", "--porcelain"))}
+
+
+def _print_table(rows: dict[str, dict[str, Any]], real_names: list[str]) -> None:
+    header = ["system"] + [k for k in _SUITE_KEYS] + ["decomp_mean_macro", "n"]
+    print("| " + " | ".join(header) + " |")
+    print("|" + "---|" * len(header))
+    for name in list(JUNK_SYSTEMS) + real_names:
+        row = rows[name]
+        cells = [f"{row[k]:.4f}" for k in _SUITE_KEYS]
+        print(
+            f"| {name} | " + " | ".join(cells) + f" | {row['decomp_mean_macro']:.4f} | "
+            f"{row['n_items']} |"
+        )
+    print()
+    print("Directions (⇓ = lower is better): " + ", ".join(
+        f"{k} {'⇓' if _lower_is_better(k) else '⇑'}" for k in _SUITE_KEYS
+    ))
+    print("Junk systems: " + "; ".join(f"{k} = {v}" for k, v in JUNK_DESCRIPTIONS.items()))
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--config",
+        default="decomposition_junk_battery.json",
+        help="Config (default: configs/decomposition_junk_battery.json)",
+    )
+    p.add_argument("--gold", type=Path, default=None, help="Override the gold JSONL from config.")
+    p.add_argument(
+        "--eval-set",
+        choices=("pinned", "all-gold"),
+        default="pinned",
+        help="Which items to score. 'pinned' (default) restricts the gold to the ADR 0007 "
+        "evaluation set, which is the set every committed arm was scored on. 'all-gold' "
+        "scores every gold row and is NOT comparable to a committed arm — the same-set check "
+        "below will refuse the arms.",
+    )
+    p.add_argument(
+        "--limit", type=int, default=None, help="Score only the first N gold rows (tiny run)."
+    )
+    p.add_argument(
+        "--no-real-arms",
+        action="store_true",
+        help="Skip the committed arms (they live under the gitignored runs/ and may be "
+        "absent on another machine); A2/A4/A5 then have nothing to compare against and are "
+        "reported as not evaluated.",
+    )
+    p.add_argument("--json", type=Path, default=None, help="Also write the table as JSON.")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    cfg = load_config(args.config)
+    paths_cfg = load_paths(require(cfg, "paths_config"))
+    seed = int(require(cfg, "seed"))
+    seeded = set_global_seed(seed)
+
+    # The metric's own parameters come from the evaluator's config, not from this one: two
+    # copies of a GED cap or a blend definition would drift, and then this battery would be
+    # gating a metric nobody runs.
+    eval_cfg = load_config(require(cfg, "evaluator_config"))
+    ged_policy = EVAL._ged_policy(eval_cfg)
+    decomp_policy = EVAL._decomp_mean_policy(eval_cfg)
+
+    gold_path = (
+        args.gold
+        if args.gold is not None
+        else resolve_path(
+            require(paths_cfg, "datasets." + require(cfg, "gold_key")),
+            Path(paths_cfg["data_root_resolved"]),
+        )
+    )
+    if not gold_path.exists():
+        raise SystemExit(f"gold file not found: {gold_path}")
+    gold_by_question = EVAL._load_gold(
+        gold_path, int(require(eval_cfg, "gold_validation.max_reported_mismatches"))
+    )
+    gold_rows_total = len(gold_by_question)
+    pinned_missing_from_gold = 0
+    if args.eval_set == "pinned":
+        pinned = _pinned_eval_questions(paths_cfg, cfg)
+        pinned_missing_from_gold = len(pinned - set(gold_by_question))
+        gold_by_question = {k: v for k, v in gold_by_question.items() if k in pinned}
+        if not gold_by_question:
+            raise SystemExit(
+                "no gold row is in the pinned evaluation set — the gold file and the pinned "
+                "question files do not describe the same data."
+            )
+    if args.limit is not None:
+        gold_by_question = dict(list(gold_by_question.items())[: args.limit])
+    if not gold_by_question:
+        raise SystemExit("no gold rows to score.")
+
+    junk_steps = list(require(cfg, "fixed_junk_steps"))
+    if len(junk_steps) < 3 or any(not isinstance(s, str) or not s.strip() for s in junk_steps):
+        raise SystemExit(
+            f"fixed_junk_steps must be at least 3 non-empty strings (J4 takes three), got "
+            f"{junk_steps!r}"
+        )
+
+    rows: dict[str, dict[str, Any]] = {}
+    for name, system in JUNK_SYSTEMS.items():
+        rows[name] = _score_system(
+            _junk_predictions(gold_by_question, system, junk_steps),
+            gold_by_question,
+            ged_policy,
+            decomp_policy,
+        )
+
+    real_names: list[str] = []
+    real_arm_paths: dict[str, str] = {}
+    if not args.no_real_arms:
+        for arm in require(cfg, "real_arms"):
+            name = require(arm, "name")
+            path = runs_path(paths_cfg, require(arm, "per_item"))
+            if not path.exists():
+                raise SystemExit(
+                    f"real arm {name!r}: per-item file not found: {path}\n"
+                    f"These live under the gitignored runs/ and are the committed arms of "
+                    f"exp-011. Pass --no-real-arms to run the junk half only."
+                )
+            row, arm_items = _real_arm_row(path, decomp_policy)
+            _assert_same_eval_set(set(gold_by_question), name, arm_items, path)
+            rows[name] = row
+            real_arm_paths[name] = str(path)
+            real_names.append(name)
+
+    verdicts = _verdicts(rows, real_names) if real_names else None
+
+    git = _git_commit()
+    print(f"# Decomposition junk battery — {now_iso()}")
+    print(
+        f"commit {git['commit'][:12]}{' (DIRTY TREE)' if git['dirty'] else ''}, seed {seed}, "
+        f"gold {gold_path.name} ({gold_rows_total} rows), eval set '{args.eval_set}' -> "
+        f"{len(gold_by_question)} items, {len(real_names)} real arm(s)"
+    )
+    if args.eval_set == "pinned":
+        print(
+            f"Every row below is scored on the SAME {len(gold_by_question)} items: the junk "
+            f"baselines were scored on them here, and each real arm's per-item file was "
+            f"checked to cover exactly them"
+            + (
+                f" ({pinned_missing_from_gold} pinned question(s) have no gold row and are "
+                f"in neither)"
+                if pinned_missing_from_gold
+                else ""
+            )
+            + "."
+        )
+    else:
+        print(
+            "WARNING: --eval-set all-gold scores every gold row, which is NOT the set any "
+            "committed arm was evaluated on."
+        )
+    print()
+    _print_table(rows, real_names)
+    print()
+    if verdicts is None:
+        print(
+            "A2 / A4 / A5 NOT EVALUATED: no real arms were read (--no-real-arms), and every "
+            "one of them is a statement about junk versus a real arm."
+        )
+    else:
+        for name, verdict in verdicts.items():
+            if "passed" not in verdict:
+                print(
+                    f"{name}: ordering_holds={verdict['ordering_holds']} "
+                    f"(junk max {verdict['junk_max']:.4f} on {verdict['junk_max_system']}, "
+                    f"real min {verdict['real_min']:.4f} on {verdict['real_min_arm']}, "
+                    f"margin {verdict['margin']:+.4f}) — EXEMPT from A2 by design"
+                )
+                continue
+            print(f"{name}: {'PASS' if verdict['passed'] else 'FAIL'}")
+            for failure in verdict["failures"]:
+                print(f"    {failure}")
+
+    if args.json is not None:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(
+            json.dumps(
+                {
+                    "script": Path(__file__).name,
+                    "created_utc": now_iso(),
+                    "git": git,
+                    "seed": seed,
+                    "seeded": seeded,
+                    "gold_path": str(gold_path.resolve()),
+                    "eval_set": args.eval_set,
+                    "gold_rows_total": gold_rows_total,
+                    "pinned_questions_without_a_gold_row": pinned_missing_from_gold,
+                    "n_items": len(gold_by_question),
+                    "fixed_junk_steps": junk_steps,
+                    "junk_descriptions": JUNK_DESCRIPTIONS,
+                    "ged_policy": ged_policy,
+                    "decomp_mean_policy": decomp_policy,
+                    "real_arm_paths": real_arm_paths,
+                    "rows": rows,
+                    "verdicts": verdicts,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"\nWrote {args.json}")
+
+    if verdicts is not None and not all(
+        v.get("passed", True) for v in verdicts.values()
+    ):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/decomposition_junk_battery.py
+++ b/scripts/decomposition_junk_battery.py
@@ -15,8 +15,10 @@ each of them beside every real arm's, plus the pass/fail verdicts:
 
     A1  the gold itself scores the extremum on every term
     A2  every real arm beats J1-J4 on ged_macro, chain_validity_macro, break_exact_match_rate
-    A3  SARI is EXEMPT from A2 by design - its junk floor on this data is high (Break's own
-        published Copy row scores SARI 0.431) - so the margin is recorded, not asserted
+    A3  SARI is EXEMPT from the A2 assertion by design - its junk floor on this data is high
+        (Break's own published Copy row scores SARI 0.431) - so what A2 asserts of the other
+        terms is only RECORDED here, as a margin. The ordering itself (every real arm above
+        every junk baseline on sari_macro) is still gated by this script's exit code
     A4  the additive blend decomp_mean must rank every junk system below every real arm.
         This is a HARD GATE: failing it disqualifies the blend rather than prompting a
         weight tweak, because the composite's weights were never the disease
@@ -306,22 +308,40 @@ def _verdicts(rows: dict[str, dict[str, Any]], real_names: list[str]) -> dict[st
 
     junk_sari = {j: rows[j]["sari_macro"] for j in JUNK_BASELINES}
     real_sari = {a: rows[a]["sari_macro"] for a in real_names}
+    junk_max_system = max(junk_sari, key=junk_sari.get)
+    ordering_holds = (
+        bool(min(real_sari.values()) > max(junk_sari.values())) if real_sari else None
+    )
+    # The A2 ASSERTION stays off SARI (its junk floor is high, so the separation is small by
+    # construction and A2's terms carry that load). The ORDERING is a different claim, and it
+    # is gated: a future arm falling below the junk SARI floor has to be caught here rather
+    # than merely reported (PR #48 review, nit 1).
+    a3_failures = (
+        []
+        if ordering_holds is not False
+        else [
+            f"sari_macro: junk {junk_max_system} ({max(junk_sari.values()):.4f}) ranks at "
+            f"or above real arm {min(real_sari, key=real_sari.get)} "
+            f"({min(real_sari.values()):.4f})"
+        ]
+    )
     a3 = {
         "exempt_from_a2": True,
         "why": (
             "SARI's floor on this data is far above 0 (an additive blend containing it hands "
             "junk a nonzero floor), and Break's own published Copy row scores SARI 0.431 "
-            "against its best model's 0.748. The ordering is recorded and the MARGIN is "
-            "reported; it is not asserted"
+            "against its best model's 0.748. SARI is therefore left out of the A2 assertion "
+            "and its MARGIN is reported; the ordering itself is still gated by this script's "
+            "exit code"
         ),
+        "passed": not a3_failures,
         "junk_max": max(junk_sari.values()),
-        "junk_max_system": max(junk_sari, key=junk_sari.get),
+        "junk_max_system": junk_max_system,
         "real_min": min(real_sari.values()) if real_sari else None,
         "real_min_arm": min(real_sari, key=real_sari.get) if real_sari else None,
         "margin": (min(real_sari.values()) - max(junk_sari.values())) if real_sari else None,
-        "ordering_holds": (
-            bool(min(real_sari.values()) > max(junk_sari.values())) if real_sari else None
-        ),
+        "ordering_holds": ordering_holds,
+        "failures": a3_failures,
     }
 
     a4_failures = [
@@ -545,18 +565,22 @@ def main() -> None:
     print()
     if verdicts is None:
         print(
-            "A2 / A4 / A5 NOT EVALUATED: no real arms were read (--no-real-arms), and every "
-            "one of them is a statement about junk versus a real arm."
+            "A2 / A3 / A4 / A5 NOT EVALUATED: no real arms were read (--no-real-arms), and "
+            "every one of them is a statement about junk versus a real arm."
         )
     else:
         for name, verdict in verdicts.items():
-            if "passed" not in verdict:
+            if verdict.get("exempt_from_a2"):
                 print(
-                    f"{name}: ordering_holds={verdict['ordering_holds']} "
+                    f"{name}: {'PASS' if verdict['passed'] else 'FAIL'} — "
+                    f"ordering_holds={verdict['ordering_holds']} "
                     f"(junk max {verdict['junk_max']:.4f} on {verdict['junk_max_system']}, "
                     f"real min {verdict['real_min']:.4f} on {verdict['real_min_arm']}, "
-                    f"margin {verdict['margin']:+.4f}) — EXEMPT from A2 by design"
+                    f"margin {verdict['margin']:+.4f}) — EXEMPT from the A2 assertion by "
+                    f"design; the ordering is gated"
                 )
+                for failure in verdict["failures"]:
+                    print(f"    {failure}")
                 continue
             print(f"{name}: {'PASS' if verdict['passed'] else 'FAIL'}")
             for failure in verdict["failures"]:
@@ -593,9 +617,9 @@ def main() -> None:
         )
         print(f"\nWrote {args.json}")
 
-    if verdicts is not None and not all(
-        v.get("passed", True) for v in verdicts.values()
-    ):
+    # Every verdict carries `passed`, A3's included: an exemption from A2's assertion is not
+    # an exemption from the exit code (PR #48 review, nit 1).
+    if verdicts is not None and not all(v["passed"] for v in verdicts.values()):
         raise SystemExit(1)
 
 

--- a/scripts/musique_decompositions_evaluator.py
+++ b/scripts/musique_decompositions_evaluator.py
@@ -376,8 +376,14 @@ COMPARISON_DEFINITIONS: dict[str, Any] = {
     ),
     "mcnemar": (
         "exact two-sided McNemar on the discordant pairs of a binary metric: with b = "
-        "#(a correct, b wrong) and c = #(a wrong, b correct), p = min(1, 2 * "
-        "BinomialCDF(min(b, c); b + c, 0.5)). p = 1.0 when there are no discordant pairs"
+        "discordant_only_in_a (the indicator is 1 for a and 0 for b) and c = "
+        "discordant_only_in_b, p = min(1, 2 * BinomialCDF(min(b, c); b + c, 0.5)). "
+        "p = 1.0 when there are no discordant pairs. WHAT A 1 MEANS depends on the row's "
+        "direction, so the counts are also emitted under a direction-specific name: on a "
+        "higher_is_better row 1 is a correct item, so b = #(a correct, b wrong) and the "
+        "pair is repeated as correct_only_in_a / correct_only_in_b; on a lower_is_better "
+        "row (the over/under-decomposition rates) 1 is the ERROR occurring, so b = #(a "
+        "errs, b does not) and the pair is repeated as error_only_in_a / error_only_in_b"
     ),
     "mcnemar_significance": "significant = p_value < alpha",
     "mcnemar_min_attainable_p_value": (
@@ -2576,12 +2582,26 @@ def _mcnemar(
         n = len(a_vals)
         difference = (sum(a_vals) - sum(b_vals)) / n
         significant = bool(p_value < alpha)
+        # The two discordant counts are named for what a 1 MEANS on this row, which the
+        # row's direction decides: on a higher-is-better metric a 1 is a correct item, on
+        # the over/under-decomposition rates a 1 is the error occurring. One pair of names
+        # cannot be right for both, so `discordant_only_in_*` (always correct, and what the
+        # run note prints) is emitted on every row and the direction-specific pair beside
+        # it. `correct_only_in_*` therefore still appears on exactly the rows it has always
+        # been true of, and a consumer that reads it off an error row gets a KeyError
+        # rather than a number that means the opposite of its name.
+        named_counts = (
+            {"error_only_in_a": only_a, "error_only_in_b": only_b}
+            if _direction(name) == "lower_is_better"
+            else {"correct_only_in_a": only_a, "correct_only_in_b": only_b}
+        )
         out[name] = {
             "system_a_rate": sum(a_vals) / n,
             "system_b_rate": sum(b_vals) / n,
             "difference": difference,
-            "correct_only_in_a": only_a,
-            "correct_only_in_b": only_b,
+            "discordant_only_in_a": only_a,
+            "discordant_only_in_b": only_b,
+            **named_counts,
             "discordant_pairs": only_a + only_b,
             "p_value": p_value,
             "significant": significant,
@@ -2589,8 +2609,8 @@ def _mcnemar(
             "min_attainable_p_value": min_p,
             "min_attainable_p_reaches_alpha": bool(min_p < alpha),
             "underpowered": bool(underpowered or min_p >= alpha),
-            # Every McNemar metric here is higher-is-better, but the field is written
-            # anyway so a consumer reads direction off the row rather than off a name.
+            # Written on every row so a consumer reads the direction off the row rather
+            # than off a name: two of these metrics are lower-is-better error rates.
             "direction": _direction(name),
             "favours": _favours(name, difference, significant),
         }
@@ -2943,8 +2963,9 @@ def _compare(
     for name, r in mcnemar.items():
         note_lines.append(
             f"| {name} | {better(name)} | {r['system_a_rate']:.4f} | {r['system_b_rate']:.4f} | "
-            f"{r['difference']:+.4f} | p={r['p_value']:.4g} (b={r['correct_only_in_a']}, "
-            f"c={r['correct_only_in_b']}, min attainable p={r['min_attainable_p_value']:.4g}) | "
+            f"{r['difference']:+.4f} | p={r['p_value']:.4g} "
+            f"(b={r['discordant_only_in_a']}, c={r['discordant_only_in_b']}, "
+            f"min attainable p={r['min_attainable_p_value']:.4g}) | "
             f"McNemar | {verdict(r)} | "
             f"{'yes' if r['underpowered'] else 'no'} |"
         )
@@ -2977,6 +2998,13 @@ def _compare(
         "carries `direction` / `favours` per row."
     )
     note_lines.append(
+        "- `b` and `c` in a McNemar cell are the discordant counts (`discordant_only_in_a` "
+        "/ `discordant_only_in_b` in the metrics JSON): the items where the metric's "
+        "indicator is 1 for one system and 0 for the other. What a 1 means follows the "
+        "`better` column — a correct item on a higher-is-better row, the error occurring on "
+        "the two length-error rate rows."
+    )
+    note_lines.append(
         "- The over/under rows are a PAIR and are never summed: ADR 0017 records that "
         "over-decomposition is tolerable and under-decomposition is not, so read the two "
         "verdicts separately rather than as one 'wrong length' result."
@@ -2984,8 +3012,10 @@ def _compare(
     if unavailable:
         note_lines.append(
             f"- NOT COMPARED (the inputs do not carry these per-item columns): "
-            f"{', '.join(unavailable)}. A v1 prior-work per-item file predates them; "
-            f"computing them here would be a re-score of v1 outputs, not a comparison."
+            f"{', '.join(unavailable)}. An input scored before those columns existed does "
+            f"not carry them — either a v1 prior-work per-item file, or a v2 file scored "
+            f"before ADR 0029 added the suite columns. Computing them here from the stored "
+            f"steps would be a re-score of that input, not a comparison of what it measured."
         )
     note_lines.append(
         f"- n = {n}; the reporting floor is min_items_for_significance_claim = {min_items} "

--- a/scripts/musique_decompositions_evaluator.py
+++ b/scripts/musique_decompositions_evaluator.py
@@ -9,7 +9,7 @@ Scoring techniques (all string-level, no model in the loop):
 - Step count error, signed (over- vs under-decomposition) and absolute
 - Reference validity for [#k] chains
 - ROUGE-L precision/recall/F1 (LCS-based)
-- A composite score whose weights come from the config
+- A composite score whose weights come from the config. It is **legacy** (see below)
 - The official Break leaderboard trio, ported from ``allenai/break-evaluator`` (issue #40):
   exact match, SARI and normalized graph edit distance (GED, **lower is better**). Break's
   fourth metric, norm_EM, is deliberately not ported — its normalizer is
@@ -19,6 +19,21 @@ Scoring techniques (all string-level, no model in the loop):
 
 The last two blocks are **additive**: they are new columns beside the existing ones, they do
 not enter ``composite_score``, and no metric that existed before them changes value.
+
+**The reported primary is a suite, not a composite** (``decomposition_report_card``, built by
+:func:`_report_card` from the specification in
+``docs/analysis/2026-08-23-decomposition-quality-metric-specification.md`` §2.1 and recorded
+in ADR 0029). Six unblended terms, every one a macro mean over every evaluated item, every
+one carrying its direction: Break EM, SARI, GED (lower is better), ``chain_validity``,
+hop-count EM, and the over/under-decomposition pair kept split and never summed. Where one
+number is structurally required, it is ``ged_macro`` — a member of the suite, not a function
+over it — with the three caveats the report card carries. ``decomp_mean`` is the blended
+**contingency** of §2.3, computed beside the suite and never inside it.
+
+``composite_score`` and its ``_REF_RX`` are **frozen as legacy, not repaired** (§5 option 1 of
+that note): every committed number — nine arms, exp-010's 33 sweep cells, both v1
+re-analysis notes — stays valid and quotable, and the run states the status rather than
+leaving it to be inferred. Freezing is for reproducibility, not because the term is correct.
 
 Inputs:
 - predictions: JSON list (e.g. a decomposer run's results.json) of items like
@@ -73,6 +88,17 @@ from step_lines import split_step_lines  # noqa: E402
 
 _WS_RX = re.compile(r"\s+")
 _PUNCT_KEEP_HASH_RX = re.compile(r"[^\w\s#]")
+
+#: FROZEN, deliberately not repaired. It matches only the **bracketed** ``[#k]``; MuSiQue's
+#: gold writes bare ``#k``, so ``reference_validity_*`` — and through it the legacy
+#: ``composite_score`` — has never measured reference validity on this data (issue #40).
+#: The specification's §5 verdict is freeze-don't-fix, for two reasons kept together here:
+#: correcting the regex would move every committed number under an unchanged name, and even
+#: a corrected regex would still be a micro-pooled rate with a **model-dependent
+#: denominator** inside an aggregate-of-aggregates — the defect *class*, not just this
+#: instance. The replacement is per-item ``chain_validity`` (:data:`_BARE_REF_RX`), which is
+#: term 4 of the reported suite. Do not "fix" this line: doing so silently invalidates
+#: exp-010's 33 sweep cells and nine committed arms. ADR 0029.
 _REF_RX = re.compile(r"\[#(\d+)\]")
 
 #: Written into every metrics JSON. A number like "step F1 0.42" is meaningless without
@@ -200,6 +226,20 @@ METRIC_DEFINITIONS: dict[str, Any] = {
     ),
     "over_decomposition_rate": "fraction of rows with len(pred steps) > len(gold steps)",
     "under_decomposition_rate": "fraction of rows with len(pred steps) < len(gold steps)",
+    "over_decomposition": (
+        "per item: 1.0 when len(pred steps) > len(gold steps), else 0.0 — the 0/1 column "
+        "over_decomposition_rate is the mean of. It exists so the ADR 0017 asymmetry "
+        "('over-decomposition is tolerable, under-decomposition is not') can be "
+        "SIGNIFICANCE-TESTED: until this column existed the two rates were aggregate-only, "
+        "so no paired test could be run on either"
+    ),
+    "under_decomposition": (
+        "per item: 1.0 when len(pred steps) < len(gold steps), else 0.0. Both direction "
+        "columns are lower-is-better (a length error is an error either way); ADR 0017's "
+        "asymmetry is about how BADLY each is scored by a reader, not about the sign, and "
+        "the specification keeps the two rates split and never summed for exactly that "
+        "reason"
+    ),
     "step_count_exact_rate": (
         "fraction of rows with len(pred steps) == len(gold steps), i.e. exactly "
         "1 - over_decomposition_rate - under_decomposition_rate. NOT the same as "
@@ -221,11 +261,49 @@ METRIC_DEFINITIONS: dict[str, Any] = {
         "gold 'hop_count' field when present and positive, else the gold step count"
     ),
     "composite_score": (
-        "weighted sum of step_f1_macro, ordered_step_accuracy_macro, "
-        "reference_validity_micro and a step-count term "
+        "LEGACY — see composite_score_status. Weighted sum of step_f1_macro, "
+        "ordered_step_accuracy_macro, reference_validity_micro and a step-count term "
         "max(0, 1 - step_count_abs_error_mae / scale); the weights and scale are "
         "recorded alongside as composite_score_weights and "
         "composite_step_count_error_scale"
+    ),
+    "composite_score_status": (
+        "'legacy'. The composite is FROZEN, byte-identical to the form every committed "
+        "number was produced under, and it is NOT the reported primary — "
+        "decomposition_report_card is. Frozen rather than repaired because its "
+        "reference_validity_micro term is a micro-pooled rate with a MODEL-DEPENDENT "
+        "denominator inside an aggregate-of-aggregates: repairing the regex would move "
+        "every committed value under an unchanged name while leaving the defect class in "
+        "place. It is still computed and still reported so nine committed arms and "
+        "exp-010's 33 sweep cells stay quotable"
+    ),
+    "decomposition_report_card": (
+        "the reported primary: an UNBLENDED six-term suite, each term a macro mean over "
+        "every evaluated item, each carrying its direction and the n it was averaged over. "
+        "No term is a ratio pooled across items, which is the structural fix for the issue "
+        "#40 defect class, and the block is asserted to be macro at build time. Whether any "
+        "of this becomes the THESIS-primary metric is issue #6 item 5 — Jahid's with his "
+        "supervisor. This file specifies and reports; it does not adopt"
+    ),
+    "decomp_mean": (
+        "the blended CONTINGENCY of the specification's §2.3 (P3), not a member of the "
+        "suite: per item, the unweighted mean of five [0,1] higher-is-better terms — "
+        "break_exact_match, sari, 1 - min(ged_clamp, ged), chain_validity and "
+        "hop_count_exact_match. Equal weights, no weighted variant (GLUE's unweighted "
+        "average is the only weighting form with a precedent; an unequal weighting would "
+        "need a Dynascore-style unit conversion nothing here estimates). It is per item, so "
+        "unlike composite_score it takes the full paired battery. It is reported ONLY "
+        "beside the suite, never instead of it, and it shipped only because the junk "
+        "battery of scripts/decomposition_junk_battery.py measured every junk baseline "
+        "below every real arm on it"
+    ),
+    "chain_validity_gold_unchained_items": (
+        "count of evaluated items whose GOLD emits no '#k' reference at all. That is "
+        "chain_validity's one conditional-credit branch (such an item scores 1.0 for free), "
+        "and it is conditioned on the gold, so no model can trigger it. On the ADR 0007 "
+        "pinned 600 it is 0 by construction — every gold decomposition is a tree with n-1 "
+        "references — but MetaQA or any future gold could reintroduce free credit silently, "
+        "which is exactly how issue #40 happened. The count makes it visible instead"
     ),
     "lower_is_better_statistics": (
         "the per-item metric names in this report where a LOWER value is better; every "
@@ -252,10 +330,18 @@ COMPARISON_DEFINITIONS: dict[str, Any] = {
     "difference_direction": "every reported difference is system_a minus system_b",
     "metric_direction": (
         "every row carries 'direction': 'higher_is_better' for a score, 'lower_is_better' "
-        "for a distance. Exactly one compared metric is a distance today — 'ged', Break's "
-        "normalized graph edit distance — so a difference of -0.16 there means system_a is "
-        "BETTER, the opposite of what the same number means on every other row. The names "
-        "are also listed in 'lower_is_better_statistics'"
+        "for a distance or an error rate. Three compared metrics are lower-is-better today — "
+        "'ged' (Break's normalized graph edit distance) and the two length-error rates "
+        "'under_decomposition' and 'over_decomposition' — so a difference of -0.16 on one of "
+        "them means system_a is BETTER, the opposite of what the same number means on every "
+        "other row. The names are also listed in 'lower_is_better_statistics'"
+    ),
+    "over_and_under_decomposition_are_a_pair": (
+        "the two length-error rates are reported side by side and are NEVER summed: ADR 0017 "
+        "records the supervisor's judgment that over-decomposition is tolerable and "
+        "under-decomposition is not, and a single 'wrong length' figure erases exactly that. "
+        "Both are lower-is-better; the asymmetry is in how heavily a reader weighs them, not "
+        "in their sign"
     ),
     "favours": (
         "for a SIGNIFICANT row, which system the difference favours once 'direction' is "
@@ -318,8 +404,14 @@ COMPARISON_DEFINITIONS: dict[str, Any] = {
         "composite_score, plus the McNemar metrics. composite_score has no per-item "
         "value (its reference term is a micro rate and its step-count term a MAE), so no "
         "paired difference exists to t-test and only its bootstrap CI is reported. This is "
-        "the asymmetry issue #40 turns on: the additive per-item metrics (sari, ged, "
-        "chain_validity, break_exact_match) take all three tests, the composite one"
+        "the asymmetry issue #40 turns on: every term of the reported suite (break_exact_match, "
+        "sari, ged, chain_validity, hop_count_exact_match, over/under_decomposition) takes all "
+        "three tests, the LEGACY composite one"
+    ),
+    "composite_score_status": (
+        "'legacy'. It is still compared, unchanged, so a comparison against a committed "
+        "number stays possible; the reported primary is the six-term suite, whose terms are "
+        "compared in the same battery on the rows above"
     ),
     "t_test_degenerate_rows": (
         "a row carries t_statistic = null, p_value = null, significant = false and a "
@@ -450,7 +542,15 @@ def _load_gold(path: Path, max_reported_mismatches: int) -> dict[str, dict[str, 
         else:
             # No usable field: the two denominators are the same number by construction.
             hop_count = len(steps)
-        out[_normalize_question(question)] = {"steps": steps, "hop_count": hop_count}
+        # 'question' is the RAW text; the key is its normalized form. Scoring reads only
+        # 'steps' and 'hop_count', so this is an additive field — it exists so a caller that
+        # builds predictions out of the gold (the junk battery) can use the question the
+        # dataset actually wrote rather than the lowercased key.
+        out[_normalize_question(question)] = {
+            "question": question,
+            "steps": steps,
+            "hop_count": hop_count,
+        }
 
     if mismatches:
         shown = mismatches[:max_reported_mismatches]
@@ -1059,6 +1159,91 @@ def _build_eval_rows(
     return rows, missing_gold
 
 
+def score_item(
+    row: EvalRow,
+    ged_max_nodes: int,
+    ged_time_budget: float,
+    decomp_mean_components: tuple[str, ...],
+    ged_clamp: float,
+) -> dict[str, Any]:
+    """Every per-item column for one evaluation row.
+
+    Lifted out of ``main()`` unchanged so that the junk battery
+    (``scripts/decomposition_junk_battery.py``) scores its baselines with **this** code and
+    not a second copy of the metric — the same reason the GED benchmark imports its metric
+    functions from here. Nothing in the extraction changes a value: the body is the loop that
+    was inline, plus the three columns the suite registration added.
+    """
+    step_p, step_r, step_f1 = _step_prf(row.pred_steps, row.gold_steps)
+    rouge_lp, rouge_lr, rouge_lf = _rouge_l(
+        _join_steps(row.pred_steps), _join_steps(row.gold_steps)
+    )
+    ref_rate, ref_ok, ref_total = _reference_validity(row.pred_steps)
+    chain_valid, chain_pred_refs, chain_gold_refs = _chain_validity(
+        row.pred_steps, row.gold_steps
+    )
+    pred_break = _break_steps(row.pred_steps)
+    gold_break = _break_steps(row.gold_steps)
+    pred_break_string = _break_string(pred_break)
+    gold_break_string = _break_string(gold_break)
+    ged, ged_fallback, ged_fallback_seconds = _normalized_ged(
+        _decomposition_graph(pred_break),
+        _decomposition_graph(gold_break),
+        max_nodes_for_optimizer=ged_max_nodes,
+        time_budget_seconds=ged_time_budget,
+    )
+    pred_hops = len(row.pred_steps)
+    gold_hops = row.gold_hop_count
+    signed = len(row.pred_steps) - len(row.gold_steps)
+
+    item_row = {
+        "item_id": row.item_id,
+        "question": row.question,
+        "pred_steps": row.pred_steps,
+        "gold_steps": row.gold_steps,
+        "pred_step_count": len(row.pred_steps),
+        "gold_step_count": len(row.gold_steps),
+        "exact_match": _exact_decomposition_match(row.pred_steps, row.gold_steps),
+        "step_precision": step_p,
+        "step_recall": step_r,
+        "step_f1": step_f1,
+        "ordered_step_accuracy": _ordered_step_accuracy(row.pred_steps, row.gold_steps),
+        "rouge_l_precision": rouge_lp,
+        "rouge_l_recall": rouge_lr,
+        "rouge_l_f1": rouge_lf,
+        "reference_validity_rate": ref_rate,
+        "reference_valid_count": ref_ok,
+        "reference_total_count": ref_total,
+        # The issue #40 additions. chain_validity is the repaired house term; the other
+        # three are the official Break leaderboard metrics (EM / SARI / GED).
+        "chain_validity": chain_valid,
+        "chain_pred_reference_count": chain_pred_refs,
+        "chain_gold_reference_count": chain_gold_refs,
+        "break_exact_match": _break_exact_match(pred_break_string, gold_break_string),
+        "sari": _sari(row.question, pred_break_string, gold_break_string),
+        "ged": ged,
+        "ged_fallback": ged_fallback,
+        # Null except where the time budget stopped the optimizer, which is the one
+        # machine-dependent path: the elapsed seconds are recorded so a reader can see
+        # how far past the budget that item ran (the deadline is only tested between
+        # approximations, so it can overshoot).
+        "ged_fallback_seconds": ged_fallback_seconds,
+        "step_count_signed_error": signed,
+        "step_count_abs_error": abs(signed),
+        # The two direction columns the suite registration added: the 0/1 per-item form of
+        # the rates that were aggregate-only, so the ADR 0017 asymmetry can be tested.
+        "over_decomposition": 1.0 if signed > 0 else 0.0,
+        "under_decomposition": 1.0 if signed < 0 else 0.0,
+        "predicted_hop_count": pred_hops,
+        "gold_hop_count": gold_hops,
+        "hop_count_abs_error": abs(pred_hops - gold_hops),
+        "hop_count_exact_match": 1.0 if pred_hops == gold_hops else 0.0,
+    }
+    # Last, because it is a function of the columns above it.
+    item_row["decomp_mean"] = decomp_mean(item_row, decomp_mean_components, ged_clamp)
+    return item_row
+
+
 _EMPTY_AGGREGATE = {
     "num_rows": 0,
     "exact_match_rate": 0.0,
@@ -1072,6 +1257,8 @@ _EMPTY_AGGREGATE = {
     "reference_validity_macro": 0.0,
     "reference_validity_micro": 1.0,
     "chain_validity_macro": 0.0,
+    "chain_validity_gold_unchained_items": 0,
+    "decomp_mean_macro": 0.0,
     "break_exact_match_rate": 0.0,
     "sari_macro": 0.0,
     # 0.0 like every other placeholder in this block, even though a GED of 0.0 would read as
@@ -1131,6 +1318,15 @@ def _aggregate(items: list[dict[str, Any]]) -> dict[str, Any]:
         # The additive metrics of issue #40. All four are per-item values, so all four are
         # plain macro averages and all four are in the paired battery.
         "chain_validity_macro": mean("chain_validity"),
+        # chain_validity's one conditional-credit branch, counted rather than argued: an item
+        # whose GOLD emits no reference scores 1.0 for free. 0 on the pinned 600 by
+        # construction, but a future gold could reintroduce free credit silently, which is
+        # exactly how issue #40 happened (specification §2.5 item 2).
+        "chain_validity_gold_unchained_items": sum(
+            1 for it in items if int(it["chain_gold_reference_count"]) == 0
+        ),
+        # The blended CONTINGENCY, beside the suite and not inside it.
+        "decomp_mean_macro": mean("decomp_mean"),
         "break_exact_match_rate": mean("break_exact_match"),
         "sari_macro": mean("sari"),
         "ged_macro": mean("ged"),
@@ -1172,11 +1368,22 @@ BOOTSTRAP_STATISTICS = (
     "sari",
     "ged",
     "chain_validity",
+    # The blended contingency (§2.3). Per item, so unlike composite_score it takes all
+    # three tests; reported beside the suite, never as the suite.
+    "decomp_mean",
     "composite_score",
 )
 
-#: Binary per-item metrics compared with McNemar.
-MCNEMAR_STATISTICS = ("exact_match", "hop_count_exact_match", "break_exact_match")
+#: Binary per-item metrics compared with McNemar. The two direction columns joined it with
+#: the suite registration: the ADR 0017 asymmetry could not be significance-tested while the
+#: over/under rates were aggregate-only (specification §2.5 item 1).
+MCNEMAR_STATISTICS = (
+    "exact_match",
+    "hop_count_exact_match",
+    "break_exact_match",
+    "over_decomposition",
+    "under_decomposition",
+)
 
 #: Compared statistics that are a plain mean of a per-item column. Everything in
 #: :data:`BOOTSTRAP_STATISTICS` except ``composite_score``, which is built from aggregates.
@@ -1195,7 +1402,16 @@ _COMPOSITE_INPUT_COLUMNS = (
 #: higher-is-better, so a reader who does not know which is which can invert a verdict: a
 #: difference of -0.16 on ``ged`` means system_a is BETTER. Every reported row therefore
 #: carries ``direction``, and every significant row names the system it ``favours``.
-LOWER_IS_BETTER_STATISTICS = ("ged",)
+#:
+#: ``ged`` is a distance. The two direction columns are here because a length error is an
+#: error in either direction — the specification's §2.1 prints the pair as "under ↓, over ↓
+#: but tolerated". §2.5 item 1 names only ``under_decomposition``; ``over_decomposition`` is
+#: registered with it because the alternative is worse: left out, every comparison row would
+#: be stamped ``higher_is_better`` and ``favours`` would name the wrong system on it. The
+#: ADR 0017 asymmetry (over is tolerable, under is not) is about how heavily a reader should
+#: weigh the two, not about their sign, and it is carried by keeping the two rates split and
+#: never summed — never by calling more over-decomposition better.
+LOWER_IS_BETTER_STATISTICS = ("ged", "under_decomposition", "over_decomposition")
 
 #: Per-item metrics this script gained with issue #40. They are required of a v2 per-item
 #: file (they are computed by default) but cannot exist in a v1 prior-work file, which
@@ -1203,14 +1419,467 @@ LOWER_IS_BETTER_STATISTICS = ("ged",)
 #: records which ones it could not compute.
 _ISSUE_40_STATISTICS = ("sari", "ged", "chain_validity", "break_exact_match")
 
+#: Per-item columns this script gained with the six-term suite registration (ADR 0029).
+#: They are computed on every scoring run — there is no switch — but they are **not**
+#: required of a per-item file being compared, for the same reason the issue #40 columns are
+#: not required of a v1 file: nine committed arms and exp-010's 33 sweep cells were scored
+#: before these columns existed, and requiring them would refuse those files outright rather
+#: than comparing what they do carry. What is missing is named in the output
+#: (``statistics_not_available_in_inputs``), never silently dropped.
+_SUITE_ADDITION_STATISTICS = ("over_decomposition", "under_decomposition", "decomp_mean")
+
 #: Statistics a paired t-test is reported on, added alongside the two families above per
 #: ADR 0017 item 4 / issue #30 (never as a replacement). It is every compared metric that
 #: HAS a per-item value: the bootstrap statistics minus ``composite_score``, whose
 #: reference term is a micro rate and step-count term a MAE, so no per-item difference to
-#: t-test exists, plus the two binary McNemar metrics (which do have one).
+#: t-test exists, plus the binary McNemar metrics (which do have one). Every term of the
+#: reported suite has a per-item value, so every one of them is in here — the asymmetry
+#: issue #40 turns on is now the composite's alone.
 T_TEST_STATISTICS = (
     tuple(name for name in BOOTSTRAP_STATISTICS if name != "composite_score") + MCNEMAR_STATISTICS
 )
+
+
+# --------------------------------------------------------------------------------------
+# The reported primary: the six-term suite (specification §2.1; ADR 0029)
+# --------------------------------------------------------------------------------------
+# Registration, not new metric mathematics: all six terms were already computed at the
+# commit the specification was written against. What this block adds is that they are named
+# as one reported object, in one order, each with its direction, its range, its per-item
+# column and the n it was averaged over — so a note or a table cannot quote three of them
+# and call that the metric.
+
+
+@dataclass(frozen=True)
+class SuiteTerm:
+    """One reported term of ``decomposition_report_card``."""
+
+    #: 1-6. Term 6 is a PAIR of members (over/under), which is why this is not the index.
+    number: int
+    #: The key in the metrics JSON.
+    aggregate_key: str
+    #: The per-item column the aggregate is the plain mean of.
+    per_item_column: str
+    #: ``[0,1]``, ``{0,1}`` or ``[0,inf)`` — GED is a distance and is not bounded above.
+    value_range: str
+    #: What the term prices, in the specification's words.
+    prices: str
+    #: ``literature`` (Break's own metric set) or ``house`` (a repair or a house term).
+    provenance: str
+
+
+#: The six terms, in the specification's order. All six are ALWAYS reported together: a
+#: report that quotes fewer than six is not reporting this metric (§2.1 reporting rule 1).
+DECOMPOSITION_SUITE_TERMS: tuple[SuiteTerm, ...] = (
+    SuiteTerm(
+        1,
+        "break_exact_match_rate",
+        "break_exact_match",
+        "{0,1}",
+        "whole-plan verbatim identity of the '@@SEP@@'-joined string, lowercased",
+        "literature: Break official get_exact_match",
+    ),
+    SuiteTerm(
+        2,
+        "sari_macro",
+        "sari",
+        "[0,1]",
+        "n-gram edit quality vs the question: kept-F1, added-F1, deleted-precision, n = 1..4",
+        "literature: Break / Xu et al. (TACL 2016)",
+    ),
+    SuiteTerm(
+        3,
+        "ged_macro",
+        "ged",
+        "[0,inf)",
+        "one distance over wording (node substitution), chaining (edges) and step count "
+        "(node insertion/deletion)",
+        "literature: Break official normalized graph edit distance",
+    ),
+    SuiteTerm(
+        4,
+        "chain_validity_macro",
+        "chain_validity",
+        "[0,1]",
+        "did the plan chain where the gold requires chaining, and do its '#k' resolve "
+        "backwards",
+        "house repair, not a published metric (PR #44 / ADR 0026)",
+    ),
+    SuiteTerm(
+        5,
+        "hop_count_exact_match_rate",
+        "hop_count_exact_match",
+        "{0,1}",
+        "granularity: the right number of steps",
+        "house",
+    ),
+    SuiteTerm(
+        6,
+        "under_decomposition_rate",
+        "under_decomposition",
+        "{0,1}",
+        "a length error in the direction the supervisor judged NOT tolerable (ADR 0017)",
+        "house, required by ADR 0017",
+    ),
+    SuiteTerm(
+        6,
+        "over_decomposition_rate",
+        "over_decomposition",
+        "{0,1}",
+        "a length error in the direction the supervisor judged tolerable (ADR 0017)",
+        "house, required by ADR 0017",
+    ),
+)
+
+#: The one term the specification's §2.2 names where a single ordering number is
+#: structurally required (ranking the 33-cell sweep, model selection, an abstract sentence).
+#: It is a MEMBER of the suite, never a function over it.
+SUITE_SINGLE_NUMBER = "ged_macro"
+
+#: The three caveats that travel with :data:`SUITE_SINGLE_NUMBER` every time it is quoted.
+#: They are emitted with the number, not kept in a doc, because the number is what gets
+#: pasted into a table.
+SUITE_SINGLE_NUMBER_CAVEATS = (
+    "LOWER IS BETTER - it is a distance, where terms 1, 2, 4 and 5 are scores; the only "
+    "other lower-is-better terms are the two length-error rates of term 6.",
+    "It is order-light, and on a 2-step plan order-BLIND (a reversed gold can score better "
+    "than a real arm), which is why terms 1, 5 and 6 must stay reported beside it.",
+    "Absolute values are NOT comparable to published Break GED: this port has no spaCy "
+    "lemmatizer in the node substitution cost (ADR 0026 item 3), and it scores against "
+    "MuSiQue gold rather than QDMR annotations.",
+)
+
+#: What the junk battery measured about ``decomp_mean``, emitted with the number. The blend
+#: ships **only** because this gate passed: an additive blend containing SARI hands junk a
+#: nonzero floor, which is the same failure family as issue #40, so a junk baseline ranking
+#: above a real arm disqualifies the blend rather than prompting a weight tweak.
+#: Re-derive with ``scripts/decomposition_junk_battery.py`` (ADR 0027, ADR 0029).
+DECOMP_MEAN_JUNK_GATE = (
+    "GATE PASSED on the ADR 0007 pinned 600 (all 15 rows on the same 600 items): the best "
+    "junk baseline scored decomp_mean 0.1412 (J4, three fixed steps) against a real-arm worst "
+    "of 0.5085 (exp005 unguided / unguided_capped), a margin of +0.3673, and every one of "
+    "J1-J4 ranked below every one of the nine committed arms. Re-derive with "
+    "scripts/decomposition_junk_battery.py; the table is in ADR 0029."
+)
+
+#: ``composite_score``'s status, emitted beside it in every metrics JSON. See the
+#: ``composite_score_status`` entry of :data:`METRIC_DEFINITIONS` for the reasoning and
+#: :data:`_REF_RX` for the thing that is frozen.
+COMPOSITE_SCORE_STATUS = "legacy"
+
+#: Terms forbidden from the reported suite, with the reason. ``reference_validity_micro`` is
+#: the instance that motivated the rule (issue #40); the rule is the general one — no
+#: headline term may be a ratio whose DENOMINATOR is produced by the model, because an item
+#: that emits nothing then vanishes from the denominator instead of scoring badly.
+_FORBIDDEN_IN_SUITE = {
+    "reference_validity_micro": (
+        "a ratio pooled across items whose denominator is produced by the model: on five of "
+        "seven committed arms it was empty and scored 1.0 by rule, and on the other two, 2 "
+        "of 600 items owned the whole denominator (issue #40)"
+    ),
+    "composite_score": (
+        "an aggregate-of-aggregates with no per-item value, so it takes 1 of the 3 tests in "
+        "the ADR 0009 battery; it is frozen as legacy and reported separately"
+    ),
+}
+
+
+#: The component names :func:`_decomp_mean_terms` can build. Declared beside it so the
+#: config validation and the function cannot drift; a test pins that they agree.
+DECOMP_MEAN_KNOWN_COMPONENTS = (
+    "break_exact_match",
+    "sari",
+    "ged",
+    "chain_validity",
+    "hop_count_exact_match",
+)
+
+
+def _decomp_mean_terms(item: dict[str, Any], ged_clamp: float) -> dict[str, float]:
+    """The [0,1] higher-is-better terms ``decomp_mean`` averages, per item.
+
+    One entry per component name the config may list. GED is the only one that needs work:
+    it is a distance, it is unbounded above (measured above 1.0 for junk), so it is clamped
+    and flipped. The clamp is a judgment call with no source — recorded as such in ADR 0029
+    and in the config's note — which is one reason this blend is a contingency and not a
+    member of the suite.
+    """
+    return {
+        "break_exact_match": float(item["break_exact_match"]),
+        "sari": float(item["sari"]),
+        "ged": 1.0 - min(ged_clamp, float(item["ged"])),
+        "chain_validity": float(item["chain_validity"]),
+        "hop_count_exact_match": float(item["hop_count_exact_match"]),
+    }
+
+
+def decomp_mean(item: dict[str, Any], components: tuple[str, ...], ged_clamp: float) -> float:
+    """The specification's §2.3 blend: the UNWEIGHTED mean of ``components``, per item.
+
+    Equal weights, no weighted variant: GLUE's unweighted average is the only weighting form
+    this survey found a precedent for, and an unequal weighting would need a Dynascore-style
+    unit conversion that nothing in this repo estimates.
+    """
+    available = _decomp_mean_terms(item, ged_clamp)
+    return sum(available[name] for name in components) / len(components)
+
+
+def _decomp_mean_policy(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Read the blend's component list and GED clamp from config, and validate them loudly.
+
+    Both live in the config rather than in this file so a run's snapshot records the blend it
+    was scored under — exactly as the legacy composite's weights do.
+    """
+    raw_components = require(cfg, "decomposition_suite.decomp_mean.components")
+    clamp = require(cfg, "decomposition_suite.decomp_mean.ged_clamp")
+
+    known = DECOMP_MEAN_KNOWN_COMPONENTS
+    if (
+        not isinstance(raw_components, list)
+        or not raw_components
+        or any(not isinstance(c, str) for c in raw_components)
+    ):
+        raise SystemExit(
+            "decomposition_suite.decomp_mean.components must be a non-empty list of per-item "
+            f"column names, got {raw_components!r}"
+        )
+    unknown = [c for c in raw_components if c not in known]
+    if unknown:
+        raise SystemExit(
+            f"decomposition_suite.decomp_mean.components names column(s) this blend cannot "
+            f"build: {unknown}. Known components: {sorted(known)}. Every component must be a "
+            f"per-item value in [0,1] and higher-is-better; adding one means adding its "
+            f"conversion to _decomp_mean_terms, not just a name to the config."
+        )
+    if len(set(raw_components)) != len(raw_components):
+        raise SystemExit(
+            f"decomposition_suite.decomp_mean.components lists a component twice: "
+            f"{raw_components}. A repeated component is an unequal weighting written as an "
+            f"equal one, and this blend has no weighted variant."
+        )
+    if (
+        isinstance(clamp, bool)
+        or not isinstance(clamp, (int, float))
+        or not (0.0 < float(clamp) <= 1.0)
+    ):
+        raise SystemExit(
+            f"decomposition_suite.decomp_mean.ged_clamp must be a number in (0, 1], got "
+            f"{clamp!r}. GED is unbounded above, so the blend clamps it before flipping "
+            f"direction (1 - min(clamp, ged)); a clamp above 1 would make the term negative "
+            f"and take the blend out of [0,1]."
+        )
+    return {
+        "components": list(raw_components),
+        "ged_clamp": float(clamp),
+        "formula": (
+            "per item, the unweighted mean over the components of: break_exact_match, sari, "
+            "1 - min(ged_clamp, ged), chain_validity, hop_count_exact_match"
+        ),
+        "weights": "all equal by construction; there is no weighted variant",
+        "status": (
+            "CONTINGENCY, not part of the reported suite. Offered only against a requirement "
+            "for one blended number, reported beside the suite and never instead of it"
+        ),
+        "junk_gate": DECOMP_MEAN_JUNK_GATE,
+    }
+
+
+#: The five reporting rules of the specification's §2.1 that are part of the metric rather
+#: than decoration. Emitted with the numbers so a table built from this file carries them.
+_SUITE_REPORTING_RULES = (
+    "All six terms are always reported together, with their direction. A note or table that "
+    "quotes fewer than six is not reporting this metric.",
+    "Every comparison carries the ADR 0009 battery PER TERM (paired bootstrap CI, paired "
+    "t-test, and McNemar for the binary terms 1, 5 and 6). Every term has a per-item value, "
+    "so the legacy composite's 1-of-3-tests weakness does not apply to any of them.",
+    "Report per gold hop depth as well as overall (per_gold_hop_metrics carries the whole "
+    "block).",
+    "Report a junk-baseline block beside the arms — Break prints its own 'Copy' baseline in "
+    "its results table. The battery is scripts/decomposition_junk_battery.py, and its "
+    "acceptance criteria are tests in tests/test_decomposition_metrics.py.",
+    "Composite terms with model-dependent denominators are forbidden in the headline; "
+    "reference_validity_micro is the instance that motivated the rule.",
+)
+
+#: Term 6 is a pair, and the pair is the point: ADR 0017 records the supervisor's judgment
+#: that over-decomposition is tolerable and under-decomposition is not. No metric in the
+#: survey expresses that asymmetry, so it is carried by reporting the two rates separately.
+_SUITE_PAIR_RULE = (
+    "Terms 6a and 6b (under_decomposition_rate, over_decomposition_rate) are reported as a "
+    "PAIR and never summed: ADR 0017 records that over-decomposition is tolerable and "
+    "under-decomposition is not, and summing them would erase exactly that. "
+    "step_count_exact_rate is 1 - the two of them and is reported separately."
+)
+
+
+#: How far a suite aggregate may sit from the mean of its column before the run is refused.
+#: It exists only to absorb float summation order; the two are computed from the same values.
+_SUITE_MACRO_TOLERANCE = 1e-12
+
+
+def _assert_suite_terms_are_macro_means(
+    overall: dict[str, Any], per_item: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Refuse to report a suite term that is not the plain mean of its per-item column.
+
+    The structural guard behind the whole specification: the issue #40 defect was a headline
+    term pooled across items with a model-produced denominator, and "every term is a macro
+    mean over the evaluation set" is the property that makes it impossible. Argued, that
+    property is a claim; checked here against the columns actually written, it is auditable.
+    """
+    tolerance = _SUITE_MACRO_TOLERANCE
+    n = len(per_item)
+    checked: dict[str, int] = {}
+    broken: list[str] = []
+    for term in DECOMPOSITION_SUITE_TERMS:
+        column = [float(row[term.per_item_column]) for row in per_item]
+        expected = sum(column) / n if n else 0.0
+        actual = float(overall[term.aggregate_key])
+        checked[term.aggregate_key] = n
+        if abs(actual - expected) > tolerance:
+            broken.append(
+                f"{term.aggregate_key} = {actual!r} but the mean of its per-item column "
+                f"'{term.per_item_column}' over {n} items is {expected!r}"
+            )
+    if broken:
+        raise SystemExit(
+            "a reported suite term is not the macro mean of its per-item column:\n  "
+            + "\n  ".join(broken)
+            + "\nEvery term of decomposition_report_card must be averaged over a "
+            "denominator fixed by the EVALUATION SET, not by what the model emitted "
+            "(specification §3.1). A term that is not is the issue #40 defect class."
+        )
+    for name in _FORBIDDEN_IN_SUITE:
+        if any(term.aggregate_key == name for term in DECOMPOSITION_SUITE_TERMS):
+            raise SystemExit(
+                f"{name!r} is registered as a suite term, and it must not be: "
+                f"{_FORBIDDEN_IN_SUITE[name]}"
+            )
+    return {
+        "every_term_is_the_macro_mean_of_its_per_item_column": True,
+        "items_per_term": checked,
+        "tolerance": tolerance,
+        "terms_excluded_and_why": dict(_FORBIDDEN_IN_SUITE),
+    }
+
+
+def _report_card(
+    overall: dict[str, Any],
+    per_item: list[dict[str, Any]],
+    decomp_mean_policy: dict[str, Any],
+    composite_score: float,
+) -> dict[str, Any]:
+    """Build ``decomposition_report_card``: the reported primary, as one object.
+
+    Registration and reporting, not new mathematics — every value here is read out of
+    ``overall``, which computed it exactly as it did before this block existed.
+    """
+    n = len(per_item)
+    return {
+        "name": "decomposition_report_card",
+        "specification": (
+            "docs/analysis/2026-08-23-decomposition-quality-metric-specification.md §2.1; "
+            "ADR 0029"
+        ),
+        "shape": "an UNBLENDED suite of six terms — there is no composite over them",
+        "n_items": n,
+        "denominator": (
+            "every term is a macro mean over the evaluated items; no term is a ratio pooled "
+            "across items, and no denominator depends on what the model emitted"
+        ),
+        "terms": [
+            {
+                "term": term.number,
+                "metric": term.aggregate_key,
+                "per_item_column": term.per_item_column,
+                "value": float(overall[term.aggregate_key]),
+                "direction": _direction(term.per_item_column),
+                "range": term.value_range,
+                "prices": term.prices,
+                "provenance": term.provenance,
+                "n_items": n,
+            }
+            for term in DECOMPOSITION_SUITE_TERMS
+        ],
+        "paired_terms_rule": _SUITE_PAIR_RULE,
+        "reporting_rules": list(_SUITE_REPORTING_RULES),
+        "single_number_when_one_is_required": {
+            "metric": SUITE_SINGLE_NUMBER,
+            "value": float(overall[SUITE_SINGLE_NUMBER]),
+            "direction": _direction("ged"),
+            "why_a_member_and_not_a_formula": (
+                "the field's own precedent for a single number is one member of the family "
+                "made stricter (Break/QDMR's NormEM) or one strict column selected on "
+                "(EntailmentBank), never a blend over the family"
+            ),
+            "caveats": list(SUITE_SINGLE_NUMBER_CAVEATS),
+        },
+        "contingency_blend": {
+            "metric": "decomp_mean_macro",
+            "per_item_column": "decomp_mean",
+            "value": float(overall["decomp_mean_macro"]),
+            "direction": _direction("decomp_mean"),
+            "in_the_suite": False,
+            **decomp_mean_policy,
+        },
+        "guards": _assert_suite_terms_are_macro_means(overall, per_item),
+        "adoption": (
+            "NOT ADOPTED HERE. Whether this suite (or any part of it) becomes the "
+            "THESIS-primary metric is issue #6 item 5 — Jahid's decision with his "
+            "supervisor. This script specifies and reports; it does not adopt"
+        ),
+        "legacy_composite": {
+            "metric": "composite_score",
+            "status": COMPOSITE_SCORE_STATUS,
+            "value": float(composite_score),
+            "why_it_is_still_computed": (
+                "frozen byte-identical so nine committed arms, exp-010's 33 sweep cells and "
+                "both v1 re-analysis notes stay valid and quotable — for reproducibility, "
+                "not because the term is correct"
+            ),
+        },
+    }
+
+
+def _report_card_note_lines(report_card: dict[str, Any]) -> list[str]:
+    """The report card as the run note prints it — all six terms, with their directions.
+
+    The run note is what gets quoted into ``experiments/log.md``, so the whole suite has to
+    be readable off it: a note that carries three of the six is not reporting this metric
+    (§2.1 reporting rule 1), and the ⇑/⇓ column is Break's own convention.
+    """
+    numbered = len({term["term"] for term in report_card["terms"]})
+    lines = [
+        f"### Decomposition report card — the reported primary "
+        f"({numbered} terms in {len(report_card['terms'])} rows — term 6 is a pair — "
+        f"over n = {report_card['n_items']} items)",
+        "",
+        "| # | term | value | better | range | provenance |",
+        "|---|---|---|---|---|---|",
+    ]
+    for term in report_card["terms"]:
+        better = "lower ⇓" if term["direction"] == "lower_is_better" else "higher ⇑"
+        lines.append(
+            f"| {term['term']} | `{term['metric']}` | {term['value']:.4f} | {better} | "
+            f"{term['range']} | {term['provenance']} |"
+        )
+    single = report_card["single_number_when_one_is_required"]
+    blend = report_card["contingency_blend"]
+    lines += [
+        "",
+        f"- **Unblended by design.** There is no composite over these six; "
+        f"{report_card['denominator']}.",
+        f"- {report_card['paired_terms_rule']}",
+        f"- Where ONE number is structurally required: `{single['metric']}` = "
+        f"{single['value']:.4f} ({single['direction']}). Caveats that travel with it: "
+        + " ".join(single["caveats"]),
+        f"- Contingency blend (NOT part of the suite): `{blend['metric']}` = "
+        f"{blend['value']:.4f}, the unweighted mean of {len(blend['components'])} per-item "
+        f"terms {blend['components']} with GED clamped at {blend['ged_clamp']}. "
+        f"{blend['junk_gate']}",
+        f"- {report_card['adoption']} (issue #6 item 5).",
+    ]
+    return lines
 
 #: Top-level shape of ``<prefix>_per_item.json``. It is an object rather than a bare list
 #: because the composite-score weights the rows were scored under have to travel with them:
@@ -1228,7 +1897,7 @@ _REQUIRED_PER_ITEM_FIELDS = (
     "reference_valid_count",
     "reference_total_count",
     "step_count_abs_error",
-    *MCNEMAR_STATISTICS,
+    *(n for n in MCNEMAR_STATISTICS if n not in _SUITE_ADDITION_STATISTICS),
     *(n for n in _ISSUE_40_STATISTICS if n not in MCNEMAR_STATISTICS),
 )
 
@@ -2199,6 +2868,7 @@ def _compare(
         "v1_format_inputs": v1_inputs,
         "composite_score_weights": weights,
         "composite_step_count_error_scale": scale,
+        "composite_score_status": COMPOSITE_SCORE_STATUS,
         "per_item_composite_score_weights": per_item_weights,
         "per_item_composite_step_count_error_scale": per_item_scale,
         "config_weights_match_per_item_files": weights_match_config,
@@ -2299,10 +2969,17 @@ def _compare(
         )
     note_lines.append("")
     note_lines.append(
-        "- The `better` column is the metric's direction: `ged` is a graph edit **distance**, "
-        "so a negative `a - b` on that row means system a is better; every other row is a "
-        "score, where positive means system a is better. Each significant row also names the "
-        "system it favours, and the metrics JSON carries `direction` / `favours` per row."
+        "- The `better` column is the metric's direction. Three rows are lower-is-better: "
+        "`ged` (a graph edit **distance**) and the two length-error rates "
+        "(`under_decomposition`, `over_decomposition`), so a negative `a - b` on those means "
+        "system a is better; every other row is a score, where positive means system a is "
+        "better. Each significant row also names the system it favours, and the metrics JSON "
+        "carries `direction` / `favours` per row."
+    )
+    note_lines.append(
+        "- The over/under rows are a PAIR and are never summed: ADR 0017 records that "
+        "over-decomposition is tolerable and under-decomposition is not, so read the two "
+        "verdicts separately rather than as one 'wrong length' result."
     )
     if unavailable:
         note_lines.append(
@@ -2427,6 +3104,11 @@ def main() -> None:
     ged_policy = _ged_policy(cfg)
     ged_max_nodes = ged_policy["max_nodes_for_optimizer"]
     ged_time_budget = ged_policy["per_item_time_budget_seconds"]
+    # The contingency blend's component list and GED clamp, from config for the same reason
+    # the composite's weights are: a run's snapshot must state the blend it was scored under.
+    decomp_mean_policy = _decomp_mean_policy(cfg)
+    decomp_mean_components = tuple(decomp_mean_policy["components"])
+    ged_clamp = decomp_mean_policy["ged_clamp"]
 
     gold_path = (
         args.gold
@@ -2461,70 +3143,22 @@ def main() -> None:
     gold_hop_distribution: dict[str, int] = {}
 
     for row in rows:
-        step_p, step_r, step_f1 = _step_prf(row.pred_steps, row.gold_steps)
-        rouge_lp, rouge_lr, rouge_lf = _rouge_l(_join_steps(row.pred_steps), _join_steps(row.gold_steps))
-        ref_rate, ref_ok, ref_total = _reference_validity(row.pred_steps)
-        chain_valid, chain_pred_refs, chain_gold_refs = _chain_validity(
-            row.pred_steps, row.gold_steps
+        item_row = score_item(
+            row,
+            ged_max_nodes=ged_max_nodes,
+            ged_time_budget=ged_time_budget,
+            decomp_mean_components=decomp_mean_components,
+            ged_clamp=ged_clamp,
         )
-        pred_break = _break_steps(row.pred_steps)
-        gold_break = _break_steps(row.gold_steps)
-        pred_break_string = _break_string(pred_break)
-        gold_break_string = _break_string(gold_break)
-        ged, ged_fallback, ged_fallback_seconds = _normalized_ged(
-            _decomposition_graph(pred_break),
-            _decomposition_graph(gold_break),
-            max_nodes_for_optimizer=ged_max_nodes,
-            time_budget_seconds=ged_time_budget,
-        )
-        pred_hops = len(row.pred_steps)
-        gold_hops = row.gold_hop_count
-
-        item_row = {
-            "item_id": row.item_id,
-            "question": row.question,
-            "pred_steps": row.pred_steps,
-            "gold_steps": row.gold_steps,
-            "pred_step_count": len(row.pred_steps),
-            "gold_step_count": len(row.gold_steps),
-            "exact_match": _exact_decomposition_match(row.pred_steps, row.gold_steps),
-            "step_precision": step_p,
-            "step_recall": step_r,
-            "step_f1": step_f1,
-            "ordered_step_accuracy": _ordered_step_accuracy(row.pred_steps, row.gold_steps),
-            "rouge_l_precision": rouge_lp,
-            "rouge_l_recall": rouge_lr,
-            "rouge_l_f1": rouge_lf,
-            "reference_validity_rate": ref_rate,
-            "reference_valid_count": ref_ok,
-            "reference_total_count": ref_total,
-            # The issue #40 additions. chain_validity is the repaired house term; the other
-            # three are the official Break leaderboard metrics (EM / SARI / GED).
-            "chain_validity": chain_valid,
-            "chain_pred_reference_count": chain_pred_refs,
-            "chain_gold_reference_count": chain_gold_refs,
-            "break_exact_match": _break_exact_match(pred_break_string, gold_break_string),
-            "sari": _sari(row.question, pred_break_string, gold_break_string),
-            "ged": ged,
-            "ged_fallback": ged_fallback,
-            # Null except where the time budget stopped the optimizer, which is the one
-            # machine-dependent path: the elapsed seconds are recorded so a reader can see
-            # how far past the budget that item ran (the deadline is only tested between
-            # approximations, so it can overshoot).
-            "ged_fallback_seconds": ged_fallback_seconds,
-            "step_count_signed_error": len(row.pred_steps) - len(row.gold_steps),
-            "step_count_abs_error": abs(len(row.pred_steps) - len(row.gold_steps)),
-            "predicted_hop_count": pred_hops,
-            "gold_hop_count": gold_hops,
-            "hop_count_abs_error": abs(pred_hops - gold_hops),
-            "hop_count_exact_match": 1.0 if pred_hops == gold_hops else 0.0,
-        }
         per_item.append(item_row)
+        gold_hops = int(item_row["gold_hop_count"])
         per_hop_rows.setdefault(gold_hops, []).append(item_row)
         gold_hop_distribution[str(gold_hops)] = gold_hop_distribution.get(str(gold_hops), 0) + 1
 
     overall = _aggregate(per_item)
     n = len(per_item)
+    composite = _composite_score(overall, weights, scale)
+    report_card = _report_card(overall, per_item, decomp_mean_policy, composite)
 
     metrics = {
         "script": Path(__file__).name,
@@ -2541,10 +3175,15 @@ def main() -> None:
         "per_gold_hop_metrics": {
             str(h): _aggregate(items) for h, items in sorted(per_hop_rows.items(), key=lambda kv: kv[0])
         },
-        "composite_score": _composite_score(overall, weights, scale),
+        # THE REPORTED PRIMARY. It is placed above composite_score deliberately: the
+        # composite below it is legacy, kept so committed numbers stay quotable.
+        "decomposition_report_card": report_card,
+        "composite_score": composite,
+        "composite_score_status": COMPOSITE_SCORE_STATUS,
         "composite_score_weights": weights,
         "composite_step_count_error_scale": scale,
         "ged_policy": ged_policy,
+        "decomp_mean_policy": decomp_mean_policy,
         # Metric direction, discoverable by a machine reader of this file rather than only
         # by a human reader of the prose (PR #44 review, nit 6). A comparison's metrics JSON
         # has carried this key since the metrics landed; a scoring run's did not, so a
@@ -2582,7 +3221,9 @@ def main() -> None:
         "out_prefix": out_prefix,
         "composite_score_weights": weights,
         "composite_step_count_error_scale": scale,
+        "composite_score_status": COMPOSITE_SCORE_STATUS,
         "ged_policy": ged_policy,
+        "decomp_mean_policy": decomp_mean_policy,
     }
     fallbacks = metrics["ged_fallback_counts"]
     write_run_artifacts(
@@ -2594,6 +3235,11 @@ def main() -> None:
             f"- Predictions: `{args.predictions}`",
             f"- Gold: `{gold_path}`",
             f"- Evaluated rows: {n} (missing gold matches: {missing_gold})",
+            "",
+            *_report_card_note_lines(report_card),
+            "",
+            "### The rest of the report (not the primary)",
+            "",
             f"- Exact match: {metrics['exact_match_rate']:.4f}",
             f"- Step F1 (macro): {metrics['step_f1_macro']:.4f}",
             f"- Ordered step accuracy: {metrics['ordered_step_accuracy_macro']:.4f}",
@@ -2603,7 +3249,11 @@ def main() -> None:
             f"(over {metrics['over_decomposition_rate']:.4f} / "
             f"under {metrics['under_decomposition_rate']:.4f} / "
             f"exact {metrics['step_count_exact_rate']:.4f})",
-            f"- Composite score: {metrics['composite_score']:.4f}",
+            f"- Composite score ({COMPOSITE_SCORE_STATUS.upper()}): "
+            f"{metrics['composite_score']:.4f} — frozen byte-identical so committed numbers "
+            f"stay quotable, NOT the reported primary and not repaired; its "
+            f"`reference_validity_micro` term is a micro-pooled rate with a model-dependent "
+            f"denominator (issue #40, ADR 0029).",
             # The issue #40 additions, reported beside the house metrics and not folded into
             # any of them. GED is a distance, so its direction is stated on the line.
             f"- Break EM: {metrics['break_exact_match_rate']:.4f} / SARI: "
@@ -2638,6 +3288,13 @@ def main() -> None:
                 else "none (every value is the optimizer's own, so nothing here is "
                 "machine-dependent)"
             ),
+            # The one conditional-credit branch left in the suite, counted so a future gold
+            # cannot reintroduce free credit silently (specification §2.5 item 2).
+            f"- Guard — `chain_validity` free-credit branch: "
+            f"{metrics['chain_validity_gold_unchained_items']} of {n} evaluated items have a "
+            f"GOLD that emits no `#k` and therefore score 1.0 on that term for free. It is "
+            f"conditioned on the gold, so no model can trigger it; a non-zero count here "
+            f"means the term is measuring less than it appears to.",
             f"- Per-item: `{per_item_path}`",
         ],
         prefix=f"{out_prefix}_",

--- a/tests/test_decomposition_metrics.py
+++ b/tests/test_decomposition_metrics.py
@@ -40,6 +40,8 @@ FIXTURES = REPO_ROOT / "tests" / "fixtures"
 GOLD_PATH = FIXTURES / "data_root" / "musique" / "dev_data" / "musique_ans_v1.0_dev_clean.jsonl"
 PREDICTIONS_FIXTURE = FIXTURES / "predictions" / "decomposer_results_musique.json"
 EVALUATOR = REPO_ROOT / "scripts" / "musique_decompositions_evaluator.py"
+JUNK_BATTERY = REPO_ROOT / "scripts" / "decomposition_junk_battery.py"
+BATTERY_CONFIG = "decomposition_junk_battery.json"
 SMOKE_PATHS_CONFIG = REPO_ROOT / "configs" / "smoke_paths.json"
 
 PLACES = 9
@@ -58,6 +60,24 @@ def _import_evaluator() -> Any:
 
 
 EVAL = _import_evaluator()
+
+
+def _import_junk_battery() -> Any:
+    """Import the junk battery, so A1-A6 are asserted on the constructions it actually runs.
+
+    It imports the evaluator by the same path and name, so ``BATTERY.EVAL`` is this module's
+    ``EVAL`` object; nothing below compares class identities across the two.
+    """
+    name = "decomposition_junk_battery"
+    spec = importlib.util.spec_from_file_location(name, JUNK_BATTERY)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BATTERY = _import_junk_battery()
 
 
 def _load_gold() -> dict[str, dict[str, Any]]:
@@ -669,12 +689,24 @@ class TestBreakMetrics(EvaluatorTestBase):
         """
         preds = json.loads(PREDICTIONS_FIXTURE.read_text(encoding="utf-8"))
         metrics, _ = self.evaluate("break_direction", preds)
-        self.assertEqual(metrics["lower_is_better_statistics"], ["ged"])
-        self.assertEqual(list(EVAL.LOWER_IS_BETTER_STATISTICS), ["ged"])
+        self.assertEqual(
+            metrics["lower_is_better_statistics"],
+            ["ged", "under_decomposition", "over_decomposition"],
+        )
+        self.assertEqual(
+            list(EVAL.LOWER_IS_BETTER_STATISTICS),
+            ["ged", "under_decomposition", "over_decomposition"],
+        )
         self.assertIn("lower_is_better_statistics", metrics["metric_definitions"])
-        # The named metric is one this file actually reports, under its '_macro' aggregate.
+        # Every named metric is one this file actually reports, under the aggregate key the
+        # report card gives for its per-item column ('ged' -> 'ged_macro',
+        # 'under_decomposition' -> 'under_decomposition_rate').
+        aggregate_of = {
+            term.per_item_column: term.aggregate_key
+            for term in EVAL.DECOMPOSITION_SUITE_TERMS
+        }
         for name in metrics["lower_is_better_statistics"]:
-            self.assertIn(f"{name}_macro", metrics)
+            self.assertIn(aggregate_of[name], metrics)
 
     def test_the_run_note_caveat_covers_all_four_new_numbers(self) -> None:
         """PR #44 review, I2: the caveat counts the numbers on the line above it correctly
@@ -882,7 +914,12 @@ class TestMcNemarPower(unittest.TestCase):
 
         rows_a = [row(1.0), row(1.0), row(1.0), row(0.0), row(0.0)]
         rows_b = [row(0.0), row(0.0), row(0.0), row(1.0), row(0.0)]
-        out = EVAL._mcnemar(rows_a, rows_b, alpha=0.05, underpowered=False)["exact_match"]
+        # Only the metric this test is about: these fabricated rows carry no length columns,
+        # and the point being pinned is the arithmetic of the test, not its metric coverage
+        # (which TestPairedTTest.test_statistics_covered pins).
+        out = EVAL._mcnemar(
+            rows_a, rows_b, alpha=0.05, underpowered=False, statistics=("exact_match",)
+        )["exact_match"]
 
         self.assertEqual(out["correct_only_in_a"], 3)
         self.assertEqual(out["correct_only_in_b"], 1)
@@ -1048,23 +1085,59 @@ class TestPairedTTest(unittest.TestCase):
                     "exact_match",
                     "hop_count_exact_match",
                     "break_exact_match",
+                    # Registered with the six-term suite (ADR 0029): the two direction
+                    # columns, so the ADR 0017 asymmetry is testable, and the contingency
+                    # blend, which unlike the composite HAS a per-item value.
+                    "over_decomposition",
+                    "under_decomposition",
+                    "decomp_mean",
                 ]
             ),
         )
         # composite_score is bootstrapped but has no per-item value, so no paired difference
-        # to t-test exists.
+        # to t-test exists. It is the ONLY compared metric in that position now — every term
+        # of the reported suite takes all three tests.
         self.assertIn("composite_score", EVAL.BOOTSTRAP_STATISTICS)
         self.assertNotIn("composite_score", EVAL.T_TEST_STATISTICS)
+        self.assertEqual(
+            sorted(set(EVAL.BOOTSTRAP_STATISTICS) - set(EVAL.T_TEST_STATISTICS)),
+            ["composite_score"],
+        )
+        for term in EVAL.DECOMPOSITION_SUITE_TERMS:
+            with self.subTest(term=term.aggregate_key):
+                self.assertIn(term.per_item_column, EVAL.T_TEST_STATISTICS)
 
 
 class TestMetricDirection(unittest.TestCase):
-    """GED is a distance, so a comparison has to carry direction, not assume it."""
+    """GED is a distance and the two length rates are errors, so a comparison has to carry
+    direction rather than assume every row is a score."""
 
-    def test_ged_is_the_only_lower_is_better_statistic(self) -> None:
-        self.assertEqual(EVAL.LOWER_IS_BETTER_STATISTICS, ("ged",))
+    def test_the_lower_is_better_registry_is_ged_plus_the_two_length_rates(self) -> None:
+        """One distance and two error rates — and nothing else — point the other way.
+
+        `over_decomposition` is here as well as `under_decomposition` (which the
+        specification's §2.5 item 1 names explicitly): leaving it out would stamp its
+        comparison rows `higher_is_better` and make `favours` name the wrong system on them.
+        ADR 0017's asymmetry — over-decomposition is tolerable, under-decomposition is not —
+        is about how heavily a reader weighs the two, not about their sign, and it is carried
+        by the two rates staying split and never summed.
+        """
+        self.assertEqual(
+            EVAL.LOWER_IS_BETTER_STATISTICS,
+            ("ged", "under_decomposition", "over_decomposition"),
+        )
         self.assertIn("ged", EVAL.BOOTSTRAP_STATISTICS)
-        self.assertEqual(EVAL._direction("ged"), "lower_is_better")
-        for name in ("step_f1", "sari", "chain_validity", "break_exact_match"):
+        for name in ("ged", "under_decomposition", "over_decomposition"):
+            with self.subTest(statistic=name):
+                self.assertEqual(EVAL._direction(name), "lower_is_better")
+        for name in (
+            "step_f1",
+            "sari",
+            "chain_validity",
+            "break_exact_match",
+            "hop_count_exact_match",
+            "decomp_mean",
+        ):
             with self.subTest(statistic=name):
                 self.assertEqual(EVAL._direction(name), "higher_is_better")
 
@@ -1107,6 +1180,8 @@ class TestBootstrapChunking(unittest.TestCase):
             "sari": np.clip(base * 0.7 + offset, 0.0, 1.0),
             "ged": np.clip(1.0 - base - offset, 0.0, 2.0),
             "chain_validity": np.clip(base * 0.95 + offset, 0.0, 1.0),
+            # The contingency blend, so the chunking invariance covers it too.
+            "decomp_mean": np.clip(base * 0.6 + offset, 0.0, 1.0),
             "reference_valid_count": np.array([1, 2, 0, 3, 1, 2], dtype=float),
             "reference_total_count": np.array([2, 2, 0, 3, 2, 2], dtype=float),
             "step_count_abs_error": np.array([0, 1, 2, 0, 1, 3], dtype=float),
@@ -1239,6 +1314,8 @@ class TestPairedComparison(EvaluatorTestBase):
                 "sari",
                 "ged",
                 "chain_validity",
+                # The contingency blend, per item and so bootstrapped (ADR 0029).
+                "decomp_mean",
                 "composite_score",
             ]
         ))
@@ -1253,7 +1330,14 @@ class TestPairedComparison(EvaluatorTestBase):
                 self.assertIsNone(result["favours"])
         self.assertEqual(
             sorted(metrics["mcnemar"]),
-            ["break_exact_match", "exact_match", "hop_count_exact_match"],
+            [
+                "break_exact_match",
+                "exact_match",
+                "hop_count_exact_match",
+                # The two direction columns, so the ADR 0017 asymmetry is testable.
+                "over_decomposition",
+                "under_decomposition",
+            ],
         )
         for name, result in metrics["mcnemar"].items():
             with self.subTest(statistic=name):
@@ -1367,14 +1451,23 @@ class TestPairedComparison(EvaluatorTestBase):
         """
         issue_40_columns = {"sari", "ged", "chain_validity", "break_exact_match"}
         self.assertEqual(set(EVAL._ISSUE_40_STATISTICS), issue_40_columns)
+        # Likewise literal: the three columns the six-term suite registration added. They are
+        # deliberately OUTSIDE the required gate — nine committed arms and 33 sweep cells were
+        # scored before they existed, and requiring them would refuse every one of those files
+        # instead of comparing what they carry (ADR 0029).
+        suite_additions = {"over_decomposition", "under_decomposition", "decomp_mean"}
+        self.assertEqual(set(EVAL._SUITE_ADDITION_STATISTICS), suite_additions)
         gate = set(EVAL._NUMERIC_PER_ITEM_FIELDS)
         self.assertNotIn("item_id", gate)
         for name in issue_40_columns:
             self.assertIn(name, gate)
+        for name in suite_additions:
+            self.assertNotIn(name, gate)
         for name in EVAL.MCNEMAR_STATISTICS:
-            self.assertIn(name, gate)
+            if name not in suite_additions:
+                self.assertIn(name, gate)
         for name in EVAL.BOOTSTRAP_STATISTICS:
-            if name != "composite_score":
+            if name != "composite_score" and name not in suite_additions:
                 self.assertIn(name, gate)
         for name in EVAL._COMPOSITE_INPUT_COLUMNS:
             self.assertIn(name, gate)
@@ -1433,6 +1526,9 @@ class TestPairedComparison(EvaluatorTestBase):
                     "exact_match",
                     "hop_count_exact_match",
                     "break_exact_match",
+                    "over_decomposition",
+                    "under_decomposition",
+                    "decomp_mean",
                 ]
             ),
         )
@@ -1440,9 +1536,9 @@ class TestPairedComparison(EvaluatorTestBase):
         self.assertEqual(
             metrics["tests_reported"],
             {
-                "bootstrap": 7,
-                "mcnemar": 3,
-                "paired_t_test": 9,
+                "bootstrap": 8,
+                "mcnemar": 5,
+                "paired_t_test": 12,
                 "headline_protocol": (
                     "bootstrap + McNemar (ADR 0009); the t-test is additive (ADR 0017)"
                 ),
@@ -1476,29 +1572,33 @@ class TestPairedComparison(EvaluatorTestBase):
     def test_every_row_states_its_direction_and_the_note_says_it_too(self) -> None:
         """No row can be read without its direction, and the run note prints the column.
 
-        The failure this guards is arithmetic-free: `ged` is the only distance in the report,
-        so a table that drops the direction turns "system a is 0.16 better" into "0.16
-        worse". Every row therefore carries `direction`, every significant row names the
-        system it `favours` with the direction already applied, and the note has a `better`
-        column plus a sentence saying which way `ged` reads.
+        The failure this guards is arithmetic-free: `ged` is a distance and the two length
+        rates are errors, so a table that drops the direction turns "system a is 0.16 better"
+        into "0.16 worse". Every row therefore carries `direction`, every significant row
+        names the system it `favours` with the direction already applied, and the note has a
+        `better` column plus a sentence saying which rows read the other way.
         """
+        lower = set(EVAL.LOWER_IS_BETTER_STATISTICS)
         run_dir, metrics = self._degraded_comparison()
         for family in ("bootstrap", "mcnemar", "t_test"):
             for name, row in metrics[family].items():
                 with self.subTest(family=family, statistic=name):
                     self.assertEqual(
                         row["direction"],
-                        "lower_is_better" if name == "ged" else "higher_is_better",
+                        "lower_is_better" if name in lower else "higher_is_better",
                     )
                     if not row["significant"]:
                         self.assertIsNone(row["favours"])
                     else:
                         difference = row["difference"]
-                        a_better = difference < 0 if name == "ged" else difference > 0
+                        a_better = difference < 0 if name in lower else difference > 0
                         self.assertEqual(
                             row["favours"], "system_a" if a_better else "system_b"
                         )
-        self.assertEqual(metrics["lower_is_better_statistics"], ["ged"])
+        self.assertEqual(
+            metrics["lower_is_better_statistics"],
+            ["ged", "under_decomposition", "over_decomposition"],
+        )
         # v2 inputs carry every compared column, so nothing is skipped.
         self.assertEqual(metrics["statistics_not_available_in_inputs"], [])
 
@@ -1572,10 +1672,10 @@ class TestV1CompareShim(EvaluatorTestBase):
     read-only, outside this repo, and a test must not depend on it existing.
     """
 
-    #: Fields a v1 per-item row cannot have: ``item_id`` (v1 had no concept of it) and every
-    #: column added by issue #40 (v1 ran years before those metrics existed). Both are
-    #: dropped when a v1 file is reconstructed here, so the shim is exercised on rows the
-    #: shape v1 actually wrote.
+    #: Fields a v1 per-item row cannot have: ``item_id`` (v1 had no concept of it), every
+    #: column added by issue #40, and the three the six-term suite registration added (v1 ran
+    #: years before any of those metrics existed). All are dropped when a v1 file is
+    #: reconstructed here, so the shim is exercised on rows the shape v1 actually wrote.
     NOT_IN_V1 = (
         "item_id",
         "break_exact_match",
@@ -1585,6 +1685,9 @@ class TestV1CompareShim(EvaluatorTestBase):
         "chain_validity",
         "chain_pred_reference_count",
         "chain_gold_reference_count",
+        "over_decomposition",
+        "under_decomposition",
+        "decomp_mean",
     )
 
     def _v1_file(self, name: str, predictions: list[dict[str, Any]]) -> Path:
@@ -1681,12 +1784,13 @@ class TestV1CompareShim(EvaluatorTestBase):
                             self.assertEqual(value, expected)
 
     def test_v1_inputs_record_the_metrics_they_cannot_carry(self) -> None:
-        """A v1 file predates sari / ged / chain_validity / break_exact_match.
+        """A v1 file predates the issue #40 columns and the suite's three additions.
 
         Requiring them would refuse every v1 file and retire the ADR 0020 path; computing
         them from a v1 file's stored steps would be a re-score of v1 output rather than a
         comparison of what v1 measured. So they are omitted, named in the metrics JSON and
-        named in the run note (ADR 0026 item 10).
+        named in the run note (ADR 0026 item 10). The same mechanism is what lets a v2 arm
+        scored before ADR 0029 still be compared on everything it does carry.
         """
         a, b = self._v1_pair()
         run_dir = self.tmp / "v1_missing_metrics"
@@ -1695,11 +1799,22 @@ class TestV1CompareShim(EvaluatorTestBase):
 
         self.assertEqual(
             metrics["statistics_not_available_in_inputs"],
-            sorted(["sari", "ged", "chain_validity", "break_exact_match"]),
+            sorted(
+                [
+                    "sari",
+                    "ged",
+                    "chain_validity",
+                    "break_exact_match",
+                    "over_decomposition",
+                    "under_decomposition",
+                    "decomp_mean",
+                ]
+            ),
         )
-        for name in ("sari", "ged", "chain_validity"):
+        for name in ("sari", "ged", "chain_validity", "decomp_mean"):
             self.assertNotIn(name, metrics["bootstrap"])
-        self.assertNotIn("break_exact_match", metrics["mcnemar"])
+        for name in ("break_exact_match", "over_decomposition", "under_decomposition"):
+            self.assertNotIn(name, metrics["mcnemar"])
         # The legacy battery is untouched: 4 bootstrap intervals, 2 McNemar, 5 t-tests.
         self.assertEqual(metrics["tests_reported"]["bootstrap"], 4)
         self.assertEqual(metrics["tests_reported"]["mcnemar"], 2)
@@ -2159,6 +2274,468 @@ class TestGedConfigKnobs(unittest.TestCase):
         for key in ("max_nodes_for_optimizer", "per_item_time_budget_seconds"):
             with self.subTest(key=key):
                 self.assertIn(f'require(cfg, "break_metrics.ged.{key}")', source)
+
+
+class TestDecompositionReportCard(EvaluatorTestBase):
+    """The reported primary is an unblended six-term suite (specification §2.1, ADR 0029).
+
+    These pin registration and reporting, which is all the suite is: every term was already
+    computed before it existed, so a value moving here means a metric changed, not a report.
+    """
+
+    def _card(self) -> tuple[dict[str, Any], dict[str, Any], Path]:
+        preds = json.loads(PREDICTIONS_FIXTURE.read_text(encoding="utf-8"))
+        metrics, per_item = self.evaluate("report_card", preds)
+        return metrics, metrics["decomposition_report_card"], per_item
+
+    def test_the_suite_is_the_six_terms_the_specification_names(self) -> None:
+        """Six numbered terms in seven rows: term 6 is the over/under pair, never summed."""
+        terms = EVAL.DECOMPOSITION_SUITE_TERMS
+        self.assertEqual(
+            [(t.number, t.aggregate_key, t.per_item_column) for t in terms],
+            [
+                (1, "break_exact_match_rate", "break_exact_match"),
+                (2, "sari_macro", "sari"),
+                (3, "ged_macro", "ged"),
+                (4, "chain_validity_macro", "chain_validity"),
+                (5, "hop_count_exact_match_rate", "hop_count_exact_match"),
+                (6, "under_decomposition_rate", "under_decomposition"),
+                (6, "over_decomposition_rate", "over_decomposition"),
+            ],
+        )
+        self.assertEqual(sorted({t.number for t in terms}), [1, 2, 3, 4, 5, 6])
+
+    def test_the_report_card_carries_every_term_with_its_direction_and_denominator(self) -> None:
+        """§2.5 item 3: each term states the n it was averaged over, and its direction."""
+        metrics, card, _ = self._card()
+        self.assertEqual(len(card["terms"]), len(EVAL.DECOMPOSITION_SUITE_TERMS))
+        for row in card["terms"]:
+            with self.subTest(term=row["metric"]):
+                self.assertEqual(row["n_items"], metrics["total_evaluated"])
+                self.assertIn(row["direction"], ("higher_is_better", "lower_is_better"))
+                self.assertAlmostEqual(row["value"], metrics[row["metric"]], places=PLACES)
+        self.assertEqual(
+            [row["metric"] for row in card["terms"] if row["direction"] == "lower_is_better"],
+            ["ged_macro", "under_decomposition_rate", "over_decomposition_rate"],
+        )
+
+    def test_no_headline_term_is_a_pooled_ratio(self) -> None:
+        """The structural fix for the issue #40 defect class, checked rather than argued.
+
+        Every suite term is the plain mean of its per-item column over a denominator fixed by
+        the evaluation set. The guard runs inside the scoring path and refuses the run if it
+        is ever false; here it is re-derived from the written per-item file, so the guard and
+        the file cannot agree with each other while both being wrong.
+        """
+        metrics, card, per_item = self._card()
+        items = json.loads(per_item.read_text(encoding="utf-8"))["items"]
+        self.assertTrue(card["guards"]["every_term_is_the_macro_mean_of_its_per_item_column"])
+        for term in EVAL.DECOMPOSITION_SUITE_TERMS:
+            with self.subTest(term=term.aggregate_key):
+                expected = sum(float(r[term.per_item_column]) for r in items) / len(items)
+                self.assertAlmostEqual(metrics[term.aggregate_key], expected, places=PLACES)
+        # And the term that motivated the rule is named as excluded, with its reason.
+        self.assertIn("reference_validity_micro", card["guards"]["terms_excluded_and_why"])
+        self.assertNotIn(
+            "reference_validity_micro",
+            [term.aggregate_key for term in EVAL.DECOMPOSITION_SUITE_TERMS],
+        )
+
+    def test_the_single_number_is_a_member_of_the_suite_with_its_three_caveats(self) -> None:
+        """§2.2: where one number is required it is `ged_macro`, never a formula over six."""
+        metrics, card, _ = self._card()
+        single = card["single_number_when_one_is_required"]
+        self.assertEqual(single["metric"], "ged_macro")
+        self.assertIn(
+            single["metric"], [term.aggregate_key for term in EVAL.DECOMPOSITION_SUITE_TERMS]
+        )
+        self.assertAlmostEqual(single["value"], metrics["ged_macro"], places=PLACES)
+        self.assertEqual(single["direction"], "lower_is_better")
+        self.assertEqual(len(single["caveats"]), 3)
+        joined = " ".join(single["caveats"])
+        self.assertIn("LOWER IS BETTER", joined)
+        self.assertIn("order-BLIND", joined)
+        self.assertIn("lemmatizer", joined)
+
+    def test_the_run_note_prints_all_six_terms_and_refuses_to_adopt(self) -> None:
+        """A note quoting fewer than six is not reporting this metric (§2.1 rule 1).
+
+        The run note is what gets quoted into `experiments/log.md`, so the whole card has to
+        be readable off it — and so does the fact that adopting a thesis-primary metric is
+        issue #6 item 5, not this script's call.
+        """
+        _, card, per_item = self._card()
+        note = (per_item.parent / "eval_notes.md").read_text(encoding="utf-8")
+        self.assertIn("the reported primary", note)
+        for term in EVAL.DECOMPOSITION_SUITE_TERMS:
+            with self.subTest(term=term.aggregate_key):
+                self.assertIn(f"`{term.aggregate_key}`", note)
+        self.assertIn("never summed", note)
+        self.assertIn("issue #6 item 5", note)
+        self.assertIn("NOT ADOPTED", card["adoption"])
+
+    def test_the_composite_is_reported_as_legacy_everywhere(self) -> None:
+        """Frozen for reproducibility, not because it is correct — and it says so."""
+        metrics, card, per_item = self._card()
+        self.assertEqual(EVAL.COMPOSITE_SCORE_STATUS, "legacy")
+        self.assertEqual(metrics["composite_score_status"], "legacy")
+        self.assertEqual(card["legacy_composite"]["status"], "legacy")
+        self.assertAlmostEqual(
+            card["legacy_composite"]["value"], metrics["composite_score"], places=PLACES
+        )
+        self.assertIn("quotable", card["legacy_composite"]["why_it_is_still_computed"])
+        note = (per_item.parent / "eval_notes.md").read_text(encoding="utf-8")
+        self.assertIn("Composite score (LEGACY)", note)
+        self.assertIn(
+            "LEGACY", EVAL.METRIC_DEFINITIONS["composite_score"]
+        )
+
+    def test_the_chain_validity_free_credit_branch_is_counted(self) -> None:
+        """§2.5 item 2: the one conditional-credit branch left in the suite is visible.
+
+        0 on the fixture gold (every fixture gold decomposition chains), which is the same
+        thing measured on the pinned 600 — but a MetaQA or future gold could reintroduce free
+        credit silently, and a counter is what makes that show up in the metrics JSON instead
+        of in an analysis note two months later.
+        """
+        metrics, _, per_item = self._card()
+        self.assertEqual(metrics["chain_validity_gold_unchained_items"], 0)
+        items = json.loads(per_item.read_text(encoding="utf-8"))["items"]
+        self.assertEqual(
+            metrics["chain_validity_gold_unchained_items"],
+            sum(1 for r in items if r["chain_gold_reference_count"] == 0),
+        )
+        # It travels per gold hop depth too, like every other aggregate.
+        for block in metrics["per_gold_hop_metrics"].values():
+            self.assertIn("chain_validity_gold_unchained_items", block)
+
+    def test_the_direction_columns_are_the_per_item_form_of_the_existing_rates(self) -> None:
+        """The rates do not move; they gain a per-item column so they can be tested.
+
+        Hand computation on the 4-step prediction against the 2-step gold of 2hop__d001_a:
+        signed error +2, so `over_decomposition` is 1.0, `under_decomposition` 0.0, and the
+        two rates over that single row are 1.0 and 0.0 — the values they already had.
+        """
+        item = "2hop__d001_a"
+        steps = gold_steps(item) + ["Extra step one?", "Extra step two?"]
+        metrics, per_item = self.evaluate("direction_columns", [prediction(item, steps)])
+        row = json.loads(per_item.read_text(encoding="utf-8"))["items"][0]
+        self.assertEqual(row["step_count_signed_error"], 2)
+        self.assertEqual(row["over_decomposition"], 1.0)
+        self.assertEqual(row["under_decomposition"], 0.0)
+        self.assertMetrics(
+            metrics, {"over_decomposition_rate": 1.0, "under_decomposition_rate": 0.0}
+        )
+
+    def test_decomp_mean_is_the_unweighted_mean_of_its_five_terms(self) -> None:
+        """The contingency blend, hand-computed on the identical-to-gold fixture row.
+
+        Hand computation for 2hop__d001_a predicted exactly as gold (the anchors of
+        TestBreakMetrics): break_exact_match 1, sari 1, ged 0 -> 1 - min(1, 0) = 1,
+        chain_validity 1, hop_count_exact_match 1, so decomp_mean = 5/5 = 1.0.
+        """
+        item = "2hop__d001_a"
+        metrics, per_item = self.evaluate("decomp_mean_anchor", [prediction(item, gold_steps(item))])
+        row = json.loads(per_item.read_text(encoding="utf-8"))["items"][0]
+        self.assertAlmostEqual(row["decomp_mean"], 1.0, places=PLACES)
+        self.assertAlmostEqual(metrics["decomp_mean_macro"], 1.0, places=PLACES)
+
+        # And on a row where the terms differ, against the formula applied to the columns.
+        preds = json.loads(PREDICTIONS_FIXTURE.read_text(encoding="utf-8"))
+        metrics, per_item = self.evaluate("decomp_mean_formula", preds)
+        policy = metrics["decomp_mean_policy"]
+        for row in json.loads(per_item.read_text(encoding="utf-8"))["items"]:
+            with self.subTest(item=row["item_id"]):
+                expected = (
+                    row["break_exact_match"]
+                    + row["sari"]
+                    + (1.0 - min(policy["ged_clamp"], row["ged"]))
+                    + row["chain_validity"]
+                    + row["hop_count_exact_match"]
+                ) / 5
+                self.assertAlmostEqual(row["decomp_mean"], expected, places=PLACES)
+
+    def test_the_blend_is_a_contingency_and_says_so(self) -> None:
+        """It is reported beside the suite, never inside it, and it carries its junk gate."""
+        _, card, _ = self._card()
+        blend = card["contingency_blend"]
+        self.assertFalse(blend["in_the_suite"])
+        self.assertNotIn(
+            "decomp_mean_macro",
+            [term.aggregate_key for term in EVAL.DECOMPOSITION_SUITE_TERMS],
+        )
+        self.assertIn("CONTINGENCY", blend["status"])
+        self.assertIn("GATE PASSED", blend["junk_gate"])
+        self.assertEqual(
+            blend["components"],
+            ["break_exact_match", "sari", "ged", "chain_validity", "hop_count_exact_match"],
+        )
+
+    def test_the_blend_components_come_from_config_and_are_validated(self) -> None:
+        """No silent default, no unknown component, no repeated one (a hidden weighting)."""
+        base = EVAL.load_config("musique_eval.json")
+        self.assertEqual(
+            set(EVAL.DECOMP_MEAN_KNOWN_COMPONENTS),
+            set(
+                EVAL._decomp_mean_terms(
+                    {name: 0.0 for name in EVAL.DECOMP_MEAN_KNOWN_COMPONENTS}, 1.0
+                )
+            ),
+        )
+        for broken, expected in (
+            ({"components": [], "ged_clamp": 1.0}, "non-empty list"),
+            ({"components": ["not_a_column"], "ged_clamp": 1.0}, "cannot build"),
+            ({"components": ["sari", "sari"], "ged_clamp": 1.0}, "twice"),
+            ({"components": ["sari"], "ged_clamp": 0.0}, "in (0, 1]"),
+            ({"components": ["sari"], "ged_clamp": 2.0}, "in (0, 1]"),
+        ):
+            with self.subTest(config=broken):
+                cfg = copy.deepcopy(base)
+                cfg["decomposition_suite"]["decomp_mean"] = broken
+                with self.assertRaises(SystemExit) as caught:
+                    EVAL._decomp_mean_policy(cfg)
+                self.assertIn(expected, str(caught.exception))
+        cfg = copy.deepcopy(base)
+        del cfg["decomposition_suite"]
+        with self.assertRaises(SystemExit) as caught:
+            EVAL._decomp_mean_policy(cfg)
+        self.assertIn("decomposition_suite.decomp_mean.components", str(caught.exception))
+
+
+class TestJunkBattery(EvaluatorTestBase):
+    """A1-A6: the acceptance criteria of the specification's §3.3, as tests.
+
+    Break prints a trivial ``Copy`` baseline in its own results table; this is that practice
+    turned into a pass/fail gate, which is the single cheapest guard against a repeat of
+    issue #40 (junk outranking the deployable baseline under the legacy composite, unnoticed
+    for two analysis notes).
+
+    The six systems are built by ``scripts/decomposition_junk_battery.py`` — the same
+    functions the real 600-item run uses, so this file cannot pass while the battery measures
+    something else. Here they run against the fabricated fixture gold (4 items), with two
+    "real arms" that are ordinary prediction sets: the committed fixture predictions and the
+    unevenly degraded ones the comparison tests use.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cfg = EVAL.load_config("musique_eval.json")
+        battery_cfg = EVAL.load_config(str(BATTERY_CONFIG))
+        ged_policy = EVAL._ged_policy(cfg)
+        decomp_policy = EVAL._decomp_mean_policy(cfg)
+        gold = EVAL._load_gold(GOLD_PATH, 20)
+        junk_steps = battery_cfg["fixed_junk_steps"]
+
+        cls.rows = {
+            name: BATTERY._score_system(
+                BATTERY._junk_predictions(gold, system, junk_steps),
+                gold,
+                ged_policy,
+                decomp_policy,
+            )
+            for name, system in BATTERY.JUNK_SYSTEMS.items()
+        }
+        cls.real_names = ["fixture_predictions", "degraded"]
+        for name, preds in (
+            ("fixture_predictions", json.loads(PREDICTIONS_FIXTURE.read_text(encoding="utf-8"))),
+            ("degraded", degraded_predictions()),
+        ):
+            rows, _missing = EVAL._build_eval_rows(preds, gold)
+            items = [
+                EVAL.score_item(
+                    row,
+                    ged_max_nodes=ged_policy["max_nodes_for_optimizer"],
+                    ged_time_budget=ged_policy["per_item_time_budget_seconds"],
+                    decomp_mean_components=tuple(decomp_policy["components"]),
+                    ged_clamp=decomp_policy["ged_clamp"],
+                )
+                for row in rows
+            ]
+            cls.rows[name] = BATTERY._row_of(EVAL._aggregate(items), len(items))
+
+    def test_a1_the_gold_itself_scores_the_extremum_on_every_term(self) -> None:
+        """J6: EM 1, SARI 1, GED 0, chain validity 1, hop-count EM 1, both rates 0."""
+        gold = self.rows["J6_gold"]
+        for key, value in (
+            ("break_exact_match_rate", 1.0),
+            ("sari_macro", 1.0),
+            ("ged_macro", 0.0),
+            ("chain_validity_macro", 1.0),
+            ("hop_count_exact_match_rate", 1.0),
+            ("under_decomposition_rate", 0.0),
+            ("over_decomposition_rate", 0.0),
+        ):
+            with self.subTest(metric=key):
+                self.assertAlmostEqual(gold[key], value, places=PLACES)
+        self.assertAlmostEqual(gold["decomp_mean_macro"], 1.0, places=PLACES)
+
+    def test_a2_every_real_arm_beats_every_junk_baseline(self) -> None:
+        """On ged_macro, chain_validity_macro and break_exact_match_rate — the assertion the
+        legacy composite fails and the one that matters."""
+        for term in BATTERY.A2_TERMS:
+            for junk in BATTERY.JUNK_BASELINES:
+                for arm in self.real_names:
+                    with self.subTest(metric=term, junk=junk, arm=arm):
+                        self.assertTrue(
+                            BATTERY._beats(term, self.rows[arm][term], self.rows[junk][term]),
+                            f"{arm} {self.rows[arm][term]:.4f} does not beat "
+                            f"{junk} {self.rows[junk][term]:.4f} on {term}",
+                        )
+
+    def test_a3_sari_is_exempt_from_a2_and_its_margin_is_recorded(self) -> None:
+        """SARI's junk floor is high by construction, so the ordering is recorded, not asserted.
+
+        Break's own published `Copy` row scores SARI 0.431 against its best model's 0.748, and
+        on this repo's data an empty prediction measured 0.2911. So SARI does separate junk,
+        but from a high floor and by a small margin — which is exactly why A2 excludes it and
+        why an additive blend containing it needs its own gate (A4).
+        """
+        self.assertNotIn("sari_macro", BATTERY.A2_TERMS)
+        junk_max = max(self.rows[j]["sari_macro"] for j in BATTERY.JUNK_BASELINES)
+        real_min = min(self.rows[a]["sari_macro"] for a in self.real_names)
+        # The margin is the thing worth seeing: it is far smaller than on any A2 term.
+        self.assertGreater(real_min, junk_max)
+        for term in BATTERY.A2_TERMS:
+            if term == "break_exact_match_rate":
+                continue
+            with self.subTest(metric=term):
+                self.assertGreater(
+                    abs(
+                        min(self.rows[a][term] for a in self.real_names)
+                        - max(self.rows[j][term] for j in BATTERY.JUNK_BASELINES)
+                    ),
+                    real_min - junk_max,
+                )
+
+    def test_a4_the_blend_ranks_every_junk_baseline_below_every_real_arm(self) -> None:
+        """The HARD GATE on `decomp_mean`. Failing it disqualifies the blend.
+
+        It is not a prompt to re-tune weights: the legacy composite's weights were never the
+        disease, its free-credit term was, and a weight tweak would have hidden that.
+        """
+        for junk in BATTERY.JUNK_BASELINES:
+            for arm in self.real_names:
+                with self.subTest(junk=junk, arm=arm):
+                    self.assertGreater(
+                        self.rows[arm]["decomp_mean_macro"],
+                        self.rows[junk]["decomp_mean_macro"],
+                    )
+
+    def test_a5_order_sensitivity_survives_and_ged_does_not_carry_it(self) -> None:
+        """J5 (gold reversed) is caught by Break EM and ordered accuracy, NOT by GED.
+
+        Measured on the pinned 600, the reversed gold scores GED 0.2875 — better than every
+        real arm — because GED is order-light and on a 2-step plan order-blind. That is why
+        terms 1, 5 and 6 stay in the suite and why the single-number caveat is not optional.
+        """
+        reversed_gold = self.rows["J5_gold_reversed"]
+        self.assertEqual(reversed_gold["break_exact_match_rate"], 0.0)
+        for arm in self.real_names:
+            with self.subTest(arm=arm):
+                self.assertLess(
+                    reversed_gold["ordered_step_accuracy_macro"],
+                    self.rows[arm]["ordered_step_accuracy_macro"],
+                )
+        # GED is NOT allowed to carry this: on the fixture it ranks the reversed gold ahead
+        # of the degraded arm, which is the blindness the assertion above works around.
+        self.assertLess(reversed_gold["ged_macro"], self.rows["degraded"]["ged_macro"])
+
+    def test_a6_no_pre_existing_metric_moved(self) -> None:
+        """The frozen numbers: the legacy composite and its inputs, on the fixture.
+
+        These are the same golden values the `musique_eval` smoke stage asserts, restated
+        here because A6 is an acceptance criterion of the suite and not only of the smoke
+        test: whatever the suite added, nothing that existed before it may move — that is
+        what keeps nine committed arms and exp-010's 33 sweep cells quotable.
+        """
+        preds = json.loads(PREDICTIONS_FIXTURE.read_text(encoding="utf-8"))
+        metrics, _ = self.evaluate("a6_frozen", preds)
+        self.assertMetrics(
+            metrics,
+            {
+                "exact_match_rate": 3 / 4,
+                "step_f1_macro": 11 / 12,
+                "ordered_step_accuracy_macro": 11 / 12,
+                "rouge_l_f1_macro": 51 / 55,
+                "reference_validity_macro": 1.0,
+                "reference_validity_micro": 1.0,
+                "composite_score": 113 / 120,
+                "step_count_exact_rate": 1.0,
+            },
+        )
+        # And the regex behind reference_validity is FROZEN, bracketed form and all: the
+        # specification's §5 verdict is freeze-don't-fix, because even a corrected regex
+        # leaves a micro-pooled rate with a model-dependent denominator inside an
+        # aggregate-of-aggregates. Repairing it here would move every committed number.
+        self.assertEqual(EVAL._REF_RX.pattern, r"\[#(\d+)\]")
+
+    def test_the_junk_constructions_are_defined_not_described(self) -> None:
+        """Each junk system's steps are fixed by the code, so a printed row is reproducible."""
+        question = "Who leads the union that organised the Marlow Bay strike?"
+        gold = ["Which union organised the Marlow Bay strike?", "Who leads [#1]?"]
+        junk = ["one", "two", "three", "four"]
+        self.assertEqual(BATTERY.JUNK_SYSTEMS["J1_empty"](question, gold, junk), [])
+        self.assertEqual(
+            BATTERY.JUNK_SYSTEMS["J2_question_echo"](question, gold, junk), [question]
+        )
+        self.assertEqual(BATTERY.JUNK_SYSTEMS["J3_one_fixed_step"](question, gold, junk), ["one"])
+        self.assertEqual(
+            BATTERY.JUNK_SYSTEMS["J4_three_fixed_steps"](question, gold, junk),
+            ["one", "two", "three"],
+        )
+        self.assertEqual(
+            BATTERY.JUNK_SYSTEMS["J5_gold_reversed"](question, gold, junk), list(reversed(gold))
+        )
+        self.assertEqual(BATTERY.JUNK_SYSTEMS["J6_gold"](question, gold, junk), gold)
+        # The fixed steps carry no reference: a junk system that chained would score nonzero
+        # chain_validity and blunt the very assertion A2 makes on that term.
+        for step in EVAL.load_config(str(BATTERY_CONFIG))["fixed_junk_steps"]:
+            with self.subTest(step=step):
+                self.assertEqual(EVAL._BARE_REF_RX.findall(step), [])
+
+    def test_the_battery_cli_runs_end_to_end_on_the_fixture(self) -> None:
+        """The tiny mode ADR 0027 asks for: the full path, at 4 items, before it earns 600."""
+        out = self.tmp / "junk_battery.json"
+        env = os.environ.copy()
+        env["QAV2_PATHS_CONFIG"] = str(SMOKE_PATHS_CONFIG)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(JUNK_BATTERY),
+                "--eval-set",
+                "all-gold",
+                "--no-real-arms",
+                "--json",
+                str(out),
+            ],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, f"{proc.stdout}\n{proc.stderr}")
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        self.assertEqual(payload["n_items"], 4)
+        self.assertEqual(sorted(payload["rows"]), sorted(BATTERY.JUNK_SYSTEMS))
+        # No real arms were read, so every junk-versus-arm verdict is reported as not
+        # evaluated rather than as a pass.
+        self.assertIsNone(payload["verdicts"])
+        self.assertIn("NOT EVALUATED", proc.stdout)
+
+    def test_a_real_arm_on_a_different_evaluation_set_is_refused(self) -> None:
+        """A junk row over one set and an arm row over another is not a comparison."""
+        with self.assertRaises(SystemExit) as caught:
+            BATTERY._assert_same_eval_set(
+                {"a question", "another question"},
+                "an_arm",
+                [{"question": "a question"}],
+                Path("somewhere/eval_per_item.json"),
+            )
+        message = str(caught.exception)
+        self.assertIn("not evaluated on the same set", message)
+        # Item text does not go into an error message.
+        self.assertNotIn("a question", message)
 
 
 if __name__ == "__main__":

--- a/tests/test_decomposition_metrics.py
+++ b/tests/test_decomposition_metrics.py
@@ -921,6 +921,8 @@ class TestMcNemarPower(unittest.TestCase):
             rows_a, rows_b, alpha=0.05, underpowered=False, statistics=("exact_match",)
         )["exact_match"]
 
+        self.assertEqual(out["discordant_only_in_a"], 3)
+        self.assertEqual(out["discordant_only_in_b"], 1)
         self.assertEqual(out["correct_only_in_a"], 3)
         self.assertEqual(out["correct_only_in_b"], 1)
         self.assertEqual(out["discordant_pairs"], 4)
@@ -930,6 +932,51 @@ class TestMcNemarPower(unittest.TestCase):
         self.assertFalse(out["significant"])
         self.assertTrue(out["underpowered"])
         self.assertEqual(out["n"], 5)
+
+    def test_the_discordant_counts_are_named_for_what_a_one_means(self) -> None:
+        """A 1 is a correct item on a score and an ERROR on the two length-error rates.
+
+        `correct_only_in_*` would therefore read backwards on `over_decomposition` /
+        `under_decomposition`, which joined `MCNEMAR_STATISTICS` with the §2.3 suite
+        (PR #48 review, Important 1). The neutral `discordant_only_in_*` pair is on every
+        row; the direction-specific pair appears only where its name is true, so a consumer
+        reading `correct_only_in_a` off an error row raises rather than reading a number
+        that means the opposite of its name.
+        """
+        def row(over: float) -> dict[str, Any]:
+            return {"exact_match": 1.0, "over_decomposition": over}
+
+        rows_a = [row(0.0), row(0.0), row(0.0), row(0.0)]
+        rows_b = [row(1.0), row(1.0), row(0.0), row(0.0)]
+        out = EVAL._mcnemar(
+            rows_a,
+            rows_b,
+            alpha=0.05,
+            underpowered=False,
+            statistics=("exact_match", "over_decomposition"),
+        )
+
+        error = out["over_decomposition"]
+        self.assertEqual(error["direction"], "lower_is_better")
+        # b over-decomposed on 2 items where a did not: b was WRONG on those two.
+        self.assertEqual(error["discordant_only_in_b"], 2)
+        self.assertEqual(error["error_only_in_b"], 2)
+        self.assertEqual(error["discordant_only_in_a"], 0)
+        self.assertEqual(error["error_only_in_a"], 0)
+        self.assertNotIn("correct_only_in_a", error)
+        self.assertNotIn("correct_only_in_b", error)
+
+        score = out["exact_match"]
+        self.assertEqual(score["direction"], "higher_is_better")
+        self.assertEqual(score["correct_only_in_a"], score["discordant_only_in_a"])
+        self.assertEqual(score["correct_only_in_b"], score["discordant_only_in_b"])
+        self.assertNotIn("error_only_in_a", score)
+
+        # The definition string states both readings where the numbers are reported.
+        definition = EVAL.COMPARISON_DEFINITIONS["mcnemar"]
+        self.assertIn("discordant_only_in_a", definition)
+        self.assertIn("error_only_in_a", definition)
+        self.assertIn("correct_only_in_a", definition)
 
     def test_six_discordant_pairs_can_reach_alpha(self) -> None:
         """m = 6 is the smallest discordant count whose min p clears 0.05: 2/2^6 = 0.03125."""
@@ -2607,6 +2654,31 @@ class TestJunkBattery(EvaluatorTestBase):
                     ),
                     real_min - junk_max,
                 )
+
+    def test_a3_ordering_is_gated_by_the_exit_code_like_every_other_verdict(self) -> None:
+        """Exempt from A2's ASSERTION is not exempt from the exit code (PR #48 review, nit 1).
+
+        The battery exits non-zero when any verdict fails, and A3 now carries a `passed` like
+        the rest — so a future arm whose SARI falls below the junk floor is caught rather than
+        reported. Checked by pushing one real arm's `sari_macro` under the junk maximum.
+        """
+        verdicts = BATTERY._verdicts(self.rows, self.real_names)
+        for name, verdict in verdicts.items():
+            with self.subTest(verdict=name):
+                self.assertIn("passed", verdict)
+        self.assertTrue(verdicts["A3_sari_exempt"]["passed"])
+        self.assertEqual(verdicts["A3_sari_exempt"]["failures"], [])
+
+        junk_max = max(self.rows[j]["sari_macro"] for j in BATTERY.JUNK_BASELINES)
+        broken = copy.deepcopy(self.rows)
+        broken[self.real_names[0]]["sari_macro"] = junk_max - 0.01
+        a3 = BATTERY._verdicts(broken, self.real_names)["A3_sari_exempt"]
+        self.assertFalse(a3["ordering_holds"])
+        self.assertFalse(a3["passed"])
+        self.assertTrue(a3["failures"])
+        # The exemption itself is untouched: SARI is still out of A2's terms.
+        self.assertTrue(a3["exempt_from_a2"])
+        self.assertNotIn("sari_macro", BATTERY.A2_TERMS)
 
     def test_a4_the_blend_ranks_every_junk_baseline_below_every_real_arm(self) -> None:
         """The HARD GATE on `decomp_mean`. Failing it disqualifies the blend.


### PR DESCRIPTION
Implements `docs/analysis/2026-08-23-decomposition-quality-metric-specification.md` (commit `a6ab324`), authorized by ADR 0023 item 1 / ADR 0028 item 3 and re-confirmed by Jahid in session 2026-08-23. Recorded as **ADR 0029** (the number main had reserved for this lane). `Refs #40`.

**This PR specifies and reports; it does not adopt.** Whether any of this becomes the *thesis*-primary metric is issue #6 item 5 — Jahid's with his supervisor.

## What changed

**1. The reported primary is an unblended six-term suite** (`decomposition_report_card`): Break EM, SARI, GED (⇓), `chain_validity`, hop-count EM, and the over/under-decomposition pair kept split and never summed. Every term is a macro mean over every evaluated item and carries its direction, range, provenance and `n_items`. All six were already computed at HEAD, so this is **registration, direction metadata, guards and reporting — not new metric mathematics**. The run note prints the whole card, because the note is what gets quoted into `experiments/log.md`.

**2. `ged_macro` is the single number where one is structurally required** — a *member* of the suite, not a function over it — emitted with its three mandatory caveats every time (lower-is-better; order-light and on a 2-step plan order-*blind*; not comparable to published Break GED without spaCy).

**3. `composite_score` and `_REF_RX` are frozen as legacy, byte-identical, and deliberately not repaired.** Marked legacy in code (`COMPOSITE_SCORE_STATUS`, emitted as `composite_score_status`), in `configs/musique_eval.json`, and in `docs/METRICS.md` §4. The reasoning preserved in ADR 0029 and in a comment on `_REF_RX` itself: **even a corrected regex leaves a micro-pooled rate with a model-dependent denominator inside an aggregate-of-aggregates — the defect *class*, not just its instance** — and freezing keeps every committed number (nine arms, exp-010's 33 sweep cells, both v1 re-analysis notes) quotable. Frozen for reproducibility, not because it is correct.

**4. New per-item columns**: `over_decomposition` / `under_decomposition` (so ADR 0017's asymmetry is significance-testable at all — the two rates were aggregate-only), and `decomp_mean` (the gated contingency, item 6). Registered in `MCNEMAR_STATISTICS` / `BOOTSTRAP_STATISTICS` / `T_TEST_STATISTICS`; both direction columns in `LOWER_IS_BETTER_STATISTICS`.

**5. Guards the note calls for**: `chain_validity_gold_unchained_items` (the free-credit branch, counted — 0 on the pinned 600 and on the fixture); `_assert_suite_terms_are_macro_means`, which **refuses the run** if any headline term drifts from the mean of its per-item column; `n_items` per term; and `reference_validity_micro` / `composite_score` named in the card as excluded, with the reason.

**6. `scripts/decomposition_junk_battery.py` + `configs/decomposition_junk_battery.json`** — the six-system battery (J1 empty, J2 question echo = Break's own `Copy`, J3/J4 fixed steps, J5 gold reversed, J6 gold), scored with the evaluator's own `score_item` so there is no second copy of any metric. A **tool, not an experiment** (ADR 0027 point 5): no `experiments/log.md` entry, no GPU, `runs/run.lock` **not taken**, and a tiny mode so the full path is smoke-testable.

## Where this deviates from the note, and why

- **`over_decomposition` is registered lower-is-better too.** §2.5 item 1 names only `under_decomposition`. Left out, every `over_decomposition` comparison row would be stamped `higher_is_better` and `favours` would name the wrong system on it. §2.1 of the same note prints the pair as "under ⇓, over ⇓ but tolerated", so both are registered and ADR 0017's tolerance is carried by the two rates staying split — never by calling more over-decomposition better. Recorded in ADR 0029's alternatives.
- **P4 `suite_win_rate` is not built.** Out of this brief's scope, and it is cross-arm, has no per-item value and applies HELM's *per-metric-across-scenarios* form *across metrics* — the note's own adaptation. Its definition stands if a sweep ever needs it.
- **§2.1 reporting rule 4** ("a junk-baseline block beside the arms") is implemented where §2.5 item 8 puts it — a committed battery script plus tests — not as a block inside every scoring run.
- The three new per-item columns are **computed on every run but not *required*** of a file being compared. Requiring them would refuse nine committed arms and 33 sweep cells at `--compare` (including in-flight exp-014 work) rather than comparing what they carry; absence is named in `statistics_not_available_in_inputs`.

## No metric value changed — the fixture evidence (PR #44/#45 method)

Evaluator run at base (`cff8a30`) vs branch, then every **shared numeric leaf key** compared:

| artifact | numeric shared keys | changed |
|---|---|---|
| fixture scoring `eval_metrics.json` | 113 | **0** |
| fixture `eval_per_item.json` | 105 | **0** |
| fixture `--compare` `compare_metrics.json` | 136 | **3** — and all three are `tests_reported.{bootstrap: 7→8, mcnemar: 3→5, paired_t_test: 9→12}`, i.e. *counts of tests reported*, not metric values |
| **real 600-item `--compare`** (exp-011 `exp004_unguided` vs `exp004_oracle_guided`) | 154 | **0** |

Non-numeric shared keys that changed are exactly: `lower_is_better_statistics` (1→3 entries), two `metric_definitions` / `comparison_definitions` strings, `statistics_not_available_in_inputs` (0→3 on the real compare, correctly naming the columns those files predate), and `git.*` provenance. `composite_score` and every one of its inputs are untouched, on the fixture and on the real 600. A6 also asserts the frozen golden values and `_REF_RX.pattern` in the test suite.

## `decomp_mean`: gate **PASSED**, so it ships

Battery run from the code of `87e3765`, clean tree, seed 42, on the **ADR 0007 pinned 600** — all 15 rows on the same 600 items, with each arm's per-item file *checked* to cover exactly that set (a junk row over 2411 gold rows and an arm row over 600 would not be a comparison).

| system | break EM ⇑ | SARI ⇑ | GED ⇓ | chain ⇑ | hop EM ⇑ | under ⇓ | over ⇓ | decomp_mean ⇑ |
|---|---|---|---|---|---|---|---|---|
| J1 empty | 0.0000 | 0.2911 | 1.0000 | 0.0000 | 0.0000 | 1.0000 | 0.0000 | 0.0582 |
| J2 question echo (`Copy`) | 0.0000 | 0.4676 | 0.9011 | 0.0000 | 0.0000 | 1.0000 | 0.0000 | 0.1133 |
| J3 one fixed step | 0.0000 | 0.3141 | 0.9546 | 0.0000 | 0.0000 | 1.0000 | 0.0000 | 0.0719 |
| J4 three fixed steps | 0.0000 | 0.3262 | 1.0421 | 0.0000 | 0.3333 | 0.3333 | 0.3333 | **0.1412** |
| J5 gold reversed | 0.0000 | 0.9414 | 0.2875 | 0.2328 | 1.0000 | 0.0000 | 0.0000 | 0.5774 |
| J6 gold | 1.0000 | 1.0000 | 0.0000 | 1.0000 | 1.0000 | 0.0000 | 0.0000 | 1.0000 |
| exp005 unguided / unguided_capped | 0.0517 | 0.5979 | 0.4910 | 0.8605 | 0.5200 | 0.1150 | 0.3650 | **0.5085** |
| exp008 full_train (best arm) | 0.1017 | 0.6823 | 0.3094 | 0.9942 | 0.7100 | 0.2567 | 0.0333 | 0.6357 |

(The full 15-row table is in ADR 0029.) **A1 PASS · A2 PASS · A3 ordering holds, margin +0.1173, exempt from A2 by design · A4 PASS · A5 PASS.** The gate number: best junk `decomp_mean` **0.1412** (J4) vs real-arm worst **0.5085** — margin **+0.3673** — with every one of J1–J4 below every one of the nine arms. Not disqualified, so it ships **as a contingency**, reported beside the suite and never as it.

Two things worth reading past the gate. The table **independently reproduces** every junk figure the analyst measured at `efb8530` from a different code path: GED junk floor 0.9011, SARI empty 0.2911, reversed-gold GED 0.2875, chain-validity junk 0.0000, real-arm GED worst 0.4910, chain worst 0.8605, SARI junk max 0.4676 vs real min 0.5849. (J3/J4 SARI differ from that note's 0.3229/0.3361 because the fixed step texts are this repo's, committed in the battery config; the note's were never recorded.) And **J5 is the argument for the suite in one row**: content-perfect, maximally mis-ordered, it scores GED 0.2875 and SARI 0.9414 — better than every real arm on both — and is caught only by `break_exact_match` (0.0000) and `ordered_step_accuracy`.

## Verification

- `python -m unittest discover -s tests` → **Ran 480 tests, OK** (460 on main; +20, all in `tests/test_decomposition_metrics.py`: `TestDecompositionReportCard` ×10, `TestJunkBattery` ×10 covering A1–A6). Existing tests updated for the new registry rather than relaxed.
- `python scripts/smoke_test.py` → **40/40 stages passed** (unchanged count; the new tests run inside the `decomposition_metric_tests` stage).
- `python scripts/decomposition_junk_battery.py` → the table above, exit 0, all verdicts PASS.
- No closed commercial model is anywhere in the scoring loop; every term is string- or graph-level. No data files added. `runs/run.lock` not taken; `experiments/` and `runs/` untouched.

## For the follow-on re-score run

- A re-score buys **only** the new columns: `over_decomposition`, `under_decomposition`, `decomp_mean`, the report card, `chain_validity_gold_unchained_items` and `composite_score_status`. Every pre-existing value, `composite_score` included, is unchanged — proven above on a real 600-item artifact.
- It is **CPU-only from existing `results.json` files** and needs no GPU and no `run.lock` — the exp-011 precedent. Nine arms plus exp-010's 33 sweep cells is the full coverage set.
- Until an arm is re-scored, `--compare` still works on it and names the three missing columns in `statistics_not_available_in_inputs` — so nothing is blocked on the re-score, including exp-014.
- A comparison now reports 8 bootstrap intervals / 5 McNemar / 12 t-tests (was 7/3/9). Read the counts off `tests_reported`; no multiple-comparison correction is applied, as before.

Refs #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
